### PR TITLE
Organize settings helpers

### DIFF
--- a/AwemeHeaders.h
+++ b/AwemeHeaders.h
@@ -809,6 +809,7 @@ static CGFloat gStartVal = 0.0;
 @property(nonatomic, assign) BOOL isSwitchOn;
 @property(nonatomic, copy) void (^cellTappedBlock)(void);
 @property(nonatomic, copy) void (^switchChangedBlock)(void);
+- (void)refreshCell;
 @end
 
 @interface AWESettingBaseViewModel : NSObject

--- a/DYYYImagePickerDelegate.h
+++ b/DYYYImagePickerDelegate.h
@@ -1,0 +1,5 @@
+#import <UIKit/UIKit.h>
+
+@interface DYYYImagePickerDelegate : NSObject <UIImagePickerControllerDelegate, UINavigationControllerDelegate>
+@property(nonatomic, copy) void (^completionBlock)(NSDictionary *info);
+@end

--- a/DYYYSettings.xm
+++ b/DYYYSettings.xm
@@ -20,20 +20,18 @@
 @class DYYYIconOptionsDialogView;
 static void showIconOptionsDialog(NSString *title, UIImage *previewImage, NSString *saveFilename, void (^onClear)(void), void (^onSelect)(void));
 
-@interface DYYYImagePickerDelegate : NSObject <UIImagePickerControllerDelegate, UINavigationControllerDelegate>
-@property(nonatomic, copy) void (^completionBlock)(NSDictionary *info);
-@end
+#import "DYYYImagePickerDelegate.h"
 
 @implementation DYYYImagePickerDelegate
 - (void)imagePickerController:(UIImagePickerController *)picker didFinishPickingMediaWithInfo:(NSDictionary *)info {
-	if (self.completionBlock) {
-		self.completionBlock(info);
-	}
-	[picker dismissViewControllerAnimated:YES completion:nil];
+        if (self.completionBlock) {
+                self.completionBlock(info);
+        }
+        [picker dismissViewControllerAnimated:YES completion:nil];
 }
 
 - (void)imagePickerControllerDidCancel:(UIImagePickerController *)picker {
-	[picker dismissViewControllerAnimated:YES completion:nil];
+        [picker dismissViewControllerAnimated:YES completion:nil];
 }
 @end
 
@@ -67,111 +65,6 @@ static void showIconOptionsDialog(NSString *title, UIImage *previewImage, NSStri
 }
 @end
 
-static AWESettingItemModel *createIconCustomizationItem(NSString *identifier, NSString *title, NSString *svgIconName, NSString *saveFilename) {
-	AWESettingItemModel *item = [[%c(AWESettingItemModel) alloc] init];
-	item.identifier = identifier;
-	item.title = title;
-
-	// 检查图片是否存在，使用saveFilename
-	NSString *documentsPath = [NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) firstObject];
-	NSString *dyyyFolderPath = [documentsPath stringByAppendingPathComponent:@"DYYY"];
-	NSString *imagePath = [dyyyFolderPath stringByAppendingPathComponent:saveFilename];
-
-	BOOL fileExists = [[NSFileManager defaultManager] fileExistsAtPath:imagePath];
-	item.detail = fileExists ? @"已设置" : @"默认";
-
-	item.type = 0;
-	item.svgIconImageName = svgIconName; // 使用传入的SVG图标名称
-	item.cellType = 26;
-	item.colorStyle = 0;
-	item.isEnable = YES;
-	item.cellTappedBlock = ^{
-	  // 创建文件夹（如果不存在）
-	  if (![[NSFileManager defaultManager] fileExistsAtPath:dyyyFolderPath]) {
-		  [[NSFileManager defaultManager] createDirectoryAtPath:dyyyFolderPath withIntermediateDirectories:YES attributes:nil error:nil];
-	  }
-
-	  UIViewController *topVC = topView();
-
-	  // 加载预览图片(如果存在)
-	  UIImage *previewImage = nil;
-	  if (fileExists) {
-		  previewImage = [UIImage imageWithContentsOfFile:imagePath];
-	  }
-
-	  // 显示选项对话框 - 使用saveFilename作为参数传递
-	  showIconOptionsDialog(
-	      title, previewImage, saveFilename,
-	      ^{
-		// 清除按钮回调
-		if ([[NSFileManager defaultManager] fileExistsAtPath:imagePath]) {
-			NSError *error = nil;
-			[[NSFileManager defaultManager] removeItemAtPath:imagePath error:&error];
-			if (!error) {
-				item.detail = @"默认";
-				[DYYYSettingsHelper refreshTableView];
-			}
-		}
-	      },
-	      ^{
-		// 选择按钮回调 - 打开图片选择器
-		UIImagePickerController *picker = [[UIImagePickerController alloc] init];
-		picker.sourceType = UIImagePickerControllerSourceTypePhotoLibrary;
-		picker.allowsEditing = NO;
-		picker.mediaTypes = @[ @"public.image" ];
-
-		// 创建并设置代理
-		DYYYImagePickerDelegate *pickerDelegate = [[DYYYImagePickerDelegate alloc] init];
-		pickerDelegate.completionBlock = ^(NSDictionary *info) {
-		  NSURL *originalImageURL = info[UIImagePickerControllerImageURL];
-		  if (!originalImageURL) {
-			  originalImageURL = info[UIImagePickerControllerReferenceURL];
-		  }
-
-		  if (originalImageURL) {
-			  NSString *documentsPath = [NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) firstObject];
-			  NSString *dyyyFolderPath = [documentsPath stringByAppendingPathComponent:@"DYYY"];
-			  NSString *imagePath = [dyyyFolderPath stringByAppendingPathComponent:saveFilename];
-
-			  NSData *imageData = [NSData dataWithContentsOfURL:originalImageURL];
-
-			  // GIF检测
-			  const char *bytes = (const char *)imageData.bytes;
-			  BOOL isGIF = (imageData.length >= 6 && (memcmp(bytes, "GIF87a", 6) == 0 || memcmp(bytes, "GIF89a", 6) == 0));
-
-			  if (isGIF) {
-				  [imageData writeToFile:imagePath atomically:YES];
-			  } else {
-				  UIImage *selectedImage = [UIImage imageWithData:imageData];
-				  imageData = UIImagePNGRepresentation(selectedImage);
-				  [imageData writeToFile:imagePath atomically:YES];
-			  }
-
-			  // 延迟执行UI更新，确保图片选择器已完全消失且视图已恢复
-			  dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-			    item.detail = @"已设置";
-			    [DYYYSettingsHelper refreshTableView];
-			  });
-		  }
-		};
-
-		static char kDYYYPickerDelegateKey;
-		picker.delegate = pickerDelegate;
-		objc_setAssociatedObject(picker, &kDYYYPickerDelegateKey, pickerDelegate, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-		[topVC presentViewController:picker animated:YES completion:nil];
-	      });
-	};
-
-	return item;
-}
-
-// 显示图标选项弹窗
-static void showIconOptionsDialog(NSString *title, UIImage *previewImage, NSString *saveFilename, void (^onClear)(void), void (^onSelect)(void)) {
-	DYYYIconOptionsDialogView *optionsDialog = [[DYYYIconOptionsDialogView alloc] initWithTitle:title previewImage:previewImage];
-	optionsDialog.onClear = onClear;
-	optionsDialog.onSelect = onSelect;
-	[optionsDialog show];
-}
 
 static void *kViewModelKey = &kViewModelKey;
 %hook AWESettingBaseViewController
