### PR TITLE
Add auto update for ABTest config

### DIFF
--- a/DYYYABTestHook.h
+++ b/DYYYABTestHook.h
@@ -46,4 +46,9 @@
  */
 + (NSDictionary *)getCurrentABTestData;
 
+/**
+ * 从网络检查并下载最新配置
+ */
++ (void)checkForRemoteConfigUpdate;
+
 @end

--- a/DYYYABTestHook.h
+++ b/DYYYABTestHook.h
@@ -48,7 +48,8 @@
 
 /**
  * 从网络检查并下载最新配置
+ * @param notify 是否在完成后显示提示
  */
-+ (void)checkForRemoteConfigUpdate;
++ (void)checkForRemoteConfigUpdate:(BOOL)notify;
 
 @end

--- a/DYYYABTestHook.h
+++ b/DYYYABTestHook.h
@@ -3,48 +3,32 @@
 // 声明 DYYYABTestHook 类的接口
 @interface DYYYABTestHook : NSObject
 
-/**
- * 判断当前是否为覆写模式
- */
+/** 判断当前是否为覆写模式 */
 + (BOOL)isPatchMode;
 
-/**
- * 获取本地文件是否已加载的状态
- */
+/** 获取本地文件是否已加载的状态 */
 + (BOOL)isLocalConfigLoaded;
 
-/**
- * 获取禁止下发配置的状态
- */
+/** 获取禁止下发配置的状态 */
 + (BOOL)isABTestBlockEnabled;
 
-/**
- * 设置禁止下发配置的状态
- */
+/** 设置禁止下发配置的状态 */
 + (void)setABTestBlockEnabled:(BOOL)enabled;
 
-/**
- * 清除本地加载的ABTest数据，为下次调用 loadLocalABTestConfig 做准备
- */
+/** 清除本地加载的ABTest数据，为下次调用 loadLocalABTestConfig 做准备 */
 + (void)cleanLocalABTestData;
 
-/**
- * 加载本地ABTest配置文件
- * 只加载文件和处理数据，不负责应用
- * 使用 dispatch_once 确保只加载一次
- */
+/** 加载本地ABTest配置文件 */
 + (void)loadLocalABTestConfig;
 
-/**
- * 应用本地ABTest配置数据 (负责根据模式处理并应用到 Manager)
- * 包含是否应该应用的条件判断
- */
+/** 应用本地ABTest配置数据 (负责根据模式处理并应用到 Manager) */
 + (void)applyFixedABTestData;
 
-/**
- * 获取当前ABTest数据 (从 AWEABTestManager 获取)
- */
+/** 获取当前ABTest数据 (从 AWEABTestManager 获取) */
 + (NSDictionary *)getCurrentABTestData;
+
+/** 当前是否处于远程模式 */
++ (BOOL)isRemoteMode;
 
 /**
  * 从网络检查并下载最新配置

--- a/DYYYABTestHook.xm
+++ b/DYYYABTestHook.xm
@@ -67,17 +67,17 @@ static void DYYYQueueSync(dispatch_block_t block) {
     if (savedMode) {
         if ([savedMode isEqualToString:DYYY_REMOTE_MODE_STRING] || [[savedMode lowercaseString] isEqualToString:@"remote"]) {
             if (s_fileMode) {
-                return ![[s_fileMode lowercaseString] isEqualToString:@"replace"];
+                return ![[s_fileMode lowercaseString] isEqualToString:@"DYYY_MODE_REPLACE"];
             }
             return YES;
         }
-        if ([savedMode isEqualToString:@"替换模式：忽略原配置，使用新数据"] || [[savedMode lowercaseString] isEqualToString:@"replace"]) {
+        if ([savedMode isEqualToString:@"替换模式：忽略原配置，使用新数据"] || [[savedMode lowercaseString] isEqualToString:@"DYYY_MODE_REPLACE"]) {
             return NO;
         }
         return YES;
     }
     if (s_fileMode) {
-        return ![[s_fileMode lowercaseString] isEqualToString:@"replace"];
+        return ![[s_fileMode lowercaseString] isEqualToString:@"DYYY_MODE_REPLACE"];
     }
     return YES;
 }

--- a/DYYYABTestHook.xm
+++ b/DYYYABTestHook.xm
@@ -269,6 +269,9 @@ static void DYYYQueueSync(dispatch_block_t block) {
                     [data writeToFile:jsonFilePath atomically:YES];
                     updated = YES;
                 }
+                [[NSUserDefaults standardUserDefaults] setBool:YES forKey:DYYY_REMOTE_CONFIG_FLAG_KEY];
+                [[NSUserDefaults standardUserDefaults] synchronize];
+                [[NSNotificationCenter defaultCenter] postNotificationName:DYYY_REMOTE_CONFIG_CHANGED_NOTIFICATION object:nil];
             }
             dispatch_async(dispatch_get_main_queue(), ^{
                 if (error || !data) {

--- a/DYYYABTestHook.xm
+++ b/DYYYABTestHook.xm
@@ -241,7 +241,7 @@ static void DYYYQueueSync(dispatch_block_t block) {
 /**
  * 从网络检查并下载最新配置
  */
