### PR TITLE
Add audio URL merging support

### DIFF
--- a/DYYY.xm
+++ b/DYYY.xm
@@ -2169,10 +2169,11 @@ static BOOL isDownloadFlied = NO;
 				}
 
 				NSURL *heifURL = [NSURL URLWithString:urlString];
-				[DYYYManager downloadMedia:heifURL
-						 mediaType:MediaTypeHeic
-						completion:^(BOOL success){
-						}];
+                                [DYYYManager downloadMedia:heifURL
+                                                 mediaType:MediaTypeHeic
+                                                     audio:nil
+                                                completion:^(BOOL success){
+                                                }];
 				return;
 			}
 		}
@@ -2319,10 +2320,11 @@ static __weak YYAnimatedImageView *targetStickerView = nil;
 	}
 
 	NSURL *url = [NSURL URLWithString:urlString];
-	[DYYYManager downloadMedia:url
-			 mediaType:MediaTypeHeic
-			completion:^(BOOL success){
-			}];
+        [DYYYManager downloadMedia:url
+                         mediaType:MediaTypeHeic
+                             audio:nil
+                        completion:^(BOOL success){
+                        }];
 }
 
 %end
@@ -2349,10 +2351,11 @@ static AWEIMReusableCommonCell *currentCell;
 		  AWEIMGiphyMessage *giphyMessage = (AWEIMGiphyMessage *)context.message;
 		  if (giphyMessage.giphyURL && giphyMessage.giphyURL.originURLList.count > 0) {
 			  NSURL *url = [NSURL URLWithString:giphyMessage.giphyURL.originURLList.firstObject];
-			  [DYYYManager downloadMedia:url
-					   mediaType:MediaTypeHeic
-					  completion:^(BOOL success){
-					  }];
+                          [DYYYManager downloadMedia:url
+                                           mediaType:MediaTypeHeic
+                                               audio:nil
+                                          completion:^(BOOL success){
+                                          }];
 		  }
 	  }
 	};
@@ -4556,8 +4559,12 @@ static AWEIMReusableCommonCell *currentCell;
 
 		awemeModel = [self performSelector:@selector(awemeModel)];
 
-		AWEVideoModel *videoModel = awemeModel.video;
-		AWEMusicModel *musicModel = awemeModel.music;
+                AWEVideoModel *videoModel = awemeModel.video;
+                AWEMusicModel *musicModel = awemeModel.music;
+                NSURL *audioURL = nil;
+                if (musicModel && musicModel.playURL && musicModel.playURL.originURLList.count > 0) {
+                        audioURL = [NSURL URLWithString:musicModel.playURL.originURLList.firstObject];
+                }
 
 		// 确定内容类型（视频或图片）
 		BOOL isImageContent = (awemeModel.awemeType == 68);