@@ -187,35 +80,7 @@ static void *kViewModelKey = &kViewModelKey;
 }
 %end
 
-static void showDYYYSettingsVC(UIViewController *rootVC, BOOL hasAgreed);
 
-static void addDYYYTapGesture(UIView *view, id target) {
-    view.userInteractionEnabled = YES;
-    UITapGestureRecognizer *tapGesture = [[UITapGestureRecognizer alloc] initWithTarget:target action:@selector(openDYYYSettings)];
-    [view addGestureRecognizer:tapGesture];
-}
-
-static UIViewController *findViewController(UIResponder *responder) {
-    while (responder) {
-        if ([responder isKindOfClass:[UIViewController class]]) {
-            return (UIViewController *)responder;
-        }
-        responder = [responder nextResponder];
-    }
-    return nil;
-}
-
-static void openDYYYSettingsWithViewController(UIViewController *vc) {
-    BOOL hasAgreed = [[NSUserDefaults standardUserDefaults] boolForKey:@"DYYYUserAgreementAccepted"];
-    showDYYYSettingsVC(vc, hasAgreed);
-}
-
-static void openDYYYSettingsFromView(UIView *view) {
-    UIViewController *currentVC = findViewController(view);
-    if ([currentVC isKindOfClass:%c(AWELeftSideBarViewController)]) {
-        openDYYYSettingsWithViewController(currentVC);
-    }
-}
 
 %hook AWELeftSideBarWeatherLabel
 - (id)initWithFrame:(CGRect)frame {
@@ -278,7 +143,7 @@ static void openDYYYSettingsFromView(UIView *view) {
         return;
     }
     
-    UIViewController *feedVC = findViewController(self);
+    UIViewController *feedVC = [DYYYSettingsHelper findViewController:self];
     if (![feedVC isKindOfClass:%c(AWEFeedContainerViewController)]) {
         feedVC = UIApplication.sharedApplication.keyWindow.rootViewController;
         while (feedVC && ![feedVC isKindOfClass:%c(AWEFeedContainerViewController)]) {
@@ -287,7 +152,7 @@ static void openDYYYSettingsFromView(UIView *view) {
     }
     
     if (feedVC) {
-        openDYYYSettingsWithViewController(feedVC);
+        [DYYYSettingsHelper openSettingsWithViewController:feedVC];
     } else {
         %orig;
     }
@@ -299,65 +164,11 @@ static void openDYYYSettingsFromView(UIView *view) {
 + (void)openDYYYSettingsFromSender:(UITapGestureRecognizer *)sender {
     UIView *targetView = objc_getAssociatedObject(sender, "targetView");
     if (targetView) {
-        openDYYYSettingsFromView(targetView);
+        [DYYYSettingsHelper openSettingsFromView:targetView];
     }
 }
 %end
 
-static AWESettingBaseViewController *createSubSettingsViewController(NSString *title, NSArray *sectionsArray) {
-	AWESettingBaseViewController *settingsVC = [[%c(AWESettingBaseViewController) alloc] init];
-
-	// 等待视图加载并设置标题
-	dispatch_async(dispatch_get_main_queue(), ^{
-	  if ([settingsVC.view isKindOfClass:[UIView class]]) {
-		  for (UIView *subview in settingsVC.view.subviews) {
-			  if ([subview isKindOfClass:%c(AWENavigationBar)]) {
-				  AWENavigationBar *navigationBar = (AWENavigationBar *)subview;
-				  if ([navigationBar respondsToSelector:@selector(titleLabel)]) {
-					  navigationBar.titleLabel.text = title;
-				  }
-				  break;
-			  }
-		  }
-	  }
-	});
-
-	AWESettingsViewModel *viewModel = [[%c(AWESettingsViewModel) alloc] init];
-	viewModel.colorStyle = 0;
-	viewModel.sectionDataArray = sectionsArray;
-	objc_setAssociatedObject(settingsVC, kViewModelKey, viewModel, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-
-	return settingsVC;
-}
-
-static AWESettingSectionModel *createSection(NSString *title, NSArray *items) {
-	AWESettingSectionModel *section = [[%c(AWESettingSectionModel) alloc] init];
-	section.sectionHeaderTitle = title;
-	section.sectionHeaderHeight = 40;
-	section.type = 0;
-	section.itemArray = items;
-	return section;
-}
-
-static void showUserAgreementAlert() {
-	[DYYYSettingsHelper showTextInputAlert:@"用户协议"
-	    defaultText:@""
-	    placeholder:@""
-	    onConfirm:^(NSString *text) {
-	      if ([text isEqualToString:@"我已阅读并同意继续使用"]) {
-		      [DYYYSettingsHelper setUserDefaults:@"YES" forKey:@"DYYYUserAgreementAccepted"];
-	      } else {
-		      [DYYYUtils showToast:@"请正确输入内容"];
-		      showUserAgreementAlert();
-	      }
-	    }
-	    onCancel:^(void) {
-	      [DYYYUtils showToast:@"请立即卸载本插件"];
-	      dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-		exit(0);
-	      });
-	    }];
-}
 
 void showDYYYSettingsVC(UIViewController *rootVC, BOOL hasAgreed) {
 	AWESettingBaseViewController *settingsVC = [[%c(AWESettingBaseViewController) alloc] init];
@@ -365,9 +176,9 @@ void showDYYYSettingsVC(UIViewController *rootVC, BOOL hasAgreed) {
 		[DYYYSettingsHelper showAboutDialog:@"用户协议"
 					    message:@"本插件为开源项目\n仅供学习交流用途\n如有侵权请联系, GitHub 仓库：huami1314/DYYY\n请遵守当地法律法规, "
 						    @"逆向工程仅为学习目的\n盗用源码进行商业用途/发布但未标记开源项目必究\n详情请参阅项目内 MIT 许可证\n\n请输入\"我已阅读并同意继续使用\"以继续"
-					  onConfirm:^{
-					    showUserAgreementAlert();
-					  }];
+                                          onConfirm:^{
+                                            [DYYYSettingsHelper showUserAgreementAlert];
+                                          }];
 	}
 
 	// 等待视图加载并使用KVO安全访问属性
@@ -516,7 +327,7 @@ void showDYYYSettingsVC(UIViewController *rootVC, BOOL hasAgreed) {
 							     onPresentingVC:topView()
 							   selectionChanged:^(NSString *selectedValue) {
 							     item.detail = selectedValue;
-							     [DYYYSettingsHelper refreshTableView];
+                                                               [item refreshCell];
 							   }];
 			  };
 		  }
@@ -534,7 +345,7 @@ void showDYYYSettingsVC(UIViewController *rootVC, BOOL hasAgreed) {
 							     onPresentingVC:topView()
 							   selectionChanged:^(NSString *selectedValue) {
 							     item.detail = selectedValue;
-							     [DYYYSettingsHelper refreshTableView];
+                                                             [item refreshCell];
 							   }];
 			  };
 		  }
