### PR TITLE
修复关注二次确认未弹出

### DIFF
--- a/AwemeHeaders.h
+++ b/AwemeHeaders.h
@@ -1396,8 +1396,19 @@ typedef NS_ENUM(NSUInteger, DYEdgeMode) {
 @property(retain, nonatomic) AWEAwemeModel *model;
 @end
 
+@interface AWEPlayInteractionUserAvatarContext : NSObject
+@property(retain, nonatomic) AWEAwemeModel *model;
+@end
+
 @interface AWEPlayInteractionUserAvatarFollowController : UIViewController
 @property(retain, nonatomic) AWEAwemeModel *model;
+@end
+
+@interface AWEPlayInteractionUserAvatarFollowPromptController : NSObject
+@property(retain, nonatomic) AWEPlayInteractionUserAvatarContext *userAvatarContext;
+- (void)onFollowViewClicked:(id)gesture;
+- (void)layoutElementView;
+- (void)showFollowAddView:(BOOL)show;
 @end
 
 @interface AWECodeGenCommonAnchorBasicInfoModel : UIViewController

--- a/DYYY.xm
+++ b/DYYY.xm
@@ -6488,6 +6488,57 @@ static NSHashTable *processedParentViews = nil;
 %end
 
 %hook AWEPlayInteractionUserAvatarFollowPromptController
+- (void)onFollowViewClicked:(UITapGestureRecognizer *)gesture {
+    if (DYYYGetBool(@"DYYYFollowTips")) {
+        AWEPlayInteractionUserAvatarContext *context = nil;
+        if ([self respondsToSelector:@selector(userAvatarContext)]) {
+            context = [self valueForKey:@"userAvatarContext"];
+        }
+
+        AWEUserModel *author = context.model.author;
+        NSString *nickname = @"";
+        NSString *signature = @"";
+        NSString *avatarURL = @"";
+
+        if (author) {
+            if ([author respondsToSelector:@selector(nickname)]) {
+                nickname = [author valueForKey:@"nickname"] ?: @"";
+            }
+
+            if ([author respondsToSelector:@selector(signature)]) {
+                signature = [author valueForKey:@"signature"] ?: @"";
+            }
+
+            if ([author respondsToSelector:@selector(avatarThumb)]) {
+                AWEURLModel *avatarThumb = [author valueForKey:@"avatarThumb"];
+                if (avatarThumb && avatarThumb.originURLList.count > 0) {
+                    avatarURL = avatarThumb.originURLList.firstObject;
+                }
+            }
+        }
+
+        NSMutableString *messageContent = [NSMutableString string];
+        if (signature.length > 0) {
+            [messageContent appendFormat:@"%@", signature];
+        }
+
+        NSString *title = nickname.length > 0 ? nickname : @"关注确认";
+
+        [DYYYBottomAlertView showAlertWithTitle:title
+                                        message:messageContent
+                                      avatarURL:avatarURL
+                               cancelButtonText:@"取消"
+                              confirmButtonText:@"关注"
+                                   cancelAction:nil
+                                    closeAction:nil
+                                  confirmAction:^{
+                                    %orig(gesture);
+                                  }];
+    } else {
+        %orig;
+    }
+}
+
 - (void)layoutElementView {
     %orig;
     DYYYApplyAvatarFollowPromptSettings(self);


### PR DESCRIPTION
抖音 39.1.0 及部分较早版本中，头像区域的关注点击由 `AWEPlayInteractionUserAvatarFollowPromptController` 处理，原有关注二次确认 Hook 未覆盖该入口，导致开启设置后二次确认卡片无法弹出。

本次补充 `onFollowViewClicked:` Hook，并从 `userAvatarContext` 获取作者信息，继续复用原有 `DYYYBottomAlertView` 及确认后关注逻辑，不修改原有卡片样式。

已通过 Theos arm64/arm64e 打包、MonkeyDev `DYYYDylib` 目标和完整 `DYYY` App 目标编译验证。
