### PR TITLE
Fix clear button visibility

### DIFF
--- a/DYYYFloatClearButton.xm
+++ b/DYYYFloatClearButton.xm
@@ -389,6 +389,11 @@ static void initTargetClassNames(void) {
     // 新增隐藏 AWEPlayInteractionProgressContainerView 视图
     [self hideAWEPlayInteractionProgressContainerView];
     self.isElementsHidden = YES;
+    // Ensure the button itself remains visible
+    self.hidden = NO;
+    if (self.superview) {
+        [self.superview bringSubviewToFront:self];
+    }
 }
 
 - (void)hideAWEPlayInteractionProgressContainerView {
@@ -427,6 +432,8 @@ static void initTargetClassNames(void) {
             findViewsOfClassHelper(window, viewClass, views);
             for (UIView *view in views) {
                 if ([view isKindOfClass:[UIView class]]) {
+                    if (view == self)
+                        continue;
                     if ([view isKindOfClass:NSClassFromString(@"AWELeftSideBarEntranceView")]) {
                         UIViewController *controller = [self findViewController:view];
                         if (![controller isKindOfClass:NSClassFromString(@"AWEFeedContainerViewController")]) {
@@ -445,6 +452,10 @@ static void initTargetClassNames(void) {
     self.isElementsHidden = NO;
     [self.hiddenViewsList removeAllObjects];
     self.selected = NO;
+
+    if (self.superview) {
+        [self.superview bringSubviewToFront:self];
+    }
 
     // 恢复倍速按钮的显示
     BOOL hideSpeed = [[NSUserDefaults standardUserDefaults] boolForKey:@"DYYYHideSpeed"];


### PR DESCRIPTION
## Summary
- revert previous restructuring that moved button hooks to `DYYY.xm`
- keep the floating clear button visible while hiding UI elements
- restore the button's front position when resetting
- skip the button when collecting views to hide

## Testing
- `make -n` *(fails: No rule to make target '/tweak.mk')*

------
https://chatgpt.com/codex/tasks/task_b_687528b3a278832abcb584fa0b20ae58