@@ -551,7 +362,7 @@ void showDYYYSettingsVC(UIViewController *rootVC, BOOL hasAgreed) {
 							     onPresentingVC:topView()
 							   selectionChanged:^(NSString *selectedValue) {
 							     item.detail = selectedValue;
-							     [DYYYSettingsHelper refreshTableView];
+                                                               [item refreshCell];
 							   }];
 			  };
 		  }
@@ -679,7 +490,7 @@ void showDYYYSettingsVC(UIViewController *rootVC, BOOL hasAgreed) {
 								   [DYYYSettingsHelper setUserDefaults:valueString forKey:@"DYYYfilterLowLikes"];
 
 								   item.detail = valueString;
-								   [DYYYSettingsHelper refreshTableView];
+                                                                     [item refreshCell];
 							   } else {
 								   DYYYAboutDialogView *errorDialog = [[DYYYAboutDialogView alloc] initWithTitle:@"输入错误" message:@"\n\n请输入有效的数字\n\n"];
 								   [errorDialog show];
@@ -699,7 +510,7 @@ void showDYYYSettingsVC(UIViewController *rootVC, BOOL hasAgreed) {
 			      NSString *keywordString = [keywords componentsJoinedByString:@","];
 			      [DYYYSettingsHelper setUserDefaults:keywordString forKey:@"DYYYfilterUsers"];
 			      item.detail = keywordString;
-			      [DYYYSettingsHelper refreshTableView];
+                                [item refreshCell];
 			    };
 
 			    [keywordListView show];
@@ -716,7 +527,7 @@ void showDYYYSettingsVC(UIViewController *rootVC, BOOL hasAgreed) {
 
 			      [DYYYSettingsHelper setUserDefaults:keywordString forKey:@"DYYYfilterKeywords"];
 			      item.detail = keywordString;
-			      [DYYYSettingsHelper refreshTableView];
+                                [item refreshCell];
 			    };
 			    [keywordListView show];
 			  };
@@ -731,7 +542,7 @@ void showDYYYSettingsVC(UIViewController *rootVC, BOOL hasAgreed) {
 							   NSString *trimmedText = [text stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
 							   [DYYYSettingsHelper setUserDefaults:trimmedText forKey:@"DYYYfiltertimelimit"];
 							   item.detail = trimmedText ?: @"";
-							   [DYYYSettingsHelper refreshTableView];
+                                                             [item refreshCell];
 							 }
 							  onCancel:nil];
 			  };
@@ -747,7 +558,7 @@ void showDYYYSettingsVC(UIViewController *rootVC, BOOL hasAgreed) {
 
 			      [DYYYSettingsHelper setUserDefaults:keywordString forKey:@"DYYYfilterProp"];
 			      item.detail = keywordString;
-			      [DYYYSettingsHelper refreshTableView];
+                                [item refreshCell];
 			    };
 			    [keywordListView show];
 			  };
@@ -777,14 +588,14 @@ void showDYYYSettingsVC(UIViewController *rootVC, BOOL hasAgreed) {
 
 	  // 创建并组织所有section
 	  NSMutableArray *sections = [NSMutableArray array];
-	  [sections addObject:createSection(@"外观设置", appearanceItems)];
-	  [sections addObject:createSection(@"视频播放", videoItems)];
-	  [sections addObject:createSection(@"杂项设置", miscellaneousItems)];
-	  [sections addObject:createSection(@"过滤与屏蔽", filterItems)];
-	  [sections addObject:createSection(@"二次确认", securityItems)];
+	  [sections addObject:[DYYYSettingsHelper createSectionWithTitle:@"外观设置" items:appearanceItems]];
+	  [sections addObject:[DYYYSettingsHelper createSectionWithTitle:@"视频播放" items:videoItems]];
+	  [sections addObject:[DYYYSettingsHelper createSectionWithTitle:@"杂项设置" items:miscellaneousItems]];
+	  [sections addObject:[DYYYSettingsHelper createSectionWithTitle:@"过滤与屏蔽" items:filterItems]];
+	  [sections addObject:[DYYYSettingsHelper createSectionWithTitle:@"二次确认" items:securityItems]];
 
 	  // 创建并推入二级设置页面
-	  AWESettingBaseViewController *subVC = createSubSettingsViewController(@"基本设置", sections);
+          AWESettingBaseViewController *subVC = [DYYYSettingsHelper createSubSettingsViewController:@"基本设置" sections:sections];
 	  [rootVC.navigationController pushViewController:(UIViewController *)subVC animated:YES];
 	};
 	[mainItems addObject:basicSettingItem];