-+ (void)checkForRemoteConfigUpdate {
++ (void)checkForRemoteConfigUpdate:(BOOL)notify {
     dispatch_async(DYYYABTestQueue(), ^{
         NSString *urlString = [[NSUserDefaults standardUserDefaults] objectForKey:@"DYYYRemoteConfigURL"];
         if (urlString.length == 0) {
@@ -249,9 +249,11 @@ static void DYYYQueueSync(dispatch_block_t block) {
         }
         NSURL *url = [NSURL URLWithString:urlString];
         if (!url) {
-            dispatch_async(dispatch_get_main_queue(), ^{
-                [DYYYUtils showToast:@"配置更新失败"];
-            });
+            if (notify) {
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    [DYYYUtils showToast:@"配置更新失败"];
+                });
+            }
             return;
         }
         NSURLSessionDataTask *task = [[NSURLSession sharedSession] dataTaskWithURL:url completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
@@ -270,14 +272,20 @@ static void DYYYQueueSync(dispatch_block_t block) {
             }
             dispatch_async(dispatch_get_main_queue(), ^{
                 if (error || !data) {
-                    [DYYYUtils showToast:@"配置更新失败"];
+                    if (notify) {
+                        [DYYYUtils showToast:@"配置更新失败"];
+                    }
                 } else if (updated) {
-                    [DYYYUtils showToast:@"配置已更新"];
+                    if (notify) {
+                        [DYYYUtils showToast:@"配置已更新"];
+                    }
                     [DYYYABTestHook cleanLocalABTestData];
                     [DYYYABTestHook loadLocalABTestConfig];
                     [DYYYABTestHook applyFixedABTestData];
                 } else {
-                    [DYYYUtils showToast:@"已是最新配置"];
+                    if (notify) {
+                        [DYYYUtils showToast:@"已是最新配置"];
+                    }
                 }
             });
         }];
@@ -426,6 +434,6 @@ static void DYYYQueueSync(dispatch_block_t block) {
 
         [DYYYABTestHook loadLocalABTestConfig];
         [DYYYABTestHook applyFixedABTestData];
-        [DYYYABTestHook checkForRemoteConfigUpdate];
+        [DYYYABTestHook checkForRemoteConfigUpdate:NO];
     });
 }

--- a/DYYYConstants.h
+++ b/DYYYConstants.h
@@ -9,4 +9,10 @@
 // 默认的远程 ABTest 配置地址
 #define DYYY_DEFAULT_ABTEST_URL @"https://github.com/Nathalie-Annis/AWEABTestDataPatch/releases/latest/download/ABTestDataPatch_A.json"
 
+// 是否使用远程配置的偏好键
+#define DYYY_REMOTE_CONFIG_FLAG_KEY @"DYYYUseRemoteConfig"
+
+// 远程配置状态改变的通知名
+#define DYYY_REMOTE_CONFIG_CHANGED_NOTIFICATION @"DYYYRemoteConfigStateChanged"
+
 #endif

--- a/DYYYConstants.h
+++ b/DYYYConstants.h
@@ -6,4 +6,7 @@
 
 #define DYYY_VERSION @"2.2-8"
 
+// 默认的远程 ABTest 配置地址
+#define DYYY_DEFAULT_ABTEST_URL @"https://github.com/Nathalie-Annis/AWEABTestDataPatch/releases/latest/download/ABTestDataPatch_A.json"
+
 #endif

--- a/DYYYConstants.h
+++ b/DYYYConstants.h
@@ -15,4 +15,7 @@
 // 远程配置状态改变的通知名
 #define DYYY_REMOTE_CONFIG_CHANGED_NOTIFICATION @"DYYYRemoteConfigStateChanged"
 
+// 配置应用方式中的远程模式名称
+#define DYYY_REMOTE_MODE_STRING @"远程模式：启动时自动检查更新"
+
 #endif

--- a/DYYYSettings.xm
+++ b/DYYYSettings.xm
@@ -1889,9 +1889,19 @@ extern "C"
 		    @"title" : @"配置应用方式",
 		    @"detail" : @"",
 		    @"cellType" : @26,
-		    @"imageName" : @"ic_enterpriseservice_outlined"},
-		  @{@"identifier" : @"SaveCurrentABTestData",
-		    @"title" : @"导出当前配置",
+                  @"imageName" : @"ic_enterpriseservice_outlined"},
+                  @{@"identifier" : @"DYYYRemoteConfigURL",
+                    @"title" : @"配置地址",
+                    @"detail" : @"",
+                    @"cellType" : @26,
+                    @"imageName" : @"ic_cloudarrowdown_outlined_20"},
+                  @{@"identifier" : @"DYYYCheckUpdate",
+                    @"title" : @"检查配置更新",
+                    @"detail" : @"",
+                    @"cellType" : @26,
+                    @"imageName" : @"ic_cloudarrowdown_outlined_20"},
+                  @{@"identifier" : @"SaveCurrentABTestData",
+                    @"title" : @"导出当前配置",
 		    @"detail" : @"",
 		    @"cellType" : @26,
 		    @"imageName" : @"ic_memorycard_outlined_20"},
