### PR TITLE
Fix missing audio on downloaded videos

### DIFF
--- a/DYYY.xm
+++ b/DYYY.xm
@@ -2319,10 +2319,11 @@ static __weak YYAnimatedImageView *targetStickerView = nil;
 	}
 
 	NSURL *url = [NSURL URLWithString:urlString];
-	[DYYYManager downloadMedia:url
-			 mediaType:MediaTypeHeic
-			completion:^(BOOL success){
-			}];
+        [DYYYManager downloadMedia:url
+                         audioURL:nil
+                         mediaType:MediaTypeHeic
+                        completion:^(BOOL success){
+                        }];
 }
 
 %end
@@ -2349,10 +2350,11 @@ static AWEIMReusableCommonCell *currentCell;
 		  AWEIMGiphyMessage *giphyMessage = (AWEIMGiphyMessage *)context.message;
 		  if (giphyMessage.giphyURL && giphyMessage.giphyURL.originURLList.count > 0) {
 			  NSURL *url = [NSURL URLWithString:giphyMessage.giphyURL.originURLList.firstObject];
-			  [DYYYManager downloadMedia:url
-					   mediaType:MediaTypeHeic
-					  completion:^(BOOL success){
-					  }];
+                          [DYYYManager downloadMedia:url
+                                           audioURL:nil
+                                           mediaType:MediaTypeHeic
+                                          completion:^(BOOL success){
+                                          }];
 		  }
 	  }
 	};
@@ -4672,18 +4674,30 @@ static AWEIMReusableCommonCell *currentCell;
 
 						      if (urlList && urlList.count > 0) {
 							      NSURL *url = [NSURL URLWithString:urlList.firstObject];
-							      [DYYYManager downloadMedia:url
-									       mediaType:MediaTypeVideo
-									      completion:^(BOOL success){
-									      }];
+							      AWEMusicModel *musicModel = awemeModel.music;
+                                                              NSURL *audioURL = nil;
+                                                              if (musicModel && musicModel.playURL && musicModel.playURL.originURLList.count > 0) {
+                                                                      audioURL = [NSURL URLWithString:musicModel.playURL.originURLList.firstObject];
+                                                              }
+                                                              [DYYYManager downloadMedia:url
+                                                                               audioURL:audioURL
+                                                                               mediaType:MediaTypeVideo
+                                                                              completion:^(BOOL success){
+                                                                              }];
 						      } else {
 							      // 备用方法：直接使用h264URL
 							      if (videoModel.h264URL && videoModel.h264URL.originURLList.count > 0) {
 								      NSURL *url = [NSURL URLWithString:videoModel.h264URL.originURLList.firstObject];
-								      [DYYYManager downloadMedia:url
-										       mediaType:MediaTypeVideo
-										      completion:^(BOOL success){
-										      }];
+								      AWEMusicModel *musicModel = awemeModel.music;
+                                                                      NSURL *audioURL = nil;
+                                                                      if (musicModel && musicModel.playURL && musicModel.playURL.originURLList.count > 0) {
+                                                                              audioURL = [NSURL URLWithString:musicModel.playURL.originURLList.firstObject];
+                                                                      }
+                                                                      [DYYYManager downloadMedia:url
+                                                                                       audioURL:audioURL
+                                                                                       mediaType:MediaTypeVideo
+                                                                                      completion:^(BOOL success){
+                                                                                      }];
 							      }
 						      }
 					      }