@@ -925,22 +736,22 @@ void showDYYYSettingsVC(UIViewController *rootVC, BOOL hasAgreed) {
 	  // 【图标自定义】分类
 	  NSMutableArray<AWESettingItemModel *> *iconItems = [NSMutableArray array];
 
-	  [iconItems addObject:createIconCustomizationItem(@"DYYYIconLikeBefore", @"未点赞图标", @"ic_heart_outlined_20", @"like_before.png")];
-	  [iconItems addObject:createIconCustomizationItem(@"DYYYIconLikeAfter", @"已点赞图标", @"ic_heart_filled_20", @"like_after.png")];
-	  [iconItems addObject:createIconCustomizationItem(@"DYYYIconComment", @"评论的图标", @"ic_comment_outlined_20", @"comment.png")];
-	  [iconItems addObject:createIconCustomizationItem(@"DYYYIconUnfavorite", @"未收藏图标", @"ic_star_outlined_20", @"unfavorite.png")];
-	  [iconItems addObject:createIconCustomizationItem(@"DYYYIconFavorite", @"已收藏图标", @"ic_star_filled_20", @"favorite.png")];
-	  [iconItems addObject:createIconCustomizationItem(@"DYYYIconShare", @"分享的图标", @"ic_share_outlined", @"share.png")];
-	  [iconItems addObject:createIconCustomizationItem(@"DYYYIconPlus", @"拍摄的图标", @"ic_camera_outlined", @"tab_plus.png")];
+          [iconItems addObject:[DYYYSettingsHelper createIconCustomizationItemWithIdentifier:@"DYYYIconLikeBefore" title:@"未点赞图标" svgIcon:@"ic_heart_outlined_20" saveFile:@"like_before.png"]];
+          [iconItems addObject:[DYYYSettingsHelper createIconCustomizationItemWithIdentifier:@"DYYYIconLikeAfter" title:@"已点赞图标" svgIcon:@"ic_heart_filled_20" saveFile:@"like_after.png"]];
+          [iconItems addObject:[DYYYSettingsHelper createIconCustomizationItemWithIdentifier:@"DYYYIconComment" title:@"评论的图标" svgIcon:@"ic_comment_outlined_20" saveFile:@"comment.png"]];
+          [iconItems addObject:[DYYYSettingsHelper createIconCustomizationItemWithIdentifier:@"DYYYIconUnfavorite" title:@"未收藏图标" svgIcon:@"ic_star_outlined_20" saveFile:@"unfavorite.png"]];
+          [iconItems addObject:[DYYYSettingsHelper createIconCustomizationItemWithIdentifier:@"DYYYIconFavorite" title:@"已收藏图标" svgIcon:@"ic_star_filled_20" saveFile:@"favorite.png"]];
+          [iconItems addObject:[DYYYSettingsHelper createIconCustomizationItemWithIdentifier:@"DYYYIconShare" title:@"分享的图标" svgIcon:@"ic_share_outlined" saveFile:@"share.png"]];
+          [iconItems addObject:[DYYYSettingsHelper createIconCustomizationItemWithIdentifier:@"DYYYIconPlus" title:@"拍摄的图标" svgIcon:@"ic_camera_outlined" saveFile:@"tab_plus.png"]];
 
 	  NSMutableArray *sections = [NSMutableArray array];
-	  [sections addObject:createSection(@"透明度设置", transparencyItems)];
-	  [sections addObject:createSection(@"缩放与大小", scaleItems)];
-	  [sections addObject:createSection(@"标题自定义", titleItems)];
-	  [sections addObject:createSection(@"图标自定义", iconItems)];
+	  [sections addObject:[DYYYSettingsHelper createSectionWithTitle:@"透明度设置" items:transparencyItems]];
+	  [sections addObject:[DYYYSettingsHelper createSectionWithTitle:@"缩放与大小" items:scaleItems]];
+	  [sections addObject:[DYYYSettingsHelper createSectionWithTitle:@"标题自定义" items:titleItems]];
+	  [sections addObject:[DYYYSettingsHelper createSectionWithTitle:@"图标自定义" items:iconItems]];
 	  // 创建并组织所有section
 	  // 创建并推入二级设置页面
-	  AWESettingBaseViewController *subVC = createSubSettingsViewController(@"界面设置", sections);
+          AWESettingBaseViewController *subVC = [DYYYSettingsHelper createSubSettingsViewController:@"界面设置" sections:sections];
 	  [rootVC.navigationController pushViewController:(UIViewController *)subVC animated:YES];
 	};
 
@@ -1648,16 +1459,16 @@ void showDYYYSettingsVC(UIViewController *rootVC, BOOL hasAgreed) {
 	  }
 	  // 创建并组织所有section
 	  NSMutableArray *sections = [NSMutableArray array];