@@ -2000,8 +2010,8 @@ extern "C"
 			  };
 		  } else if ([item.identifier isEqualToString:@"DYYYABTestModeString"]) {
 			  // 使用 DYYYABTestHook 的类方法获取当前的模式
-			  BOOL isPatchMode = [DYYYABTestHook isPatchMode];
-			  item.detail = isPatchMode ? @"覆写模式" : @"替换模式";
+                  BOOL isPatchMode = [DYYYABTestHook isPatchMode];
+                  item.detail = isPatchMode ? @"覆写模式" : @"替换模式";
 
 			  item.cellTappedBlock = ^{
 			    NSString *currentMode = [[NSUserDefaults standardUserDefaults] objectForKey:@"DYYYABTestModeString"] ?: @"替换模式：忽略原配置，使用新数据";
@@ -2019,10 +2029,31 @@ extern "C"
 							     if (![selectedValue isEqualToString:currentMode]) {
 								     [DYYYABTestHook applyFixedABTestData];
 							     }
-							     [item refreshCell];
-							   }];
-			  };
-		  } else if ([item.identifier isEqualToString:@"SaveCurrentABTestData"]) {
+                                                           [item refreshCell];
+                                                         }];
+                          };
+                } else if ([item.identifier isEqualToString:@"DYYYRemoteConfigURL"]) {
+                        NSString *savedURL = [[NSUserDefaults standardUserDefaults] objectForKey:@"DYYYRemoteConfigURL"];
+                        item.detail = savedURL.length > 0 ? savedURL : DYYY_DEFAULT_ABTEST_URL;
+                        item.cellTappedBlock = ^{
+                          NSString *defaultText = item.detail;
+                          [DYYYSettingsHelper showTextInputAlert:@"设置远程配置地址"
+                                                         defaultText:defaultText
+                                                         placeholder:@"JSON URL"
+                                                           onConfirm:^(NSString *text) {
+                                                             NSString *trimmedText = [text stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+                                                             [DYYYSettingsHelper setUserDefaults:trimmedText forKey:@"DYYYRemoteConfigURL"];
+                                                             item.detail = trimmedText.length > 0 ? trimmedText : DYYY_DEFAULT_ABTEST_URL;
+                                                             [item refreshCell];
+                                                           }
+                                                            onCancel:nil];
+                        };
+                } else if ([item.identifier isEqualToString:@"DYYYCheckUpdate"]) {
+                        item.cellTappedBlock = ^{
+                          [DYYYUtils showToast:@"正在检查更新..."];
+                          [DYYYABTestHook checkForRemoteConfigUpdate];
+                        };
+                } else if ([item.identifier isEqualToString:@"SaveCurrentABTestData"]) {
 			  item.detail = @"(获取中...)";
 			  item.isEnable = NO;
 

--- a/DYYYSettings.xm
+++ b/DYYYSettings.xm
@@ -1891,7 +1891,7 @@ extern "C"
 		    @"cellType" : @26,
                   @"imageName" : @"ic_enterpriseservice_outlined"},
                   @{@"identifier" : @"DYYYRemoteConfigURL",
-                    @"title" : @"配置地址",
+                    @"title" : @"远程配置地址",
                     @"detail" : @"",
                     @"cellType" : @26,
                     @"imageName" : @"ic_cloudarrowdown_outlined_20"},
@@ -2051,7 +2051,7 @@ extern "C"
                 } else if ([item.identifier isEqualToString:@"DYYYCheckUpdate"]) {
                         item.cellTappedBlock = ^{
                           [DYYYUtils showToast:@"正在检查更新..."];
-                          [DYYYABTestHook checkForRemoteConfigUpdate];
+                          [DYYYABTestHook checkForRemoteConfigUpdate:YES];
                         };
                 } else if ([item.identifier isEqualToString:@"SaveCurrentABTestData"]) {
 			  item.detail = @"(获取中...)";

--- a/DYYYSettings.xm
+++ b/DYYYSettings.xm
@@ -922,12 +922,12 @@ extern "C"
 		    @"cellType" : @6,
 		    @"imageName" : @"ic_eyeslash_outlined_16"},
 		  @{
-			@"identifier" : @"DYYYHideGradient",
-			@"title" : @"隐藏遮罩效果",
-			@"subTitle" : @"优化视频文案展开时出现的黑色背景遮罩效果，但可能对部分视频的文案可读性产生一定影响。",
-			@"detail" : @"",
-			@"cellType" : @37,
-			@"imageName" : @"ic_eyeslash_outlined_16"
+			  @"identifier" : @"DYYYHideGradient",
+			  @"title" : @"隐藏遮罩效果",
+			  @"subTitle" : @"优化视频文案展开时出现的黑色背景遮罩效果，但可能对部分视频的文案可读性产生一定影响。",
+			  @"detail" : @"",
+			  @"cellType" : @37,
+			  @"imageName" : @"ic_eyeslash_outlined_16"
 		  }
 	  ];
 
@@ -1134,12 +1134,14 @@ extern "C"
 		    @"detail" : @"",
 		    @"cellType" : @6,
 		    @"imageName" : @"ic_eyeslash_outlined_16"},
-		  @{@"identifier" : @"DYYYHideFeedAnchorContainer",
-		    @"title" : @"隐藏视频锚点",
-			@"subTitle" : @"包括拍摄同款、抖音精选、游戏、轻颜等供稿链接",
-			@"detail" : @"",
-			@"cellType" : @37,
-		    @"imageName" : @"ic_eyeslash_outlined_16"},
+		  @{
+			  @"identifier" : @"DYYYHideFeedAnchorContainer",
+			  @"title" : @"隐藏视频锚点",
+			  @"subTitle" : @"包括拍摄同款、抖音精选、游戏、轻颜等供稿链接",
+			  @"detail" : @"",
+			  @"cellType" : @37,
+			  @"imageName" : @"ic_eyeslash_outlined_16"
+		  },
 		  @{@"identifier" : @"DYYYHideChallengeStickers",
 		    @"title" : @"隐藏挑战贴纸",
 		    @"detail" : @"",
@@ -1889,19 +1891,19 @@ extern "C"
 		    @"title" : @"配置应用方式",
 		    @"detail" : @"",
 		    @"cellType" : @26,
-                  @"imageName" : @"ic_enterpriseservice_outlined"},
-                  @{@"identifier" : @"DYYYRemoteConfigURL",
-                    @"title" : @"远程配置地址",
-                    @"detail" : @"",
-                    @"cellType" : @26,
-                    @"imageName" : @"ic_cloudarrowdown_outlined_20"},
-                  @{@"identifier" : @"DYYYCheckUpdate",
-                    @"title" : @"检查配置更新",
-                    @"detail" : @"",
-                    @"cellType" : @26,
-                    @"imageName" : @"ic_cloudarrowdown_outlined_20"},
-                  @{@"identifier" : @"SaveCurrentABTestData",
-                    @"title" : @"导出当前配置",
+		    @"imageName" : @"ic_enterpriseservice_outlined"},
+		  @{@"identifier" : @"DYYYRemoteConfigURL",
+		    @"title" : @"远程配置地址",
+		    @"detail" : @"",
+		    @"cellType" : @26,
+		    @"imageName" : @"ic_cloudarrowdown_outlined_20"},
+		  @{@"identifier" : @"DYYYCheckUpdate",
+		    @"title" : @"检查配置更新",
+		    @"detail" : @"",
+		    @"cellType" : @26,
+		    @"imageName" : @"ic_cloudarrowdown_outlined_20"},
+		  @{@"identifier" : @"SaveCurrentABTestData",
+		    @"title" : @"导出当前配置",
 		    @"detail" : @"",
 		    @"cellType" : @26,
 		    @"imageName" : @"ic_memorycard_outlined_20"},