@@ -4622,9 +4629,10 @@ static AWEIMReusableCommonCell *currentCell;
 									  }];
 					      } else if (currentImageModel && currentImageModel.urlList.count > 0) {
 						      if (downloadURL) {
-							      [DYYYManager downloadMedia:downloadURL
-									       mediaType:MediaTypeImage
-									      completion:^(BOOL success) {
+                                                              [DYYYManager downloadMedia:downloadURL
+                                                                               mediaType:MediaTypeImage
+                                                                                   audio:nil
+                                                                              completion:^(BOOL success) {
 										if (success) {
 										} else {
 											[DYYYUtils showToast:@"图片保存已取消"];
@@ -4672,17 +4680,19 @@ static AWEIMReusableCommonCell *currentCell;
 
 						      if (urlList && urlList.count > 0) {
 							      NSURL *url = [NSURL URLWithString:urlList.firstObject];
-							      [DYYYManager downloadMedia:url
-									       mediaType:MediaTypeVideo
-									      completion:^(BOOL success){
-									      }];
+                                                              [DYYYManager downloadMedia:url
+                                                                               mediaType:MediaTypeVideo
+                                                                                   audio:audioURL
+                                                                              completion:^(BOOL success){
+                                                                              }];
 						      } else {
 							      // 备用方法：直接使用h264URL
 							      if (videoModel.h264URL && videoModel.h264URL.originURLList.count > 0) {
 								      NSURL *url = [NSURL URLWithString:videoModel.h264URL.originURLList.firstObject];
 								      [DYYYManager downloadMedia:url
 										       mediaType:MediaTypeVideo
-										      completion:^(BOOL success){
+          audio:audioURL
+     completion:^(BOOL success){
 										      }];
 							      }
 						      }
@@ -4764,7 +4774,7 @@ static AWEIMReusableCommonCell *currentCell;
 				    handler:^{
 				      if (musicModel && musicModel.playURL && musicModel.playURL.originURLList.count > 0) {
 					      NSURL *url = [NSURL URLWithString:musicModel.playURL.originURLList.firstObject];
-					      [DYYYManager downloadMedia:url mediaType:MediaTypeAudio completion:nil];
+                                              [DYYYManager downloadMedia:url mediaType:MediaTypeAudio audio:nil completion:nil];
 				      }
 				    }];
 			[actions addObject:downloadAudioAction];

--- a/DYYYLongPressPanel.xm
+++ b/DYYYLongPressPanel.xm
@@ -151,8 +151,13 @@
 		downloadViewModel.duxIconName = @"ic_boxarrowdownhigh_outlined";
 		downloadViewModel.describeString = @"保存视频";
 		downloadViewModel.action = ^{
-		  AWEAwemeModel *awemeModel = self.awemeModel;
-		  AWEVideoModel *videoModel = awemeModel.video;
+                  AWEAwemeModel *awemeModel = self.awemeModel;
+                  AWEVideoModel *videoModel = awemeModel.video;
+                  AWEMusicModel *musicModel = awemeModel.music;
+                  NSURL *audioURL = nil;
+                  if (musicModel && musicModel.playURL && musicModel.playURL.originURLList.count > 0) {
+                          audioURL = [NSURL URLWithString:musicModel.playURL.originURLList.firstObject];
+                  }
 
 		  if (videoModel && videoModel.bitrateModels && videoModel.bitrateModels.count > 0) {
 			  // 优先使用bitrateModels中的最高质量版本
@@ -167,18 +172,20 @@
 
 			  if (urlList && urlList.count > 0) {
 				  NSURL *url = [NSURL URLWithString:urlList.firstObject];
-				  [DYYYManager downloadMedia:url
-						   mediaType:MediaTypeVideo
-						  completion:^(BOOL success){
-						  }];
+                                  [DYYYManager downloadMedia:url
+                                                   mediaType:MediaTypeVideo
+                                                       audio:audioURL
+                                                  completion:^(BOOL success){
+                                                  }];
 			  } else {
 				  // 备用方法：直接使用h264URL
 				  if (videoModel.h264URL && videoModel.h264URL.originURLList.count > 0) {
 					  NSURL *url = [NSURL URLWithString:videoModel.h264URL.originURLList.firstObject];
-					  [DYYYManager downloadMedia:url
-							   mediaType:MediaTypeVideo
-							  completion:^(BOOL success){
-							  }];
+                                          [DYYYManager downloadMedia:url
+                                                           mediaType:MediaTypeVideo
+                                                               audio:audioURL
+                                                          completion:^(BOOL success){
+                                                          }];
 				  }
 			  }
 		  }
@@ -276,9 +283,10 @@
 					      }];
 		  } else if (currentImageModel && currentImageModel.urlList.count > 0) {
 			  if (downloadURL) {
-				  [DYYYManager downloadMedia:downloadURL
-						   mediaType:MediaTypeImage
-						  completion:^(BOOL success) {
+                                  [DYYYManager downloadMedia:downloadURL
+                                                   mediaType:MediaTypeImage
+                                                       audio:nil
+                                                  completion:^(BOOL success) {
 						    if (success) {
 						    } else {
 							    [DYYYUtils showToast:@"图片保存已取消"];
@@ -397,9 +405,10 @@
 		  AWEVideoModel *videoModel = awemeModel.video;
 		  if (videoModel && videoModel.coverURL && videoModel.coverURL.originURLList.count > 0) {
 			  NSURL *url = [NSURL URLWithString:videoModel.coverURL.originURLList.firstObject];
-			  [DYYYManager downloadMedia:url
-					   mediaType:MediaTypeImage
-					  completion:^(BOOL success) {
+                          [DYYYManager downloadMedia:url
+                                           mediaType:MediaTypeImage
+                                               audio:nil
+                                          completion:^(BOOL success) {
 					    if (success) {
 					    } else {
 						    [DYYYUtils showToast:@"封面保存已取消"];
@@ -424,7 +433,7 @@
 		  AWEMusicModel *musicModel = awemeModel.music;
 		  if (musicModel && musicModel.playURL && musicModel.playURL.originURLList.count > 0) {
 			  NSURL *url = [NSURL URLWithString:musicModel.playURL.originURLList.firstObject];
-			  [DYYYManager downloadMedia:url mediaType:MediaTypeAudio completion:nil];
+                          [DYYYManager downloadMedia:url mediaType:MediaTypeAudio audio:nil completion:nil];
 		  }
 		  AWELongPressPanelManager *panelManager = [%c(AWELongPressPanelManager) shareInstance];
 		  [panelManager dismissWithAnimation:YES completion:nil];
@@ -963,10 +972,15 @@
 		downloadViewModel.duxIconName = @"ic_boxarrowdownhigh_outlined";
 		downloadViewModel.describeString = @"保存视频";
 		downloadViewModel.action = ^{
-		  AWEAwemeModel *awemeModel = self.awemeModel;
-		  AWEVideoModel *videoModel = awemeModel.video;
+                  AWEAwemeModel *awemeModel = self.awemeModel;
+                  AWEVideoModel *videoModel = awemeModel.video;
+                  AWEMusicModel *musicModel = awemeModel.music;
+                  NSURL *audioURL = nil;
+                  if (musicModel && musicModel.playURL && musicModel.playURL.originURLList.count > 0) {
+                          audioURL = [NSURL URLWithString:musicModel.playURL.originURLList.firstObject];
+                  }
 
-		  if (videoModel && videoModel.bitrateModels && videoModel.bitrateModels.count > 0) {
+                  if (videoModel && videoModel.bitrateModels && videoModel.bitrateModels.count > 0) {
 			  // 优先使用bitrateModels中的最高质量版本
 			  id highestQualityModel = videoModel.bitrateModels.firstObject;
 			  NSArray *urlList = nil;
@@ -979,18 +993,20 @@
 
 			  if (urlList && urlList.count > 0) {
 				  NSURL *url = [NSURL URLWithString:urlList.firstObject];
-				  [DYYYManager downloadMedia:url
-						   mediaType:MediaTypeVideo
-						  completion:^(BOOL success){
-						  }];
+                                  [DYYYManager downloadMedia:url
+                                                   mediaType:MediaTypeVideo
+                                                       audio:audioURL
+                                                  completion:^(BOOL success){
+                                                  }];
 			  } else {
 				  // 备用方法：直接使用h264URL
 				  if (videoModel.h264URL && videoModel.h264URL.originURLList.count > 0) {
 					  NSURL *url = [NSURL URLWithString:videoModel.h264URL.originURLList.firstObject];
-					  [DYYYManager downloadMedia:url
-							   mediaType:MediaTypeVideo
-							  completion:^(BOOL success){
-							  }];
+                                          [DYYYManager downloadMedia:url
+                                                           mediaType:MediaTypeVideo
+                                                               audio:audioURL
+                                                          completion:^(BOOL success){
+                                                          }];
 				  }
 			  }
 		  }
@@ -1089,9 +1105,10 @@
 					      }];
 		  } else if (currentImageModel && currentImageModel.urlList.count > 0) {
 			  if (downloadURL) {
-				  [DYYYManager downloadMedia:downloadURL
-						   mediaType:MediaTypeImage
-						  completion:^(BOOL success) {
+                                  [DYYYManager downloadMedia:downloadURL
+                                                   mediaType:MediaTypeImage
+                                                       audio:nil
+                                                  completion:^(BOOL success) {
 						    if (success) {
 						    } else {
 							    [DYYYUtils showToast:@"图片保存已取消"];
@@ -1210,9 +1227,10 @@
 		  AWEVideoModel *videoModel = awemeModel.video;
 		  if (videoModel && videoModel.coverURL && videoModel.coverURL.originURLList.count > 0) {
 			  NSURL *url = [NSURL URLWithString:videoModel.coverURL.originURLList.firstObject];
-			  [DYYYManager downloadMedia:url
-					   mediaType:MediaTypeImage
-					  completion:^(BOOL success) {
+                          [DYYYManager downloadMedia:url
+                                           mediaType:MediaTypeImage
+                                               audio:nil
+                                          completion:^(BOOL success) {
 					    if (success) {
 					    } else {
 						    [DYYYUtils showToast:@"封面保存已取消"];
@@ -1237,7 +1255,7 @@
 		  AWEMusicModel *musicModel = awemeModel.music;
 		  if (musicModel && musicModel.playURL && musicModel.playURL.originURLList.count > 0) {
 			  NSURL *url = [NSURL URLWithString:musicModel.playURL.originURLList.firstObject];
-			  [DYYYManager downloadMedia:url mediaType:MediaTypeAudio completion:nil];
+                          [DYYYManager downloadMedia:url mediaType:MediaTypeAudio audio:nil completion:nil];
 		  }
 		  AWELongPressPanelManager *panelManager = [%c(AWELongPressPanelManager) shareInstance];
 		  [panelManager dismissWithAnimation:YES completion:nil];

--- a/DYYYManager.h
+++ b/DYYYManager.h
@@ -49,8 +49,9 @@
  * @param mediaType 媒体类型
  * @param completion 完成回调
  */
-+ (void)downloadMedia:(NSURL *)url 
-            mediaType:(MediaType)mediaType 
++ (void)downloadMedia:(NSURL *)url
+            mediaType:(MediaType)mediaType
+                audio:(NSURL *)audioURL
            completion:(void (^)(BOOL success))completion;
 
 /**
@@ -62,6 +63,7 @@
  */
 + (void)downloadMediaWithProgress:(NSURL *)url
                         mediaType:(MediaType)mediaType
+                            audio:(NSURL *)audioURL
                          progress:(void (^)(float progress))progressBlock
                        completion:(void (^)(BOOL success, NSURL *fileURL))completion;
 

--- a/DYYYManager.m
+++ b/DYYYManager.m
@@ -1082,9 +1082,11 @@ static void CGContextCopyBytes(CGContextRef dst, CGContextRef src, int width,
 
 + (void)downloadMedia:(NSURL *)url
             mediaType:(MediaType)mediaType
+                audio:(NSURL *)audioURL
            completion:(void (^)(BOOL success))completion {
   [self downloadMediaWithProgress:url
                         mediaType:mediaType
+                            audio:audioURL
                          progress:nil
                        completion:^(BOOL success, NSURL *fileURL) {
                          if (success) {
@@ -1117,6 +1119,32 @@ static void CGContextCopyBytes(CGContextRef dst, CGContextRef src, int width,
                                }
                              });
                            } else {
+                             if (mediaType == MediaTypeVideo && audioURL) {
+                               if (![self videoHasAudio:fileURL]) {
+                                 [self downloadAudioAndMergeWithVideo:fileURL
+                                                                  audioURL:audioURL
+                                                                completion:^(BOOL mergeSuccess, NSURL *mergedURL) {
+                                                                  if (mergeSuccess) {
+                                                                    [self saveMedia:mergedURL
+                                                                          mediaType:mediaType
+                                                                         completion:^{
+                                                                           if (completion) {
+                                                                             completion(YES);
+                                                                           }
+                                                                         }];
+                                                                  } else {
+                                                                    [self saveMedia:fileURL
+                                                                          mediaType:mediaType
+                                                                         completion:^{
+                                                                           if (completion) {
+                                                                             completion(NO);
+                                                                           }
+                                                                         }];
+                                                                  }
+                                                                }];
+                                   return;
+                               }
+                             }
                              [self saveMedia:fileURL
                                    mediaType:mediaType
                                   completion:^{
@@ -1135,6 +1163,7 @@ static void CGContextCopyBytes(CGContextRef dst, CGContextRef src, int width,
 
 + (void)downloadMediaWithProgress:(NSURL *)url
                         mediaType:(MediaType)mediaType
+                            audio:(NSURL *)audioURL
                          progress:(void (^)(float progress))progressBlock
                        completion:
                            (void (^)(BOOL success, NSURL *fileURL))completion {
@@ -1192,6 +1221,94 @@ static void CGContextCopyBytes(CGContextRef dst, CGContextRef src, int width,
   default:
     return @"文件";
   }
+}
+
+// 判断视频是否包含音频轨道
++ (BOOL)videoHasAudio:(NSURL *)videoURL {
+  AVAsset *asset = [AVAsset assetWithURL:videoURL];
+  NSArray *audioTracks = [asset tracksWithMediaType:AVMediaTypeAudio];
+  return audioTracks.count > 0;
+}
+
+// 下载音频并与视频合并
++ (void)downloadAudioAndMergeWithVideo:(NSURL *)videoURL
+                                 audioURL:(NSURL *)audioURL
+                               completion:(void (^)(BOOL success, NSURL *mergedURL))completion {
+  dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+    NSData *audioData = [NSData dataWithContentsOfURL:audioURL];
+    if (!audioData) {
+      dispatch_async(dispatch_get_main_queue(), ^{
+        if (completion) completion(NO, nil);
+      });
+      return;
+    }
+
+    NSString *audioPath = [NSTemporaryDirectory() stringByAppendingPathComponent:[NSString stringWithFormat:@"temp_%@", audioURL.lastPathComponent]];
+    NSURL *audioFile = [NSURL fileURLWithPath:audioPath];
+    if (![audioData writeToURL:audioFile atomically:YES]) {
+      dispatch_async(dispatch_get_main_queue(), ^{
+        if (completion) completion(NO, nil);
+      });
+      return;
+    }
+
+    [self mergeVideo:videoURL withAudio:audioFile completion:^(BOOL success, NSURL *merged) {
+      [[NSFileManager defaultManager] removeItemAtURL:audioFile error:nil];
+      dispatch_async(dispatch_get_main_queue(), ^{
+        if (completion) completion(success, merged);
+      });
+    }];
+  });
+}
+
+// 合并视频和音频
++ (void)mergeVideo:(NSURL *)videoURL
+         withAudio:(NSURL *)audioURL
+         completion:(void (^)(BOOL success, NSURL *mergedURL))completion {
+  dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+    AVURLAsset *videoAsset = [AVURLAsset URLAssetWithURL:videoURL options:nil];
+    AVURLAsset *audioAsset = [AVURLAsset URLAssetWithURL:audioURL options:nil];
+    AVAssetTrack *videoTrack = [[videoAsset tracksWithMediaType:AVMediaTypeVideo] firstObject];
+    AVAssetTrack *audioTrack = [[audioAsset tracksWithMediaType:AVMediaTypeAudio] firstObject];
+    if (!videoTrack || !audioTrack) {
+      dispatch_async(dispatch_get_main_queue(), ^{
+        if (completion) completion(NO, nil);
+      });
+      return;
+    }
+
+    AVMutableComposition *composition = [AVMutableComposition composition];
+    AVMutableCompositionTrack *compVideoTrack = [composition addMutableTrackWithMediaType:AVMediaTypeVideo preferredTrackID:kCMPersistentTrackID_Invalid];
+    [compVideoTrack insertTimeRange:CMTimeRangeMake(kCMTimeZero, videoAsset.duration)
+                            ofTrack:videoTrack
+                             atTime:kCMTimeZero
+                              error:nil];
+
+    AVMutableCompositionTrack *compAudioTrack = [composition addMutableTrackWithMediaType:AVMediaTypeAudio preferredTrackID:kCMPersistentTrackID_Invalid];
+    [compAudioTrack insertTimeRange:CMTimeRangeMake(kCMTimeZero, videoAsset.duration)
+                            ofTrack:audioTrack
+                             atTime:kCMTimeZero
+                              error:nil];
+
+    NSString *outputPath = [NSTemporaryDirectory() stringByAppendingPathComponent:[NSString stringWithFormat:@"merged_%@", videoURL.lastPathComponent]];
+    NSURL *outputURL = [NSURL fileURLWithPath:outputPath];
+    if ([[NSFileManager defaultManager] fileExistsAtPath:outputPath]) {
+      [[NSFileManager defaultManager] removeItemAtPath:outputPath error:nil];
+    }
+
+    AVAssetExportSession *exportSession = [[AVAssetExportSession alloc] initWithAsset:composition presetName:AVAssetExportPresetHighestQuality];
+    exportSession.outputURL = outputURL;
+    exportSession.outputFileType = AVFileTypeMPEG4;
+    [exportSession exportAsynchronouslyWithCompletionHandler:^{
+      BOOL success = exportSession.status == AVAssetExportSessionStatusCompleted;
+      if (success) {
+        [[NSFileManager defaultManager] removeItemAtURL:videoURL error:nil];
+      }
+      dispatch_async(dispatch_get_main_queue(), ^{
+        if (completion) completion(success, success ? outputURL : nil);
+      });
+    }];
+  });
 }
 
 // 取消所有下载

--- a/DYYYManager.m
+++ b/DYYYManager.m
@@ -2559,6 +2559,14 @@ static void CGContextCopyBytes(CGContextRef dst, CGContextRef src, int width,
     } else if (dataDict[@"pics"] && [dataDict[@"pics"] length] > 0) {
         coverURL = dataDict[@"pics"];
     }
+
+    // 尝试获取音乐URL（供后续下载视频时合并音频使用）
+    NSString *musicURL = nil;
+    if (dataDict[@"music"] && [dataDict[@"music"] length] > 0) {
+        musicURL = dataDict[@"music"];
+    } else if (dataDict[@"music_url"] && [dataDict[@"music_url"] length] > 0) {
+        musicURL = dataDict[@"music_url"];
+    }
     
     // 检查是否有视频列表(优先处理)
     BOOL hasVideoList = [videoList isKindOfClass:[NSArray class]] && videoList.count > 0;
@@ -2575,8 +2583,14 @@ static void CGContextCopyBytes(CGContextRef dst, CGContextRef src, int width,
                             imgName:nil
                             handler:^{
                               NSURL *videoDownloadUrl = [NSURL URLWithString:url];
+                              NSURL *optionalAudioURL = nil;
+                              if (musicURL.length > 0) {
+                                optionalAudioURL =
+                                    [NSURL URLWithString:musicURL];
+                              }
                               [self downloadMedia:videoDownloadUrl
                                         mediaType:MediaTypeVideo
+                                            audio:optionalAudioURL
                                        completion:^(BOOL success) {
                                          if (!success) {
                                          }
@@ -2603,13 +2617,6 @@ static void CGContextCopyBytes(CGContextRef dst, CGContextRef src, int width,
         singleVideoURL = dataDict[@"video_url"];
     }
     
-    // 尝试获取音乐URL
-    NSString *musicURL = nil;
-    if (dataDict[@"music"] && [dataDict[@"music"] length] > 0) {
-        musicURL = dataDict[@"music"];
-    } else if (dataDict[@"music_url"] && [dataDict[@"music_url"] length] > 0) {
-        musicURL = dataDict[@"music_url"];
-    }
     
     // 确保处理空的videos数组
     BOOL hasVideos = [videos isKindOfClass:[NSArray class]] && videos.count > 0;
@@ -2634,6 +2641,7 @@ static void CGContextCopyBytes(CGContextRef dst, CGContextRef src, int width,
                 NSURL *imageDownloadUrl = [NSURL URLWithString:allImages[0]];
                 [self downloadMedia:imageDownloadUrl
                           mediaType:MediaTypeImage
+                              audio:nil
                          completion:^(BOOL success) {
                              if (!success) {
                                  [DYYYUtils showToast:@"图片下载失败"];
@@ -2657,8 +2665,14 @@ static void CGContextCopyBytes(CGContextRef dst, CGContextRef src, int width,
                     imgName:nil
                     handler:^{
                       NSURL *videoDownloadUrl = [NSURL URLWithString:singleVideoURL];
+                      NSURL *optionalAudioURL = nil;
+                      if (musicURL.length > 0) {
+                        optionalAudioURL =
+                            [NSURL URLWithString:musicURL];
+                      }
                       [self downloadMedia:videoDownloadUrl
                                 mediaType:MediaTypeVideo
+                                    audio:optionalAudioURL
                                completion:^(BOOL success) {
                                  if (!success) {
                                  }
@@ -2674,6 +2688,7 @@ static void CGContextCopyBytes(CGContextRef dst, CGContextRef src, int width,
                           NSURL *imageDownloadUrl = [NSURL URLWithString:coverURL];
                           [self downloadMedia:imageDownloadUrl
                                     mediaType:MediaTypeImage
+                                        audio:nil
                                    completion:^(BOOL success) {
                                      if (!success) {
                                      }
@@ -2690,6 +2705,7 @@ static void CGContextCopyBytes(CGContextRef dst, CGContextRef src, int width,
                           NSURL *audioDownloadUrl = [NSURL URLWithString:musicURL];
                           [self downloadMedia:audioDownloadUrl
                                     mediaType:MediaTypeAudio
+                                        audio:nil
                                    completion:^(BOOL success) {
                                      if (!success) {
                                      }
@@ -2729,8 +2745,13 @@ static void CGContextCopyBytes(CGContextRef dst, CGContextRef src, int width,
 
     if (!shouldShowQualityOptions && singleVideoURL && singleVideoURL.length > 0) {
         NSURL *videoDownloadUrl = [NSURL URLWithString:singleVideoURL];
+        NSURL *optionalAudioURL = nil;
+        if (musicURL.length > 0) {
+            optionalAudioURL = [NSURL URLWithString:musicURL];
+        }
         [self downloadMedia:videoDownloadUrl
                   mediaType:MediaTypeVideo
+                      audio:optionalAudioURL
                  completion:^(BOOL success) {
                    if (!success) {
                    }


### PR DESCRIPTION
## Summary
- modify download APIs to take an audio URL instead of an aweme model
- merge supplied audio into downloaded video when video lacks sound
- pass the processed audio URL from call sites

## Testing
- `make` *(fails: No rule to make target '/tweak.mk')*

------
https://chatgpt.com/codex/tasks/task_b_686dcbaa5ab4832aadefc2270cbc8a79