-	  [sections addObject:createSection(@"主界面元素", mainUiItems)];
-	  [sections addObject:createSection(@"视频播放界面", videoUiItems)];
-	  [sections addObject:createSection(@"侧边栏元素", sidebarItems)];
-	  [sections addObject:createSection(@"消息页与我的页", messageAndMineItems)];
-	  [sections addObject:createSection(@"提示与位置信息", infoItems)];
-	  [sections addObject:createSection(@"直播间界面", livestreamItems)];
-	  [sections addObject:createSection(@"隐藏面板功能", modernpanels)];
-	  [sections addObject:createSection(@"隐藏长按评论功能", commentpanel)];
+	  [sections addObject:[DYYYSettingsHelper createSectionWithTitle:@"主界面元素" items:mainUiItems]];
+	  [sections addObject:[DYYYSettingsHelper createSectionWithTitle:@"视频播放界面" items:videoUiItems]];
+	  [sections addObject:[DYYYSettingsHelper createSectionWithTitle:@"侧边栏元素" items:sidebarItems]];
+	  [sections addObject:[DYYYSettingsHelper createSectionWithTitle:@"消息页与我的页" items:messageAndMineItems]];
+	  [sections addObject:[DYYYSettingsHelper createSectionWithTitle:@"提示与位置信息" items:infoItems]];
+	  [sections addObject:[DYYYSettingsHelper createSectionWithTitle:@"直播间界面" items:livestreamItems]];
+	  [sections addObject:[DYYYSettingsHelper createSectionWithTitle:@"隐藏面板功能" items:modernpanels]];
+	  [sections addObject:[DYYYSettingsHelper createSectionWithTitle:@"隐藏长按评论功能" items:commentpanel]];
 	  // 创建并推入二级设置页面
-	  AWESettingBaseViewController *subVC = createSubSettingsViewController(@"隐藏设置", sections);
+          AWESettingBaseViewController *subVC = [DYYYSettingsHelper createSubSettingsViewController:@"隐藏设置" sections:sections];
 	  [rootVC.navigationController pushViewController:(UIViewController *)subVC animated:YES];
 	};
 	[mainItems addObject:hideSettingItem];
@@ -1787,7 +1598,7 @@ void showDYYYSettingsVC(UIViewController *rootVC, BOOL hasAgreed) {
 			      NSString *keywordString = [keywords componentsJoinedByString:@","];
 			      [DYYYSettingsHelper setUserDefaults:keywordString forKey:@"DYYYHideOtherChannel"];
 			      item.detail = keywordString;
-			      [DYYYSettingsHelper refreshTableView];
+                                [item refreshCell];
 			    };
 
 			    // 显示关键词列表视图
@@ -1797,10 +1608,10 @@ void showDYYYSettingsVC(UIViewController *rootVC, BOOL hasAgreed) {
 	  }
 
 	  NSMutableArray *sections = [NSMutableArray array];
-	  [sections addObject:createSection(@"顶栏选项", removeSettingsItems)];
+	  [sections addObject:[DYYYSettingsHelper createSectionWithTitle:@"顶栏选项" items:removeSettingsItems]];
 
 	  // 创建并推入二级设置页面，使用sections数组而不是直接使用removeSettingsItems
-	  AWESettingBaseViewController *subVC = createSubSettingsViewController(@"顶栏移除", sections);
+          AWESettingBaseViewController *subVC = [DYYYSettingsHelper createSubSettingsViewController:@"顶栏移除" sections:sections];
 	  [rootVC.navigationController pushViewController:(UIViewController *)subVC animated:YES];
 	};
 	[mainItems addObject:removeSettingItem];
@@ -1964,7 +1775,7 @@ void showDYYYSettingsVC(UIViewController *rootVC, BOOL hasAgreed) {
 
 							   item.detail = trimmedText.length > 0 ? trimmedText : @"不填关闭";
 
-							   [DYYYSettingsHelper refreshTableView];
+                                                             [item refreshCell];
 							 }
 							  onCancel:nil];
 			  };
@@ -2037,7 +1848,7 @@ void showDYYYSettingsVC(UIViewController *rootVC, BOOL hasAgreed) {
 			    saveABTestConfigFileItemRef.isEnable = NO;
 		    }
 	    }
-	    [DYYYSettingsHelper refreshTableView];
+              [saveABTestConfigFileItemRef refreshCell];
 	  };
 
 	  for (NSDictionary *dict in hotUpdateSettings) {
@@ -2055,7 +1866,7 @@ void showDYYYSettingsVC(UIViewController *rootVC, BOOL hasAgreed) {
 					confirmButtonText:@"确定"
 					cancelAction:^{
 					  item.isSwitchOn = !newValue;
-					  [DYYYSettingsHelper refreshTableView];
+                                            [item refreshCell];
 					}
 					closeAction:nil
 					confirmAction:^{
@@ -2093,7 +1904,7 @@ void showDYYYSettingsVC(UIViewController *rootVC, BOOL hasAgreed) {
 								     onceToken = 0;
 								     ensureABTestDataLoaded();
 							     }
-							     [DYYYSettingsHelper refreshTableView];
+                                                               [item refreshCell];
 							   }];
 			  };
 		  } else if ([item.identifier isEqualToString:@"SaveCurrentABTestData"]) {
@@ -2298,7 +2109,7 @@ void showDYYYSettingsVC(UIViewController *rootVC, BOOL hasAgreed) {
 					    // 删除成功后修改 SaveABTestConfigFile item 的状态
 					    saveABTestConfigFileItemRef.detail = @"(文件已删除)";
 					    saveABTestConfigFileItemRef.isEnable = NO;
-					    [DYYYSettingsHelper refreshTableView];
+                                              [saveABTestConfigFileItemRef refreshCell];
 				    }
 			    } else {
 				    [DYYYUtils showToast:@"本地配置不存在"];
@@ -2478,8 +2289,8 @@ void showDYYYSettingsVC(UIViewController *rootVC, BOOL hasAgreed) {
 				    [doubleTapItems addObject:functionItem];
 			    }
 			    NSMutableArray *sections = [NSMutableArray array];
-			    [sections addObject:createSection(@"双击菜单设置", doubleTapItems)];
-			    AWESettingBaseViewController *subVC = createSubSettingsViewController(@"双击菜单设置", sections);
+                            [sections addObject:[DYYYSettingsHelper createSectionWithTitle:@"双击菜单设置" items:doubleTapItems]];
+                            AWESettingBaseViewController *subVC = [DYYYSettingsHelper createSubSettingsViewController:@"双击菜单设置" sections:sections];
 			    [rootVC.navigationController pushViewController:(UIViewController *)subVC animated:YES];
 			  };
 		  }