@@ -1923,13 +1925,13 @@ extern "C"
 	  ];
 
 	  // --- 声明一个__block变量来持有SaveABTestConfigFileitem ---
-    __block AWESettingItemModel *saveABTestConfigFileItemRef = nil;
-    __block AWESettingItemModel *remoteURLItemRef = nil;
-    __block AWESettingItemModel *checkUpdateItemRef = nil;
-    __block AWESettingItemModel *loadConfigItemRef = nil;
-    __block AWESettingItemModel *deleteConfigItemRef = nil;
+	  __block AWESettingItemModel *saveABTestConfigFileItemRef = nil;
+	  __block AWESettingItemModel *remoteURLItemRef = nil;
+	  __block AWESettingItemModel *checkUpdateItemRef = nil;
+	  __block AWESettingItemModel *loadConfigItemRef = nil;
+	  __block AWESettingItemModel *deleteConfigItemRef = nil;
 	  // --- 定义一个用于刷新SaveABTestConfigFileitem的局部block ---
-  void (^refreshSaveABTestConfigFileItem)(void) = ^{
+	  void (^refreshSaveABTestConfigFileItem)(void) = ^{
 	    if (!saveABTestConfigFileItemRef)
 		    return;
 
@@ -1980,32 +1982,71 @@ extern "C"
 		}
 	      });
 	    });
-  };
+	  };
 
-  void (^refreshConfigConflictState)(void) = ^{
-    BOOL remoteMode = [DYYYABTestHook isRemoteMode];
-    BOOL localLoaded = [DYYYABTestHook isLocalConfigLoaded];
-    if (remoteMode) {
-        if (loadConfigItemRef) { loadConfigItemRef.isEnable = NO; [loadConfigItemRef refreshCell]; }
-        if (deleteConfigItemRef) { deleteConfigItemRef.isEnable = NO; [deleteConfigItemRef refreshCell]; }
-        if (remoteURLItemRef) { remoteURLItemRef.isEnable = YES; [remoteURLItemRef refreshCell]; }
-        if (checkUpdateItemRef) { checkUpdateItemRef.isEnable = YES; [checkUpdateItemRef refreshCell]; }
-    } else if (localLoaded) {
-        if (remoteURLItemRef) { remoteURLItemRef.isEnable = NO; [remoteURLItemRef refreshCell]; }
-        if (checkUpdateItemRef) { checkUpdateItemRef.isEnable = NO; [checkUpdateItemRef refreshCell]; }
-        if (loadConfigItemRef) { loadConfigItemRef.isEnable = YES; [loadConfigItemRef refreshCell]; }
-        if (deleteConfigItemRef) { deleteConfigItemRef.isEnable = YES; [deleteConfigItemRef refreshCell]; }
-    } else {
-        if (remoteURLItemRef) { remoteURLItemRef.isEnable = YES; [remoteURLItemRef refreshCell]; }
-        if (checkUpdateItemRef) { checkUpdateItemRef.isEnable = YES; [checkUpdateItemRef refreshCell]; }
-        if (loadConfigItemRef) { loadConfigItemRef.isEnable = YES; [loadConfigItemRef refreshCell]; }
-        if (deleteConfigItemRef) { deleteConfigItemRef.isEnable = YES; [deleteConfigItemRef refreshCell]; }
-    }
-  };
+	  void (^refreshConfigConflictState)(void) = ^{
+	    BOOL remoteMode = [DYYYABTestHook isRemoteMode];
+	    BOOL localLoaded = [DYYYABTestHook isLocalConfigLoaded];
+	    if (remoteMode) {
+		    if (loadConfigItemRef) {
+			    loadConfigItemRef.isEnable = NO;
+			    [loadConfigItemRef refreshCell];
+		    }
+		    if (deleteConfigItemRef) {
+			    deleteConfigItemRef.isEnable = NO;
+			    [deleteConfigItemRef refreshCell];
+		    }
+		    if (remoteURLItemRef) {
+			    remoteURLItemRef.isEnable = YES;
+			    [remoteURLItemRef refreshCell];
+		    }
+		    if (checkUpdateItemRef) {
+			    checkUpdateItemRef.isEnable = YES;
+			    [checkUpdateItemRef refreshCell];
+		    }
+	    } else if (localLoaded) {
+		    if (remoteURLItemRef) {
+			    remoteURLItemRef.isEnable = NO;
+			    [remoteURLItemRef refreshCell];
+		    }
+		    if (checkUpdateItemRef) {
+			    checkUpdateItemRef.isEnable = NO;
+			    [checkUpdateItemRef refreshCell];
+		    }
+		    if (loadConfigItemRef) {
+			    loadConfigItemRef.isEnable = YES;
+			    [loadConfigItemRef refreshCell];
+		    }
+		    if (deleteConfigItemRef) {
+			    deleteConfigItemRef.isEnable = YES;
+			    [deleteConfigItemRef refreshCell];
+		    }
+	    } else {
+		    if (remoteURLItemRef) {
+			    remoteURLItemRef.isEnable = YES;
+			    [remoteURLItemRef refreshCell];
+		    }
+		    if (checkUpdateItemRef) {
+			    checkUpdateItemRef.isEnable = YES;
+			    [checkUpdateItemRef refreshCell];
+		    }
+		    if (loadConfigItemRef) {
+			    loadConfigItemRef.isEnable = YES;
+			    [loadConfigItemRef refreshCell];
+		    }
+		    if (deleteConfigItemRef) {
+			    deleteConfigItemRef.isEnable = YES;
+			    [deleteConfigItemRef refreshCell];
+		    }
+	    }
+	  };
 
