### PR TITLE
Check controller before setting MTKView color

### DIFF
--- a/DYYY.xm
+++ b/DYYY.xm
@@ -4405,14 +4405,18 @@ static AWEIMReusableCommonCell *currentCell;
 %hook MTKView
 
 - (void)layoutSubviews {
-	%orig;
-	NSString *colorHex = [[NSUserDefaults standardUserDefaults] objectForKey:@"DYYYVideoBGColor"];
-	if (colorHex && colorHex.length > 0) {
-		CGFloat screenWidth = [UIScreen mainScreen].bounds.size.width;
-		UIColor *customColor = [DYYYUtils colorFromSchemeHexString:colorHex targetWidth:screenWidth];
-		if (customColor)
-			self.backgroundColor = customColor;
-	}
+        %orig;
+        UIViewController *vc = [DYYYUtils firstAvailableViewControllerFromView:self];
+        Class playVCClass = NSClassFromString(@"AWEPlayVideoViewController");
+        if (vc && playVCClass && [vc isKindOfClass:playVCClass]) {
+                NSString *colorHex = [[NSUserDefaults standardUserDefaults] objectForKey:@"DYYYVideoBGColor"];
+                if (colorHex && colorHex.length > 0) {
+                        CGFloat screenWidth = [UIScreen mainScreen].bounds.size.width;
+                        UIColor *customColor = [DYYYUtils colorFromSchemeHexString:colorHex targetWidth:screenWidth];
+                        if (customColor)
+                                self.backgroundColor = customColor;
+                }
+        }
 }
 
 %end


### PR DESCRIPTION
## Summary
- only apply video background color when `MTKView` belongs to `AWEPlayVideoViewController`

## Testing
- `make` *(fails: `/tweak.mk` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6866c356c1dc832a99eb03f1cc0d2bb0