@@ -2489,12 +2300,12 @@ void showDYYYSettingsVC(UIViewController *rootVC, BOOL hasAgreed) {
 
 	  // 创建并组织所有section
 	  NSMutableArray *sections = [NSMutableArray array];
-	  [sections addObject:createSection(@"长按面板设置", longPressItems)];
-	  [sections addObject:createSection(@"媒体保存", downloadItems)];
-	  [sections addObject:createSection(@"交互增强", interactionItems)];
-	  [sections addObject:createSection(@"热更新", hotUpdateItems)];
+	  [sections addObject:[DYYYSettingsHelper createSectionWithTitle:@"长按面板设置" items:longPressItems]];
+	  [sections addObject:[DYYYSettingsHelper createSectionWithTitle:@"媒体保存" items:downloadItems]];
+	  [sections addObject:[DYYYSettingsHelper createSectionWithTitle:@"交互增强" items:interactionItems]];
+	  [sections addObject:[DYYYSettingsHelper createSectionWithTitle:@"热更新" items:hotUpdateItems]];
 	  // 创建并推入二级设置页面
-	  AWESettingBaseViewController *subVC = createSubSettingsViewController(@"增强设置", sections);
+          AWESettingBaseViewController *subVC = [DYYYSettingsHelper createSubSettingsViewController:@"增强设置" sections:sections];
 	  [rootVC.navigationController pushViewController:(UIViewController *)subVC animated:YES];
 	};
 
@@ -2552,7 +2363,7 @@ void showDYYYSettingsVC(UIViewController *rootVC, BOOL hasAgreed) {
 					   [[NSUserDefaults standardUserDefaults] setObject:trimmedText forKey:@"DYYYSpeedSettings"];
 					   [[NSUserDefaults standardUserDefaults] synchronize];
 					   speedSettingsItem.detail = trimmedText;
-					   [DYYYSettingsHelper refreshTableView];
+                                             [speedSettingsItem refreshCell];
 					 }
 					  onCancel:nil];
 	  };
@@ -2616,7 +2427,7 @@ void showDYYYSettingsVC(UIViewController *rootVC, BOOL hasAgreed) {
 						   [[NSUserDefaults standardUserDefaults] setFloat:size forKey:@"DYYYSpeedButtonSize"];
 						   [[NSUserDefaults standardUserDefaults] synchronize];
 						   buttonSizeItem.detail = [NSString stringWithFormat:@"%.0f", (CGFloat)size];
-						   [DYYYSettingsHelper refreshTableView];
+                                                     [buttonSizeItem refreshCell];
 					   } else {
 						   [DYYYUtils showToast:@"请输入20-60之间的有效数值"];
 					   }
@@ -2665,7 +2476,7 @@ void showDYYYSettingsVC(UIViewController *rootVC, BOOL hasAgreed) {
 						   [[NSUserDefaults standardUserDefaults] setFloat:size forKey:@"DYYYEnableFloatClearButtonSize"];
 						   [[NSUserDefaults standardUserDefaults] synchronize];
 						   clearButtonSizeItem.detail = [NSString stringWithFormat:@"%.0f", (CGFloat)size];
-						   [DYYYSettingsHelper refreshTableView];
+                                                     [clearButtonSizeItem refreshCell];
 					   } else {
 						   [DYYYUtils showToast:@"请输入20-60之间的有效数值"];
 					   }
@@ -2675,7 +2486,7 @@ void showDYYYSettingsVC(UIViewController *rootVC, BOOL hasAgreed) {
 	  [clearButtonItems addObject:clearButtonSizeItem];
 
 	  // 添加清屏按钮自定义图标选项
-	  AWESettingItemModel *clearButtonIcon = createIconCustomizationItem(@"DYYYClearButtonIcon", @"清屏按钮图标", @"ic_roaming_outlined", @"qingping.gif");
+          AWESettingItemModel *clearButtonIcon = [DYYYSettingsHelper createIconCustomizationItemWithIdentifier:@"DYYYClearButtonIcon" title:@"清屏按钮图标" svgIcon:@"ic_roaming_outlined" saveFile:@"qingping.gif"];
 
 	  [clearButtonItems addObject:clearButtonIcon];
 	  // 清屏隐藏弹幕
@@ -2744,11 +2555,11 @@ void showDYYYSettingsVC(UIViewController *rootVC, BOOL hasAgreed) {
 
 	  // 创建并组织所有section
 	  NSMutableArray *sections = [NSMutableArray array];
-	  [sections addObject:createSection(@"快捷倍速", speedButtonItems)];
-	  [sections addObject:createSection(@"一键清屏", clearButtonItems)];
+          [sections addObject:[DYYYSettingsHelper createSectionWithTitle:@"快捷倍速" items:speedButtonItems]];
+          [sections addObject:[DYYYSettingsHelper createSectionWithTitle:@"一键清屏" items:clearButtonItems]];
 
 	  // 创建并推入二级设置页面
-	  AWESettingBaseViewController *subVC = createSubSettingsViewController(@"悬浮按钮", sections);
+          AWESettingBaseViewController *subVC = [DYYYSettingsHelper createSubSettingsViewController:@"悬浮按钮" sections:sections];
 	  [rootVC.navigationController pushViewController:(UIViewController *)subVC animated:YES];
 	};
 	[mainItems addObject:floatButtonSettingItem];
@@ -2918,7 +2729,7 @@ void showDYYYSettingsVC(UIViewController *rootVC, BOOL hasAgreed) {
 
 	    [DYYYUtils showToast:@"设置已恢复，请重启应用以应用所有更改"];
 
-	    [DYYYSettingsHelper refreshTableView];
+              [restoreItem refreshCell];
 	  };
 
 	  static char kDYYYRestorePickerDelegateKey;
@@ -3041,7 +2852,7 @@ void showDYYYSettingsVC(UIViewController *rootVC, BOOL hasAgreed) {
             if (strongCleanCacheItem) {
                 strongCleanCacheItem.detail = [DYYYUtils formattedSize:initialSize];
                 strongCleanCacheItem.isEnable = YES;
-                [DYYYSettingsHelper refreshTableView];
+                  [strongCleanCacheItem refreshCell];
             }
         });
     });
