### PR TITLE
修复隐藏加号按钮关闭后的底栏布局无法恢复五等分的问题

### DIFF
--- a/DYYY.xm
+++ b/DYYY.xm
@@ -6394,6 +6394,7 @@ static NSHashTable *processedParentViews = nil;
 static Class barBackgroundClass = nil;
 static Class generalButtonClass = nil;
 static Class plusButtonClass = nil;
+static Class plusInnerButtonClass = nil;
 static Class tabBarButtonClass = nil;
 
 + (void)initialize {
@@ -6401,6 +6402,7 @@ static Class tabBarButtonClass = nil;
         barBackgroundClass = NSClassFromString(@"_UIBarBackground");
         generalButtonClass = %c(AWENormalModeTabBarGeneralButton);
         plusButtonClass = %c(AWENormalModeTabBarGeneralPlusButton);
+        plusInnerButtonClass = %c(AWENormalModeTabBarGeneralPlusInnerButton);
         tabBarButtonClass = %c(UITabBarButton);
     }
 }
@@ -6456,15 +6458,17 @@ static Class tabBarButtonClass = nil;
     BOOL hideMsg = DYYYGetBool(@"DYYYHideMessageButton");
     BOOL hideFri = DYYYGetBool(@"DYYYHideFriendsButton");
     BOOL hideMe = DYYYGetBool(@"DYYYHideMyButton");
+    BOOL hidePlus = DYYYGetBool(@"DYYYHidePlusButton");
     BOOL isPad = (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad);
 
     NSMutableArray *visibleButtons = [NSMutableArray array];
     UIView *ipadContainerView = nil;
 
     for (UIView *subview in self.subviews) {
-        if ([subview isKindOfClass:generalButtonClass] || [subview isKindOfClass:plusButtonClass]) {
+        if ([subview isKindOfClass:generalButtonClass] || [subview isKindOfClass:plusButtonClass] || [subview isKindOfClass:plusInnerButtonClass]) {
             NSString *label = subview.accessibilityLabel;
-            BOOL shouldHide = ([label containsString:@"商城"] && hideShop) || ([label containsString:@"消息"] && hideMsg) || ([label containsString:@"朋友"] && hideFri) ||
+            BOOL isPlusButton = [subview isKindOfClass:plusButtonClass] || [subview isKindOfClass:plusInnerButtonClass] || [label isEqualToString:@"拍摄"];
+            BOOL shouldHide = (isPlusButton && hidePlus) || ([label containsString:@"商城"] && hideShop) || ([label containsString:@"消息"] && hideMsg) || ([label containsString:@"朋友"] && hideFri) ||
                               ([label isEqualToString:@"我"] && hideMe);
 
             subview.userInteractionEnabled = !shouldHide;
@@ -6546,7 +6550,7 @@ static Class tabBarButtonClass = nil;
         // 单次遍历处理所有背景和分割线
         for (UIView *subview in self.subviews) {
             // 跳过底栏按钮
-            if ([subview isKindOfClass:generalButtonClass] || [subview isKindOfClass:plusButtonClass]) {
+            if ([subview isKindOfClass:generalButtonClass] || [subview isKindOfClass:plusButtonClass] || [subview isKindOfClass:plusInnerButtonClass]) {
                 continue;
             }
             // 隐藏底栏背景
@@ -6618,7 +6622,7 @@ static Class tabBarButtonClass = nil;
         for (UIView *subview in self.subviews) {
             CGFloat subviewHeight = subview.frame.size.height;
             // 跳过底栏按钮
-            if ([subview isKindOfClass:generalButtonClass] || [subview isKindOfClass:plusButtonClass]) {
+            if ([subview isKindOfClass:generalButtonClass] || [subview isKindOfClass:plusButtonClass] || [subview isKindOfClass:plusInnerButtonClass]) {
                 continue;
             }
             // 隐藏底栏背景
@@ -6698,25 +6702,6 @@ static Class tabBarButtonClass = nil;
     return %orig;
 }
 
-%end
-
-%hook AWENormalModeTabBarGeneralPlusButton
-+ (id)button {
-    BOOL isHidePlusButton = DYYYGetBool(@"DYYYHidePlusButton");
-    if (isHidePlusButton) {
-        return nil;
-    }
-    return %orig;
-}
-%end
-
-%hook AWENormalModeTabBarGeneralPlusInnerButton
-+ (id)buttonWithParams:(id)arg1 {
-    if (DYYYGetBool(@"DYYYHidePlusButton")) {
-        return nil;
-    }
-    return %orig;
-}
 %end
 
 %hook AWENormalModeTabBarTextView


### PR DESCRIPTION
修复开启“隐藏底栏加号”后，再关闭该设置时，底栏布局没有正确恢复的问题。

此前隐藏加号时，逻辑会直接让加号按钮的工厂方法返回 `nil`，导致加号按钮不再创建。随后底栏在 `layoutSubviews` 中会按照当前存在的 4 个按钮重新均分宽度，因此“首页、朋友、消息、我”会保持四等分布局。关闭隐藏设置后，加号虽然恢复显示逻辑，但原本缺失的视图和已经被改写的 frame 无法稳定恢复，最终造成加号位置异常。

本次修复改为保留加号按钮的创建流程，只在 `AWENormalModeTabBar` 布局阶段根据 `DYYYHidePlusButton` 控制加号的隐藏与显示。同时将加号按钮纳入底栏按钮识别和背景跳过逻辑，确保开启隐藏时为 4 等分，关闭隐藏后可恢复为 5 等分布局。

纯AI修复