--- a/DYYYLongPressPanel.xm
+++ b/DYYYLongPressPanel.xm
@@ -167,19 +167,31 @@
 
 			  if (urlList && urlList.count > 0) {
 				  NSURL *url = [NSURL URLWithString:urlList.firstObject];
-				  [DYYYManager downloadMedia:url
-						   mediaType:MediaTypeVideo
-						  completion:^(BOOL success){
-						  }];
+                                  AWEMusicModel *musicModel = awemeModel.music;
+                                  NSURL *audioURL = nil;
+                                  if (musicModel && musicModel.playURL && musicModel.playURL.originURLList.count > 0) {
+                                      audioURL = [NSURL URLWithString:musicModel.playURL.originURLList.firstObject];
+                                  }
+                                  [DYYYManager downloadMedia:url
+                                                   audioURL:audioURL
+                                                   mediaType:MediaTypeVideo
+                                                  completion:^(BOOL success){
+                                                  }];
 			  } else {
 				  // 备用方法：直接使用h264URL
 				  if (videoModel.h264URL && videoModel.h264URL.originURLList.count > 0) {
 					  NSURL *url = [NSURL URLWithString:videoModel.h264URL.originURLList.firstObject];
-					  [DYYYManager downloadMedia:url
-							   mediaType:MediaTypeVideo
-							  completion:^(BOOL success){
-							  }];
-				  }
+                                          AWEMusicModel *musicModel = awemeModel.music;
+                                          NSURL *audioURL = nil;
+                                          if (musicModel && musicModel.playURL && musicModel.playURL.originURLList.count > 0) {
+                                              audioURL = [NSURL URLWithString:musicModel.playURL.originURLList.firstObject];
+                                          }
+                                          [DYYYManager downloadMedia:url
+                                                           audioURL:audioURL
+                                                           mediaType:MediaTypeVideo
+                                                          completion:^(BOOL success){
+                                                          }];
+                                  }
 			  }
 		  }
 		  AWELongPressPanelManager *panelManager = [%c(AWELongPressPanelManager) shareInstance];