-  [[NSNotificationCenter defaultCenter] addObserverForName:DYYY_REMOTE_CONFIG_CHANGED_NOTIFICATION object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification * _Nonnull note) {
-    refreshConfigConflictState();
-  }];
+	  [[NSNotificationCenter defaultCenter] addObserverForName:DYYY_REMOTE_CONFIG_CHANGED_NOTIFICATION
+							    object:nil
+							     queue:[NSOperationQueue mainQueue]
+							usingBlock:^(NSNotification *_Nonnull note) {
+							  refreshConfigConflictState();
+							}];
 
 	  for (NSDictionary *dict in hotUpdateSettings) {
 		  AWESettingItemModel *item = [DYYYSettingsHelper createSettingItem:dict];
@@ -2037,78 +2078,81 @@ extern "C"
 				    [DYYYUtils showToast:@"已允许热更新下发配置，重启后生效。"];
 			    }
 			  };
-                } else if ([item.identifier isEqualToString:@"DYYYABTestModeString"]) {
-                        BOOL isPatchMode = [DYYYABTestHook isPatchMode];
-                        if ([DYYYABTestHook isRemoteMode]) {
-                            item.detail = isPatchMode ? @"远程模式(覆写)" : @"远程模式(替换)";
-                        } else {
-                            item.detail = isPatchMode ? @"覆写模式" : @"替换模式";
-                        }
+		  } else if ([item.identifier isEqualToString:@"DYYYABTestModeString"]) {
+			  BOOL isPatchMode = [DYYYABTestHook isPatchMode];
+			  if ([DYYYABTestHook isRemoteMode]) {
+				  item.detail = isPatchMode ? @"远程模式(覆写)" : @"远程模式(替换)";
+			  } else {
+				  item.detail = isPatchMode ? @"覆写模式" : @"替换模式";
+			  }
 
-                        item.cellTappedBlock = ^{
-                            if (!item.isEnable) return;
-                            NSString *currentMode = [[NSUserDefaults standardUserDefaults] objectForKey:@"DYYYABTestModeString"] ?: @"替换模式：忽略原配置，使用新数据";
+			  item.cellTappedBlock = ^{
+			    if (!item.isEnable)
+				    return;
+			    NSString *currentMode = [[NSUserDefaults standardUserDefaults] objectForKey:@"DYYYABTestModeString"] ?: @"替换模式：忽略原配置，使用新数据";
 
-                            NSArray *modeOptions = @[ @"覆写模式：保留原设置，覆盖同名项", @"替换模式：忽略原配置，使用新数据", DYYY_REMOTE_MODE_STRING ];
+			    NSArray *modeOptions = @[ @"覆写模式：保留原设置，覆盖同名项", @"替换模式：忽略原配置，使用新数据", DYYY_REMOTE_MODE_STRING ];
 
-                            [DYYYOptionsSelectionView showWithPreferenceKey:@"DYYYABTestModeString"
-                                                               optionsArray:modeOptions
-                                                                 headerText:@"选择本地配置的应用方式"
-                                                             onPresentingVC:topView()
-                                                           selectionChanged:^(NSString *selectedValue) {
-                                                             BOOL isPatchMode = [DYYYABTestHook isPatchMode];
-                                                             if ([DYYYABTestHook isRemoteMode]) {
-                                                                 item.detail = isPatchMode ? @"远程模式(覆写)" : @"远程模式(替换)";
-                                                             } else {
-                                                                 item.detail = isPatchMode ? @"覆写模式" : @"替换模式";
-                                                             }
+			    [DYYYOptionsSelectionView showWithPreferenceKey:@"DYYYABTestModeString"
+							       optionsArray:modeOptions
+								 headerText:@"选择本地配置的应用方式"
+							     onPresentingVC:topView()
+							   selectionChanged:^(NSString *selectedValue) {
+							     BOOL isPatchMode = [DYYYABTestHook isPatchMode];
+							     if ([DYYYABTestHook isRemoteMode]) {
+								     item.detail = isPatchMode ? @"远程模式(覆写)" : @"远程模式(替换)";
+							     } else {
+								     item.detail = isPatchMode ? @"覆写模式" : @"替换模式";
+							     }
 
-                                                             BOOL wasRemote = [[NSUserDefaults standardUserDefaults] boolForKey:DYYY_REMOTE_CONFIG_FLAG_KEY];
+							     BOOL wasRemote = [[NSUserDefaults standardUserDefaults] boolForKey:DYYY_REMOTE_CONFIG_FLAG_KEY];
 
-                                                             if ([selectedValue isEqualToString:DYYY_REMOTE_MODE_STRING]) {
-                                                                 [[NSUserDefaults standardUserDefaults] setBool:YES forKey:DYYY_REMOTE_CONFIG_FLAG_KEY];
-                                                                 [[NSUserDefaults standardUserDefaults] synchronize];
-                                                                 refreshConfigConflictState();
-                                                             } else {
-                                                                 if (wasRemote) {
-                                                                     [[NSUserDefaults standardUserDefaults] setBool:NO forKey:DYYY_REMOTE_CONFIG_FLAG_KEY];
-                                                                     [[NSUserDefaults standardUserDefaults] synchronize];
-                                                                     refreshConfigConflictState();
-                                                                 }
-                                                             }
+							     if ([selectedValue isEqualToString:DYYY_REMOTE_MODE_STRING]) {
+								     [[NSUserDefaults standardUserDefaults] setBool:YES forKey:DYYY_REMOTE_CONFIG_FLAG_KEY];
+								     [[NSUserDefaults standardUserDefaults] synchronize];
+								     refreshConfigConflictState();
+							     } else {
+								     if (wasRemote) {
+									     [[NSUserDefaults standardUserDefaults] setBool:NO forKey:DYYY_REMOTE_CONFIG_FLAG_KEY];
+									     [[NSUserDefaults standardUserDefaults] synchronize];
+									     refreshConfigConflictState();
+								     }
+							     }
 
-                                                             if (![selectedValue isEqualToString:currentMode]) {
-                                                                     [DYYYABTestHook applyFixedABTestData];
-                                                             }
-                                                             [item refreshCell];
-                                                         }];
-                        };
-                } else if ([item.identifier isEqualToString:@"DYYYRemoteConfigURL"]) {
-                        remoteURLItemRef = item;
-                        NSString *savedURL = [[NSUserDefaults standardUserDefaults] objectForKey:@"DYYYRemoteConfigURL"];
-                        item.detail = savedURL.length > 0 ? savedURL : DYYY_DEFAULT_ABTEST_URL;
-                        item.cellTappedBlock = ^{
-                          if (!item.isEnable) return;
-                          NSString *defaultText = item.detail;
-                          [DYYYSettingsHelper showTextInputAlert:@"设置远程配置地址"
-                                                         defaultText:defaultText
-                                                         placeholder:@"JSON URL"
-                                                           onConfirm:^(NSString *text) {
-                                                             NSString *trimmedText = [text stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
-                                                             [DYYYSettingsHelper setUserDefaults:trimmedText forKey:@"DYYYRemoteConfigURL"];
-                                                             item.detail = trimmedText.length > 0 ? trimmedText : DYYY_DEFAULT_ABTEST_URL;
-                                                             [item refreshCell];
-                                                           }
-                                                            onCancel:nil];
-                        };
-                } else if ([item.identifier isEqualToString:@"DYYYCheckUpdate"]) {
-                        checkUpdateItemRef = item;
-                        item.cellTappedBlock = ^{
-                          if (!item.isEnable) return;
-                          [DYYYUtils showToast:@"正在检查更新..."];
-                          [DYYYABTestHook checkForRemoteConfigUpdate:YES];
-                        };
-                } else if ([item.identifier isEqualToString:@"SaveCurrentABTestData"]) {
+							     if (![selectedValue isEqualToString:currentMode]) {
+								     [DYYYABTestHook applyFixedABTestData];
+							     }
+							     [item refreshCell];
+							   }];
+			  };
+		  } else if ([item.identifier isEqualToString:@"DYYYRemoteConfigURL"]) {
+			  remoteURLItemRef = item;
+			  NSString *savedURL = [[NSUserDefaults standardUserDefaults] objectForKey:@"DYYYRemoteConfigURL"];
+			  item.detail = savedURL.length > 0 ? savedURL : DYYY_DEFAULT_ABTEST_URL;
+			  item.cellTappedBlock = ^{
+			    if (!item.isEnable)
+				    return;
+			    NSString *defaultText = item.detail;
+			    [DYYYSettingsHelper showTextInputAlert:@"设置远程配置地址"
+						       defaultText:defaultText
+						       placeholder:@"JSON URL"
+							 onConfirm:^(NSString *text) {
+							   NSString *trimmedText = [text stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+							   [DYYYSettingsHelper setUserDefaults:trimmedText forKey:@"DYYYRemoteConfigURL"];
+							   item.detail = trimmedText.length > 0 ? trimmedText : DYYY_DEFAULT_ABTEST_URL;
+							   [item refreshCell];
+							 }
+							  onCancel:nil];
+			  };
+		  } else if ([item.identifier isEqualToString:@"DYYYCheckUpdate"]) {
+			  checkUpdateItemRef = item;
+			  item.cellTappedBlock = ^{
+			    if (!item.isEnable)
+				    return;
+			    [DYYYUtils showToast:@"正在检查更新..."];
+			    [DYYYABTestHook checkForRemoteConfigUpdate:YES];
+			  };
+		  } else if ([item.identifier isEqualToString:@"SaveCurrentABTestData"]) {
 			  item.detail = @"(获取中...)";
 			  item.isEnable = NO;
 
@@ -2203,9 +2247,10 @@ extern "C"
 			  saveABTestConfigFileItemRef = item;
 			  refreshSaveABTestConfigFileItem();
 
-                        item.cellTappedBlock = ^{
-                            if (!item.isEnable) return;
-                            NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
+			  item.cellTappedBlock = ^{
+			    if (!item.isEnable)
+				    return;
+			    NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
 			    NSString *documentsDirectory = [paths firstObject];
 
 			    NSString *dyyyFolderPath = [documentsDirectory stringByAppendingPathComponent:@"DYYY"];
@@ -2258,11 +2303,12 @@ extern "C"
 			    UIViewController *topVC = topView();
 			    [topVC presentViewController:documentPicker animated:YES completion:nil];
 			  };
-                } else if ([item.identifier isEqualToString:@"LoadABTestConfigFile"]) {
-                        loadConfigItemRef = item;
-                        item.cellTappedBlock = ^{
-                            if (!item.isEnable) return;
-                            BOOL isPatchMode = [DYYYABTestHook isPatchMode];
+		  } else if ([item.identifier isEqualToString:@"LoadABTestConfigFile"]) {
+			  loadConfigItemRef = item;
+			  item.cellTappedBlock = ^{
+			    if (!item.isEnable)
+				    return;
+			    BOOL isPatchMode = [DYYYABTestHook isPatchMode];
 
 			    NSString *confirmTitle, *confirmMessage;
 			    if (isPatchMode) {
@@ -2310,12 +2356,12 @@ extern "C"
 						  if ([fileManager replaceItemAtURL:destinationURL withItemAtURL:temporaryURL backupItemName:nil options:0 resultingItemURL:nil error:&error]) {
 							  [DYYYABTestHook cleanLocalABTestData];
 							  [DYYYABTestHook loadLocalABTestConfig];
-                                                          [DYYYABTestHook applyFixedABTestData];
-                                                          [[NSUserDefaults standardUserDefaults] setBool:NO forKey:DYYY_REMOTE_CONFIG_FLAG_KEY];
-                                                          [[NSUserDefaults standardUserDefaults] synchronize];
-                                                          [[NSNotificationCenter defaultCenter] postNotificationName:DYYY_REMOTE_CONFIG_CHANGED_NOTIFICATION object:nil];
-                                                          success = YES;
-                                                          message = @"配置已导入，部分设置需重启应用后生效";
+							  [DYYYABTestHook applyFixedABTestData];
+							  [[NSUserDefaults standardUserDefaults] setBool:NO forKey:DYYY_REMOTE_CONFIG_FLAG_KEY];
+							  [[NSUserDefaults standardUserDefaults] synchronize];
+							  [[NSNotificationCenter defaultCenter] postNotificationName:DYYY_REMOTE_CONFIG_CHANGED_NOTIFICATION object:nil];
+							  success = YES;
+							  message = @"配置已导入，部分设置需重启应用后生效";
 						  } else {
 							  [fileManager removeItemAtURL:temporaryURL error:nil];
 							  message = [NSString stringWithFormat:@"导入失败 (替换文件失败): %@", error.localizedDescription];
@@ -2333,10 +2379,10 @@ extern "C"
 				    [DYYYUtils showToast:message];
 
 				    // 仅在导入成功且 item 仍然存在时更新 UI
-                                    if (success && strongSaveItemAgain) {
-                                            refreshSaveABTestConfigFileItem();
-                                            refreshConfigConflictState();
-                                    }
+				    if (success && strongSaveItemAgain) {
+					    refreshSaveABTestConfigFileItem();
+					    refreshConfigConflictState();
+				    }
 				  });
 				});
 			      };
@@ -2350,11 +2396,12 @@ extern "C"
 			    };
 			    [confirmDialog show];
 			  };
-                } else if ([item.identifier isEqualToString:@"DeleteABTestConfigFile"]) {
-                        deleteConfigItemRef = item;
-                        item.cellTappedBlock = ^{
-                            if (!item.isEnable) return;
-                            NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
+		  } else if ([item.identifier isEqualToString:@"DeleteABTestConfigFile"]) {
+			  deleteConfigItemRef = item;
+			  item.cellTappedBlock = ^{
+			    if (!item.isEnable)
+				    return;
+			    NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
 			    NSString *documentsDirectory = [paths firstObject];
 			    NSString *dyyyFolderPath = [documentsDirectory stringByAppendingPathComponent:@"DYYY"];
 			    NSString *configPath = [dyyyFolderPath stringByAppendingPathComponent:@"abtest_data_fixed.json"];
@@ -2366,26 +2413,26 @@ extern "C"
 				    NSString *message = success ? @"本地配置已删除成功" : [NSString stringWithFormat:@"删除失败: %@", error.localizedDescription];
 				    [DYYYUtils showToast:message];
 
-                                    if (success) {
-                                            [DYYYABTestHook cleanLocalABTestData];
-                                            [[NSUserDefaults standardUserDefaults] setBool:NO forKey:DYYY_REMOTE_CONFIG_FLAG_KEY];
-                                            [[NSUserDefaults standardUserDefaults] synchronize];
-                                            [[NSNotificationCenter defaultCenter] postNotificationName:DYYY_REMOTE_CONFIG_CHANGED_NOTIFICATION object:nil];
-                                            // 删除成功后修改 SaveABTestConfigFile item 的状态
-                                            saveABTestConfigFileItemRef.detail = @"(文件已删除)";
-                                            saveABTestConfigFileItemRef.isEnable = NO;
-                                            [saveABTestConfigFileItemRef refreshCell];
-                                            refreshConfigConflictState();
-                                    }
+				    if (success) {
+					    [DYYYABTestHook cleanLocalABTestData];
+					    [[NSUserDefaults standardUserDefaults] setBool:NO forKey:DYYY_REMOTE_CONFIG_FLAG_KEY];
+					    [[NSUserDefaults standardUserDefaults] synchronize];
+					    [[NSNotificationCenter defaultCenter] postNotificationName:DYYY_REMOTE_CONFIG_CHANGED_NOTIFICATION object:nil];
+					    // 删除成功后修改 SaveABTestConfigFile item 的状态
+					    saveABTestConfigFileItemRef.detail = @"(文件已删除)";
+					    saveABTestConfigFileItemRef.isEnable = NO;
+					    [saveABTestConfigFileItemRef refreshCell];
+					    refreshConfigConflictState();
+				    }
 			    } else {
 				    [DYYYUtils showToast:@"本地配置不存在"];
 			    }
 			  };
 		  }
 