@@ -3053,7 +2864,7 @@ void showDYYYSettingsVC(UIViewController *rootVC, BOOL hasAgreed) {
 	  // Disable the button to prevent multiple triggers
 	  strongCleanCacheItem.isEnable = NO;
       strongCleanCacheItem.detail = @"清理中...";
-	  [DYYYSettingsHelper refreshTableView];
+            [strongCleanCacheItem refreshCell];
 
 	  dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
 		  for (NSString *basePath in allPaths) {
@@ -3073,7 +2884,7 @@ void showDYYYSettingsVC(UIViewController *rootVC, BOOL hasAgreed) {
 			  strongCleanCacheItem.detail = [DYYYUtils formattedSize:afterSize];
 			  // Re-enable the button after cleaning is done
 			  strongCleanCacheItem.isEnable = YES;
-			  [DYYYSettingsHelper refreshTableView];
+                            [strongCleanCacheItem refreshCell];
 		  });
 	  });
 	};

--- a/DYYYSettingsHelper.h
+++ b/DYYYSettingsHelper.h
@@ -104,4 +104,48 @@
  */
 + (AWESettingItemModel *)createSettingItem:(NSDictionary *)dict cellTapHandlers:(NSMutableDictionary *)cellTapHandlers;
 
+/**
+ * 创建自定义图标设置项
+ */
++ (AWESettingItemModel *)createIconCustomizationItemWithIdentifier:(NSString *)identifier
+                                  title:(NSString *)title
+                               svgIcon:(NSString *)svgIconName
+                            saveFile:(NSString *)saveFilename;
+
+/**
+ * 创建设置分区
+ */
++ (AWESettingSectionModel *)createSectionWithTitle:(NSString *)title items:(NSArray *)items;
+
+/**
+ * 创建子设置页面控制器
+ */
++ (AWESettingBaseViewController *)createSubSettingsViewController:(NSString *)title
+                                                        sections:(NSArray *)sectionsArray;
+
+/**
+ * 查找视图所在控制器
+ */
++ (UIViewController *)findViewController:(UIResponder *)responder;
+
+/**
+ * 打开设置页
+ */
++ (void)openSettingsWithViewController:(UIViewController *)vc;
+
+/**
+ * 从视图打开设置页
+ */
++ (void)openSettingsFromView:(UIView *)view;
+
+/**
+ * 为视图添加打开设置页的点击手势
+ */
++ (void)addTapGestureToView:(UIView *)view target:(id)target;
+
+/**
+ * 显示用户协议输入弹窗
+ */
++ (void)showUserAgreementAlert;
+
 @end

--- a/DYYYSettingsHelper.m
+++ b/DYYYSettingsHelper.m
@@ -1,9 +1,12 @@
 #import "DYYYSettingsHelper.h"
 #import "DYYYUtils.h"
 #import <UIKit/UIKit.h>
+#import <objc/runtime.h>
+#import "DYYYImagePickerDelegate.h"
 
 #import "DYYYAboutDialogView.h"
 #import "DYYYCustomInputView.h"
+#import "DYYYIconOptionsDialogView.h"
 
 @implementation DYYYSettingsHelper
 
@@ -426,6 +429,186 @@
     }
 
     return item;