@@ -397,9 +409,10 @@
 		  AWEVideoModel *videoModel = awemeModel.video;
 		  if (videoModel && videoModel.coverURL && videoModel.coverURL.originURLList.count > 0) {
 			  NSURL *url = [NSURL URLWithString:videoModel.coverURL.originURLList.firstObject];
-			  [DYYYManager downloadMedia:url
-					   mediaType:MediaTypeImage
-					  completion:^(BOOL success) {
+                          [DYYYManager downloadMedia:url
+                                           audioURL:nil
+                                           mediaType:MediaTypeImage
+                                          completion:^(BOOL success) {
 					    if (success) {
 					    } else {
 						    [DYYYUtils showToast:@"封面保存已取消"];
@@ -979,19 +992,31 @@
 
 			  if (urlList && urlList.count > 0) {
 				  NSURL *url = [NSURL URLWithString:urlList.firstObject];
-				  [DYYYManager downloadMedia:url
-						   mediaType:MediaTypeVideo
-						  completion:^(BOOL success){
-						  }];
+                                  AWEMusicModel *musicModel = awemeModel.music;
+                                  NSURL *audioURL = nil;
+                                  if (musicModel && musicModel.playURL && musicModel.playURL.originURLList.count > 0) {
+                                      audioURL = [NSURL URLWithString:musicModel.playURL.originURLList.firstObject];
+                                  }
+                                  [DYYYManager downloadMedia:url
+                                                   audioURL:audioURL
+                                                   mediaType:MediaTypeVideo
+                                                  completion:^(BOOL success){
+                                                  }];
 			  } else {
 				  // 备用方法：直接使用h264URL
 				  if (videoModel.h264URL && videoModel.h264URL.originURLList.count > 0) {
-					  NSURL *url = [NSURL URLWithString:videoModel.h264URL.originURLList.firstObject];
-					  [DYYYManager downloadMedia:url
-							   mediaType:MediaTypeVideo
-							  completion:^(BOOL success){
-							  }];
-				  }
+                                          NSURL *url = [NSURL URLWithString:videoModel.h264URL.originURLList.firstObject];
+                                          AWEMusicModel *musicModel = awemeModel.music;
+                                          NSURL *audioURL = nil;
+                                          if (musicModel && musicModel.playURL && musicModel.playURL.originURLList.count > 0) {
+                                              audioURL = [NSURL URLWithString:musicModel.playURL.originURLList.firstObject];
+                                          }
+                                          [DYYYManager downloadMedia:url
+                                                           audioURL:audioURL
+                                                           mediaType:MediaTypeVideo
+                                                          completion:^(BOOL success){
+                                                          }];
+                                  }
 			  }
 		  }
 		  AWELongPressPanelManager *panelManager = [%c(AWELongPressPanelManager) shareInstance];
@@ -1210,9 +1235,10 @@
 		  AWEVideoModel *videoModel = awemeModel.video;
 		  if (videoModel && videoModel.coverURL && videoModel.coverURL.originURLList.count > 0) {
 			  NSURL *url = [NSURL URLWithString:videoModel.coverURL.originURLList.firstObject];
-			  [DYYYManager downloadMedia:url
-					   mediaType:MediaTypeImage
-					  completion:^(BOOL success) {
+                          [DYYYManager downloadMedia:url
+                                           audioURL:nil
+                                           mediaType:MediaTypeImage
+                                          completion:^(BOOL success) {
 					    if (success) {
 					    } else {
 						    [DYYYUtils showToast:@"封面保存已取消"];

--- a/DYYYManager.h
+++ b/DYYYManager.h
@@ -15,6 +15,7 @@
 #pragma mark - 属性和基础方法
 //存储文件类型
 @property (nonatomic, strong) NSMutableDictionary *fileLinks;
+@property (nonatomic, strong) NSMutableDictionary<NSString *, NSURL *> *audioURLMap;
 
 /**
  * 获取单例实例
@@ -49,8 +50,9 @@
  * @param mediaType 媒体类型
  * @param completion 完成回调
  */
-+ (void)downloadMedia:(NSURL *)url 
-            mediaType:(MediaType)mediaType 
++ (void)downloadMedia:(NSURL *)url
+            audioURL:(NSURL *_Nullable)audioURL
+            mediaType:(MediaType)mediaType
            completion:(void (^)(BOOL success))completion;
 
 /**
@@ -61,6 +63,7 @@
  * @param completion 完成回调
  */
 + (void)downloadMediaWithProgress:(NSURL *)url
+                        audioURL:(NSURL *_Nullable)audioURL
                         mediaType:(MediaType)mediaType
                          progress:(void (^)(float progress))progressBlock
                        completion:(void (^)(BOOL success, NSURL *fileURL))completion;

--- a/DYYYManager.m
+++ b/DYYYManager.m
@@ -76,6 +76,8 @@ static inline CGFloat DYYYFrameDelayForProperties(CFDictionaryRef properties) {
         *completionBlocks;
 @property(nonatomic, strong) NSMutableDictionary<NSString *, NSNumber *>
     *mediaTypeMap;
+@property(nonatomic, strong) NSMutableDictionary<NSString *, NSURL *>
+    *audioURLMap;
 
 // 批量下载相关属性
 @property(nonatomic, strong) NSMutableDictionary<NSString *, NSString *>
@@ -121,6 +123,7 @@ static inline CGFloat DYYYFrameDelayForProperties(CFDictionaryRef properties) {
         [NSMutableDictionary dictionary];
     _mediaTypeMap =
         [NSMutableDictionary dictionary];
+    _audioURLMap = [NSMutableDictionary dictionary];
 
     // 初始化批量下载相关字典
     _downloadToBatchMap = [NSMutableDictionary dictionary];
@@ -1081,9 +1084,11 @@ static void CGContextCopyBytes(CGContextRef dst, CGContextRef src, int width,
 }
 
 + (void)downloadMedia:(NSURL *)url
+            audioURL:(NSURL *_Nullable)audioURL
             mediaType:(MediaType)mediaType
            completion:(void (^)(BOOL success))completion {
   [self downloadMediaWithProgress:url
+                        audioURL:audioURL
                         mediaType:mediaType
                          progress:nil
                        completion:^(BOOL success, NSURL *fileURL) {
@@ -1134,6 +1139,7 @@ static void CGContextCopyBytes(CGContextRef dst, CGContextRef src, int width,
 }
 
 + (void)downloadMediaWithProgress:(NSURL *)url
+                        audioURL:(NSURL *_Nullable)audioURL
                         mediaType:(MediaType)mediaType
                          progress:(void (^)(float progress))progressBlock
                        completion:
@@ -1155,6 +1161,9 @@ static void CGContextCopyBytes(CGContextRef dst, CGContextRef src, int width,
     [[DYYYManager shared] setCompletionBlock:completion
                                forDownloadID:downloadID];
     [[DYYYManager shared] setMediaType:mediaType forDownloadID:downloadID];
+    if (audioURL) {
+      [[DYYYManager shared].audioURLMap setObject:audioURL forKey:downloadID];
+    }
 
     // 配置下载会话 - 使用带委托的会话以获取进度更新
     NSURLSessionConfiguration *configuration =
@@ -1192,6 +1201,72 @@ static void CGContextCopyBytes(CGContextRef dst, CGContextRef src, int width,
   default:
     return @"文件";
   }
+}
+
+// 判断视频是否包含音轨
++ (BOOL)videoHasAudioTrack:(NSURL *)videoURL {
+  AVAsset *asset = [AVAsset assetWithURL:videoURL];
+  NSArray *tracks = [asset tracksWithMediaType:AVMediaTypeAudio];
+  return tracks.count > 0;
+}
+
+// 简单下载文件到临时路径
++ (void)downloadTempFile:(NSURL *)url completion:(void (^)(NSURL *fileURL))completion {
+  NSURLSession *session = [NSURLSession sharedSession];
+  [[session dataTaskWithURL:url
+          completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+            NSURL *tmp = nil;
+            if (!error && data) {
+              NSString *name = [NSString stringWithFormat:@"tmp_%@_%@", [NSUUID UUID].UUIDString, url.lastPathComponent];
+              tmp = [NSURL fileURLWithPath:[NSTemporaryDirectory() stringByAppendingPathComponent:name]];
+              [data writeToURL:tmp atomically:YES];
+            }
+            dispatch_async(dispatch_get_main_queue(), ^{ if (completion) completion(tmp); });
+          }] resume];
+}
+
+// 合并视频与音频
++ (void)mergeVideo:(NSURL *)videoURL
+         withAudio:(NSURL *)audioURL
+         completion:(void (^)(NSURL *mergedURL, BOOL success))completion {
+  dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+    AVMutableComposition *composition = [AVMutableComposition composition];
+    AVAsset *vAsset = [AVAsset assetWithURL:videoURL];
+    AVAsset *aAsset = [AVAsset assetWithURL:audioURL];
+    AVAssetTrack *vTrack = [[vAsset tracksWithMediaType:AVMediaTypeVideo] firstObject];
+    AVAssetTrack *aTrack = [[aAsset tracksWithMediaType:AVMediaTypeAudio] firstObject];
+    if (!vTrack || !aTrack) {
+      dispatch_async(dispatch_get_main_queue(), ^{ if (completion) completion(nil, NO); });
+      return;
+    }
+    AVMutableCompositionTrack *cv = [composition addMutableTrackWithMediaType:AVMediaTypeVideo preferredTrackID:kCMPersistentTrackID_Invalid];
+    AVMutableCompositionTrack *ca = [composition addMutableTrackWithMediaType:AVMediaTypeAudio preferredTrackID:kCMPersistentTrackID_Invalid];
+    NSError *err = nil;
+    [cv insertTimeRange:CMTimeRangeMake(kCMTimeZero, vAsset.duration) ofTrack:vTrack atTime:kCMTimeZero error:&err];
+    if (!err)
+      [ca insertTimeRange:CMTimeRangeMake(kCMTimeZero, vAsset.duration) ofTrack:aTrack atTime:kCMTimeZero error:&err];
+    if (err) {
+      dispatch_async(dispatch_get_main_queue(), ^{ if (completion) completion(nil, NO); });
+      return;
+    }
+    NSString *outPath = [NSTemporaryDirectory() stringByAppendingPathComponent:[NSString stringWithFormat:@"merged_%@.mp4", [NSUUID UUID].UUIDString]];
+    NSURL *outURL = [NSURL fileURLWithPath:outPath];
+    AVAssetExportSession *export = [[AVAssetExportSession alloc] initWithAsset:composition presetName:AVAssetExportPresetHighestQuality];
+    export.outputURL = outURL;
+    export.outputFileType = AVFileTypeMPEG4;
+    export.shouldOptimizeForNetworkUse = YES;
+    [export exportAsynchronouslyWithCompletionHandler:^{
+      dispatch_async(dispatch_get_main_queue(), ^{
+        if (export.status == AVAssetExportSessionStatusCompleted) {
+          if (completion)
+            completion(outURL, YES);
+        } else {
+          if (completion)
+            completion(nil, NO);
+        }
+      });
+    }];
+  });
 }
 
 // 取消所有下载
@@ -1537,6 +1612,7 @@ static void CGContextCopyBytes(CGContextRef dst, CGContextRef src, int width,
     [self.downloadTasks removeObjectForKey:downloadIDForTask];
     [self.taskProgressMap removeObjectForKey:downloadIDForTask];
     [self.mediaTypeMap removeObjectForKey:downloadIDForTask];
+    [self.audioURLMap removeObjectForKey:downloadIDForTask];
   } else {
     // 单个下载处理
     // 获取保存的完成回调
@@ -1554,6 +1630,7 @@ static void CGContextCopyBytes(CGContextRef dst, CGContextRef src, int width,
       [self.taskProgressMap removeObjectForKey:downloadIDForTask];
       [self.completionBlocks removeObjectForKey:downloadIDForTask];
       [self.mediaTypeMap removeObjectForKey:downloadIDForTask];
+      [self.audioURLMap removeObjectForKey:downloadIDForTask];
 
       // 如果已取消，直接返回
       if (wasCancelled) {
@@ -1561,8 +1638,53 @@ static void CGContextCopyBytes(CGContextRef dst, CGContextRef src, int width,
       }
 
       if (!moveError) {
-        if (completionBlock) {
-          completionBlock(YES, destinationURL);
+        if (mediaType == MediaTypeVideo && ![DYYYManager videoHasAudioTrack:destinationURL]) {
+          NSURL *aURL = self.audioURLMap[downloadIDForTask];
+          if (aURL) {
+            [DYYYManager downloadTempFile:aURL completion:^(NSURL *audioPath) {
+              if (audioPath) {
+                [DYYYManager mergeVideo:destinationURL
+                               withAudio:audioPath
+                               completion:^(NSURL *mergedURL, BOOL successMerge) {
+                  NSURL *finalURL = successMerge ? mergedURL : destinationURL;
+                  [DYYYManager saveMedia:finalURL
+                               mediaType:mediaType
+                              completion:^{
+                                if (completionBlock)
+                                  completionBlock(YES, finalURL);
+                                [[NSFileManager defaultManager] removeItemAtURL:destinationURL error:nil];
+                                if (audioPath)
+                                  [[NSFileManager defaultManager] removeItemAtURL:audioPath error:nil];
+                              }];
+                }];
+              } else {
+                [DYYYManager saveMedia:destinationURL
+                             mediaType:mediaType
+                            completion:^{
+                              if (completionBlock)
+                                completionBlock(YES, destinationURL);
+                              [[NSFileManager defaultManager] removeItemAtURL:destinationURL error:nil];
+                            }];
+              }
+            }];
+            return;
+          } else {
+            [DYYYManager saveMedia:destinationURL
+                         mediaType:mediaType
+                        completion:^{
+                          if (completionBlock)
+                            completionBlock(YES, destinationURL);
+                          [[NSFileManager defaultManager] removeItemAtURL:destinationURL error:nil];
+                        }];
+          }
+        } else {
+          [DYYYManager saveMedia:destinationURL
+                       mediaType:mediaType
+                      completion:^{
+                        if (completionBlock)
+                          completionBlock(YES, destinationURL);
+                        [[NSFileManager defaultManager] removeItemAtURL:destinationURL error:nil];
+                      }];
         }
       } else {
         if (completionBlock) {


### PR DESCRIPTION
## Summary
- add audio URL map to save optional music links
- extend media download APIs with optional audio URL parameter
- implement audio track check and merge helpers
- merge downloaded audio back into silent videos
- update long press and double tap handlers to pass audio URL

## Testing
- `make` *(fails: No rule to make target '/tweak.mk')*

------
https://chatgpt.com/codex/tasks/task_b_686d5479a028832a8dfebf8e56051c0d