-          [hotUpdateItems addObject:item];
-        }
-        refreshConfigConflictState();
+		  [hotUpdateItems addObject:item];
+	  }
+	  refreshConfigConflictState();
 
 	  // 【交互增强】分类
 	  NSMutableArray<AWESettingItemModel *> *interactionItems = [NSMutableArray array];
@@ -2461,12 +2508,14 @@ extern "C"
 		    @"detail" : @"",
 		    @"cellType" : @6,
 		    @"imageName" : @"ic_image_outlined_20"},
-		  @{@"identifier" : @"DYYYisEnableModernPanel",
-			@"title" : @"启用新版长按面板",
-			@"subTitle" : @"启用抖音灰度测试的新版长按面板",
-			@"detail" : @"",
-			@"cellType" : @37,
-		    @"imageName" : @"ic_squaresplit_outlined_20"},
+		  @{
+			  @"identifier" : @"DYYYisEnableModernPanel",
+			  @"title" : @"启用新版长按面板",
+			  @"subTitle" : @"启用抖音灰度测试的新版长按面板",
+			  @"detail" : @"",
+			  @"cellType" : @37,
+			  @"imageName" : @"ic_squaresplit_outlined_20"
+		  },
 		  @{@"identifier" : @"DYYYisLongPressPanelBlur",
 		    @"title" : @"长按面板玻璃效果",
 		    @"detail" : @"",
@@ -2476,7 +2525,7 @@ extern "C"
 		    @"title" : @"长按面板深色模式",
 		    @"detail" : @"",
 		    @"cellType" : @6,
-			@"imageName" : @"ic_sun_outlined"},
+		    @"imageName" : @"ic_sun_outlined"},
 		  @{@"identifier" : @"DYYYDisableHomeRefresh",
 		    @"title" : @"禁用点击首页刷新",
 		    @"detail" : @"",
@@ -2492,7 +2541,7 @@ extern "C"
 		    @"detail" : @"",
 		    @"cellType" : @6,
 		    @"imageName" : @"ic_comment_outlined_20"},
