### PR TITLE
Add prop filter option in text filtering dialog

### DIFF
--- a/DYYYFilterSettingsView.h
+++ b/DYYYFilterSettingsView.h
@@ -13,7 +13,10 @@ NS_ASSUME_NONNULL_BEGIN
 // 过滤关键词按钮点击时的回调
 @property (nonatomic, copy, nullable) void (^onKeywordFilterTap)(void);
 
-// 初始化方法，接受标题和待分词的文本
+// 初始化方法，接受标题、待分词文本和当前拍同款名称（可选）
+- (instancetype)initWithTitle:(NSString *)title text:(NSString *)text propName:(nullable NSString *)propName;
+
+// 兼容旧接口
 - (instancetype)initWithTitle:(NSString *)title text:(NSString *)text;
 
 // 显示对话框

--- a/DYYYLongPressPanel.xm
+++ b/DYYYLongPressPanel.xm
@@ -621,8 +621,12 @@
 		filterKeywords.duxIconName = @"ic_funnel_outlined_20";
 		filterKeywords.describeString = @"过滤文案";
 		filterKeywords.action = ^{
-		  NSString *descText = [self.awemeModel valueForKey:@"descriptionString"];
-		  DYYYFilterSettingsView *filterView = [[DYYYFilterSettingsView alloc] initWithTitle:@"过滤关键词调整" text:descText];
+                  NSString *descText = [self.awemeModel valueForKey:@"descriptionString"];
+                  NSString *propName = nil;
+                  if (self.awemeModel.propGuideV2) {
+                      propName = self.awemeModel.propGuideV2.propName;
+                  }
+                  DYYYFilterSettingsView *filterView = [[DYYYFilterSettingsView alloc] initWithTitle:@"过滤关键词调整" text:descText propName:propName];
 		  filterView.onConfirm = ^(NSString *selectedText) {
 		    if (selectedText.length > 0) {
 			    NSString *currentKeywords = [[NSUserDefaults standardUserDefaults] objectForKey:@"DYYYfilterKeywords"] ?: @"";
@@ -1430,8 +1434,12 @@
 		filterKeywords.duxIconName = @"ic_funnel_outlined_20";
 		filterKeywords.describeString = @"过滤文案";
 		filterKeywords.action = ^{
-		  NSString *descText = [self.awemeModel valueForKey:@"descriptionString"];
-		  DYYYFilterSettingsView *filterView = [[DYYYFilterSettingsView alloc] initWithTitle:@"过滤关键词调整" text:descText];
+                  NSString *descText = [self.awemeModel valueForKey:@"descriptionString"];
+                  NSString *propName = nil;
+                  if (self.awemeModel.propGuideV2) {
+                      propName = self.awemeModel.propGuideV2.propName;
+                  }
+                  DYYYFilterSettingsView *filterView = [[DYYYFilterSettingsView alloc] initWithTitle:@"过滤关键词调整" text:descText propName:propName];
 		  filterView.onConfirm = ^(NSString *selectedText) {
 		    if (selectedText.length > 0) {
 			    NSString *currentKeywords = [[NSUserDefaults standardUserDefaults] objectForKey:@"DYYYfilterKeywords"] ?: @"";


### PR DESCRIPTION
## Summary
- allow DYYYFilterSettingsView to take current prop name
- show a button in filter dialog to filter or unfilter the current prop
- update long press panel to pass prop name when opening the filter dialog

## Testing
- `make` *(fails: No rule to make target '/tweak.mk')*

------
https://chatgpt.com/codex/tasks/task_b_6862cd4ced1c832aad0102ca3ad185cd