+}
+
+#pragma mark - 新增工具方法
+
+extern void showDYYYSettingsVC(UIViewController *rootVC, BOOL hasAgreed);
+extern void *kViewModelKey;
+
+@class DYYYImagePickerDelegate;
+
+static void showIconOptionsDialog(NSString *title, UIImage *previewImage, NSString *saveFilename, void (^onClear)(void), void (^onSelect)(void)) {
+    DYYYIconOptionsDialogView *optionsDialog = [[DYYYIconOptionsDialogView alloc] initWithTitle:title previewImage:previewImage];
+    optionsDialog.onClear = onClear;
+    optionsDialog.onSelect = onSelect;
+    [optionsDialog show];
+}
+
++ (AWESettingItemModel *)createIconCustomizationItemWithIdentifier:(NSString *)identifier
+                                  title:(NSString *)title
+                               svgIcon:(NSString *)svgIconName
+                            saveFile:(NSString *)saveFilename {
+    AWESettingItemModel *item = [[NSClassFromString(@"AWESettingItemModel") alloc] init];
+    item.identifier = identifier;
+    item.title = title;
+
+    NSString *documentsPath = [NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) firstObject];
+    NSString *dyyyFolderPath = [documentsPath stringByAppendingPathComponent:@"DYYY"];
+    NSString *imagePath = [dyyyFolderPath stringByAppendingPathComponent:saveFilename];
+
+    BOOL fileExists = [[NSFileManager defaultManager] fileExistsAtPath:imagePath];
+    item.detail = fileExists ? @"已设置" : @"默认";
+
+    item.type = 0;
+    item.svgIconImageName = svgIconName;
+    item.cellType = 26;
+    item.colorStyle = 0;
+    item.isEnable = YES;
+
+    __weak AWESettingItemModel *weakItem = item;
+    item.cellTappedBlock = ^{
+        if (![[NSFileManager defaultManager] fileExistsAtPath:dyyyFolderPath]) {
+            [[NSFileManager defaultManager] createDirectoryAtPath:dyyyFolderPath withIntermediateDirectories:YES attributes:nil error:nil];
+        }
+
+        UIViewController *topVC = topView();
+
+        UIImage *previewImage = nil;
+        if (fileExists) {
+            previewImage = [UIImage imageWithContentsOfFile:imagePath];
+        }
+
+        showIconOptionsDialog(title, previewImage, saveFilename, ^{
+          if ([[NSFileManager defaultManager] fileExistsAtPath:imagePath]) {
+              NSError *error = nil;
+              [[NSFileManager defaultManager] removeItemAtPath:imagePath error:&error];
+              if (!error) {
+                  weakItem.detail = @"默认";
+                  [weakItem refreshCell];
+              }
+          }
+        }, ^{
+          UIImagePickerController *picker = [[UIImagePickerController alloc] init];
+          picker.sourceType = UIImagePickerControllerSourceTypePhotoLibrary;
+          picker.allowsEditing = NO;
+          picker.mediaTypes = @[ @"public.image" ];
+
+          DYYYImagePickerDelegate *pickerDelegate = [[DYYYImagePickerDelegate alloc] init];
+          pickerDelegate.completionBlock = ^(NSDictionary *info) {
+            NSURL *originalImageURL = info[UIImagePickerControllerImageURL];
+            if (!originalImageURL) {
+                originalImageURL = info[UIImagePickerControllerReferenceURL];
+            }
+            if (originalImageURL) {
+                NSString *documentsPath = [NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) firstObject];
+                NSString *dyyyFolderPath = [documentsPath stringByAppendingPathComponent:@"DYYY"];
+                NSString *imagePath = [dyyyFolderPath stringByAppendingPathComponent:saveFilename];
+
+                NSData *imageData = [NSData dataWithContentsOfURL:originalImageURL];
+                const char *bytes = (const char *)imageData.bytes;
+                BOOL isGIF = (imageData.length >= 6 && (memcmp(bytes, "GIF87a", 6) == 0 || memcmp(bytes, "GIF89a", 6) == 0));
+                if (isGIF) {
+                    [imageData writeToFile:imagePath atomically:YES];
+                } else {
+                    UIImage *selectedImage = [UIImage imageWithData:imageData];
+                    imageData = UIImagePNGRepresentation(selectedImage);
+                    [imageData writeToFile:imagePath atomically:YES];
+                }
+
+                dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+                    weakItem.detail = @"已设置";
+                    [weakItem refreshCell];
+                });
+            }
+          };
+
+          static char kDYYYPickerDelegateKey;
+          picker.delegate = pickerDelegate;
+          objc_setAssociatedObject(picker, &kDYYYPickerDelegateKey, pickerDelegate, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+          [topVC presentViewController:picker animated:YES completion:nil];
+        });
+    };
+
+    return item;
+}
+
++ (AWESettingSectionModel *)createSectionWithTitle:(NSString *)title items:(NSArray *)items {
+    AWESettingSectionModel *section = [[NSClassFromString(@"AWESettingSectionModel") alloc] init];
+    section.sectionHeaderTitle = title;
+    section.sectionHeaderHeight = 40;
+    section.type = 0;
+    section.itemArray = items;
+    return section;
+}
+
++ (AWESettingBaseViewController *)createSubSettingsViewController:(NSString *)title
+                                                        sections:(NSArray *)sectionsArray {
+    AWESettingBaseViewController *settingsVC = [[NSClassFromString(@"AWESettingBaseViewController") alloc] init];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if ([settingsVC.view isKindOfClass:[UIView class]]) {
+            for (UIView *subview in settingsVC.view.subviews) {
+                if ([subview isKindOfClass:NSClassFromString(@"AWENavigationBar")]) {
+                    id navigationBar = subview;
+                    if ([navigationBar respondsToSelector:@selector(titleLabel)]) {
+                        navigationBar.titleLabel.text = title;
+                    }
+                    break;
+                }
+            }
+        }
+    });
+
+    AWESettingsViewModel *viewModel = [[NSClassFromString(@"AWESettingsViewModel") alloc] init];
+    viewModel.colorStyle = 0;
+    viewModel.sectionDataArray = sectionsArray;
+    objc_setAssociatedObject(settingsVC, &kViewModelKey, viewModel, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+
+    return settingsVC;
+}
+
++ (UIViewController *)findViewController:(UIResponder *)responder {
+    while (responder) {
+        if ([responder isKindOfClass:[UIViewController class]]) {
+            return (UIViewController *)responder;
+        }
+        responder = [responder nextResponder];
+    }
+    return nil;
+}
+
++ (void)openSettingsWithViewController:(UIViewController *)vc {
+    BOOL hasAgreed = [[NSUserDefaults standardUserDefaults] boolForKey:@"DYYYUserAgreementAccepted"];
+    showDYYYSettingsVC(vc, hasAgreed);
+}
+
++ (void)openSettingsFromView:(UIView *)view {
+    UIViewController *currentVC = [self findViewController:view];
+    if ([currentVC isKindOfClass:NSClassFromString(@"AWELeftSideBarViewController")]) {
+        [self openSettingsWithViewController:currentVC];
+    }
+}
+
++ (void)addTapGestureToView:(UIView *)view target:(id)target {
+    view.userInteractionEnabled = YES;
+    UITapGestureRecognizer *tapGesture = [[UITapGestureRecognizer alloc] initWithTarget:target action:@selector(openDYYYSettings)];
+    [view addGestureRecognizer:tapGesture];
+}
+
++ (void)showUserAgreementAlert {
+    [self showTextInputAlert:@"用户协议" defaultText:@"" placeholder:@"" onConfirm:^(NSString *text) {
+        if ([text isEqualToString:@"我已阅读并同意继续使用"]) {
+            [self setUserDefaults:@"YES" forKey:@"DYYYUserAgreementAccepted"];
+        } else {
+            [DYYYUtils showToast:@"请正确输入内容"];
+            [self showUserAgreementAlert];
+        }
+    } onCancel:^{
+        [DYYYUtils showToast:@"请立即卸载本插件"];
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+            exit(0);
+        });
+    }];
 }
 
 @end


### PR DESCRIPTION
## Summary
- move icon, section, and view helper utilities into `DYYYSettingsHelper`
- expose `DYYYImagePickerDelegate` interface for helper usage
- fix helper imports and runtime calls
- replace direct table reloads with `refreshCell`
- fix helper call in sidebar hook

## Testing
- `make test` *(fails: /tweak.mk: No such file or directory)*
- `make` *(fails: /tweak.mk: No such file or directory)*
- `bash -c "$(curl -fsSL https://raw.githubusercontent.com/theos/theos/master/bin/install-theos)"` *(fails: running as root not allowed)*

------
https://chatgpt.com/codex/tasks/task_b_6858e1ef37d8832a9310e18d2e738a82