-		 @{@"identifier" : @"DYYYCommentShowDanmaku",
+		  @{@"identifier" : @"DYYYCommentShowDanmaku",
 		    @"title" : @"查看评论显示弹幕",
 		    @"detail" : @"",
 		    @"cellType" : @6,
@@ -2603,19 +2652,20 @@ extern "C"
 
 			  __weak AWESettingItemModel *weakItem = item;
 			  item.switchChangedBlock = ^{
-				  __strong AWESettingItemModel *strongItem = weakItem;
-				  if (!strongItem) return;
+			    __strong AWESettingItemModel *strongItem = weakItem;
+			    if (!strongItem)
+				    return;
 
-				  if (originalSwitchChangedBlock) {
-					  originalSwitchChangedBlock();
-				  }
+			    if (originalSwitchChangedBlock) {
+				    originalSwitchChangedBlock();
+			    }
 
-				  if (strongItem.isSwitchOn) {
-					  strongItem.svgIconImageName = @"ic_moon_outlined";
-				  } else {
-					  strongItem.svgIconImageName = @"ic_sun_outlined";
-				  }
-				  [strongItem refreshCell];
+			    if (strongItem.isSwitchOn) {
+				    strongItem.svgIconImageName = @"ic_moon_outlined";
+			    } else {
+				    strongItem.svgIconImageName = @"ic_sun_outlined";
+			    }
+			    [strongItem refreshCell];
 			  };
 		  }
 
@@ -2627,7 +2677,7 @@ extern "C"
 	  [sections addObject:[DYYYSettingsHelper createSectionWithTitle:@"长按面板设置" items:longPressItems]];
 	  [sections addObject:[DYYYSettingsHelper createSectionWithTitle:@"媒体保存" items:downloadItems]];
 	  [sections addObject:[DYYYSettingsHelper createSectionWithTitle:@"交互增强" items:interactionItems]];
-          [sections addObject:[DYYYSettingsHelper createSectionWithTitle:@"热更新" footerTitle:@"允许用户导出或导入抖音的ABTest配置，远程配置会在启动时自动检查更新。" items:hotUpdateItems]];
+	  [sections addObject:[DYYYSettingsHelper createSectionWithTitle:@"热更新" footerTitle:@"允许用户导出或导入抖音的ABTest配置。远程配置由 Nathalie 维护，在应用启动时自动更新远程配置。" items:hotUpdateItems]];
 	  // 创建并推入二级设置页面
 	  AWESettingBaseViewController *subVC = [DYYYSettingsHelper createSubSettingsViewController:@"增强设置" sections:sections];
 	  [rootVC.navigationController pushViewController:(UIViewController *)subVC animated:YES];
@@ -3207,7 +3257,7 @@ extern "C"
 	    }
 
 	    // 修复搜索界面的猜你想搜和猜你想看
-		NSFileManager *fileManager = [NSFileManager defaultManager];
+	    NSFileManager *fileManager = [NSFileManager defaultManager];
 	    NSString *activeMetadataFilePath = [libraryDir stringByAppendingPathComponent:@"Application Support/gurd_cache/.active_metadata"];
 	    if ([fileManager fileExistsAtPath:activeMetadataFilePath]) {
 		    [fileManager removeItemAtPath:activeMetadataFilePath error:nil];

--- a/README.md
+++ b/README.md
@@ -7,3 +7,18 @@
 #### **功能说明**  
 - 通过 **双指长按** 或 **抖音设置** 进入设置界面  
 - 功能自测
+
+#### 远程配置
+
+DYYY 可以通过远程 JSON 文件批量应用设置。默认下载地址在 `DYYYConstants.h` 中的 `DYYY_REMOTE_CONFIG_URL`。配置文件示例：
+
+```json
+{
+    "mode": "DYYY_MODE_PATCH",
+    "data": {
+        "ExampleKey": true
+    }
+}
+```
+
+`mode` 字段可选，支持 `DYYY_MODE_PATCH` 和 `DYYY_MODE_REPLACE`，若省略则默认为补丁模式 (`DYYY_MODE_PATCH`)。


### PR DESCRIPTION
## Summary
- add a constant for the default ABTest config URL
- fetch remote config URL from user settings in `checkForRemoteConfigUpdate`
- always check for updates on startup
- store remote config URL in settings under Hot Update section

## Testing
- `make` *(fails: `/tweak.mk` missing)*

------
https://chatgpt.com/codex/tasks/task_b_6868bd2e273c832a934d4637cb7e6c61