### PR TITLE
完善全局 HDR 处理并修复多项交互功能

### DIFF
--- a/AwemeHeaders.h
+++ b/AwemeHeaders.h
@@ -340,6 +340,8 @@ typedef NS_ENUM(NSUInteger, DYEdgeMode) {
 @property(nonatomic, strong) AWEAwemeModel *model;
 @property(nonatomic, strong) NSString *referString;
 @property(nonatomic, assign) BOOL isCommentVCShowing;
+- (id)controllerByProtocol:(Protocol *)protocol;
+- (id)videoDelegate;
 - (void)performCommentAction;
 - (void)performLikeAction;
 - (void)showSharePanel;
@@ -1354,12 +1356,17 @@ typedef NS_ENUM(NSUInteger, DYEdgeMode) {
 
 @interface AWEPlayInteractionSpeedController : NSObject
 @property(nonatomic, strong) id progressSliderDelegate;
+- (id)playVideoViewController;
 - (CGFloat)longPressFastSpeedValue;
 - (void)changeSpeed:(double)speed;
 - (void)handleLongPressLockedDoubleSpeedChanged:(id)arg1 gesture:(UIGestureRecognizer *)gesture;
 - (void)handleLongPressLockedSpeedBegan;
 - (void)handleLongPressLockedDoubleSpeedEnded:(id)arg1 gesture:(UIGestureRecognizer *)gesture;
 - (void)longPressSpeedControlDidChangeSpeed:(double)speed;
+@end
+
+@interface AWEPlayInteractionDPlayerSpeedController : NSObject
+- (id)playVideoViewController;
 @end
 
 @interface AWEPlayInteractionUserAvatarView : UIView

--- a/AwemeHeaders.h
+++ b/AwemeHeaders.h
@@ -147,6 +147,8 @@ typedef NS_ENUM(NSUInteger, DYEdgeMode) {
 @property(nonatomic, strong) NSString *videoFeedTag;
 @property(nonatomic, strong) id shareRecExtra;  // 收藏/喜欢以外的视频专有属性
 @property(nonatomic, copy) NSString *referString; // 推荐页为 homepage_hot
+- (BOOL)dyyy_shouldExcludeFromGlobalHDRFilter;
+- (BOOL)dyyy_containsHDRMetadataInObject:(id)object depth:(NSUInteger)depth;
 @property(nonatomic, strong) NSArray<AWEAwemeTextExtraModel *> *textExtras;
 @property(nonatomic, copy) NSString *itemTitle;
 @property(nonatomic, copy) NSString *descriptionSimpleString;

--- a/AwemeHeaders.h
+++ b/AwemeHeaders.h
@@ -1372,6 +1372,11 @@ typedef NS_ENUM(NSUInteger, DYEdgeMode) {
 @interface AWEPlayInteractionUserAvatarView : UIView
 @end
 
+@interface AWEPlayInteractionStaticFollowAnimationView : UIView
+@property(retain, nonatomic) UIImageView *plusImageView;
+@property(retain, nonatomic) UIImageView *tickImageView;
+@end
+
 @interface AWELeftSideBarViewController : UIViewController <UICollectionViewDelegate, UICollectionViewDataSource>
 - (UICollectionView *)collectionView;
 - (void)adjustContainerViewLayout:(UICollectionViewCell *)cell;
@@ -1409,6 +1414,7 @@ typedef NS_ENUM(NSUInteger, DYEdgeMode) {
 
 @interface AWEPlayInteractionUserAvatarContext : NSObject
 @property(retain, nonatomic) AWEAwemeModel *model;
+@property(nonatomic, weak) UIView *avatarPicView;
 @end
 
 @interface AWEPlayInteractionUserAvatarFollowController : UIViewController
@@ -1420,6 +1426,23 @@ typedef NS_ENUM(NSUInteger, DYEdgeMode) {
 - (void)onFollowViewClicked:(id)gesture;
 - (void)layoutElementView;
 - (void)showFollowAddView:(BOOL)show;
+@end
+
+@interface AWEPlayInteractionUserAvatarMainBusinessController : NSObject
+@property(retain, nonatomic) AWEPlayInteractionUserAvatarContext *userAvatarContext;
+@property(retain, nonatomic) UIView *avatarPicView;
+- (void)layoutElementView;
+@end
+
+@interface AWEPlayInteractionUserAvatarOptElementElement : NSObject
+@property(retain, nonatomic) AWEPlayInteractionUserAvatarContext *userAvatarContext;
+- (void)layoutElementView;
+@end
+
+@interface AWEPlayInteractionUserAvatarStoryController : NSObject
+@property(nonatomic, weak) UIView *colorRingView;
+- (void)layoutElementView;
+- (void)showStory25RingView;
 @end
 
 @interface AWECodeGenCommonAnchorBasicInfoModel : UIViewController

--- a/AwemeHeaders.h
+++ b/AwemeHeaders.h
@@ -69,6 +69,8 @@ typedef NS_ENUM(NSUInteger, DYEdgeMode) {
 @property(copy, nonatomic) NSArray *bitrateRawData;
 @property(nonatomic, strong) URLModel *h264URL;
 @property(nonatomic, strong) URLModel *coverURL;
+@property(nonatomic, assign) BOOL hasFilterHDR;
+@property(nonatomic, assign) NSInteger isSourceHDR;
 @end
 
 @interface AWEMusicModel : NSObject
@@ -1461,6 +1463,7 @@ typedef NS_ENUM(NSUInteger, DYEdgeMode) {
 - (BOOL)enableHDR;
 - (void)setEnableHDR:(BOOL)enableHDR;
 - (void)setEnablePlayHDRMode;
+- (void)buildHDRConfig:(id)config;
 - (id)awe_HDRValueFor:(long long)value enableHDR:(BOOL)enableHDR;
 @end
 
@@ -1486,6 +1489,28 @@ typedef NS_ENUM(NSUInteger, DYEdgeMode) {
 
 @interface BDImageDecoderImageIO : NSObject
 - (BOOL)isHDRCGImage:(CGImageRef)image decodedToHDR:(BOOL)decodedToHDR;
+- (id)hdrOptionsFor:(id)image decodedToHDR:(BOOL *)decodedToHDR;
+@end
+
+@interface BDImageDecoderHeic : NSObject
++ (BOOL)isHDRData:(id)data;
+- (BOOL)isHDR;
+- (void)setIsHDR:(BOOL)isHDR;
+@end
+
+@interface BDImageDecoderBVC2 : NSObject
+- (BOOL)isHDR;
+- (void)setIsHDR:(BOOL)isHDR;
+@end
+
+@interface BDImageDecoderWebP : NSObject
+- (BOOL)isHDR;
+- (void)setIsHDR:(BOOL)isHDR;
+@end
+
+@interface BDImage : UIImage
+- (BOOL)isHDR;
+- (void)setIsHDR:(BOOL)isHDR;
 @end
 
 @class HDRMTImageView;
@@ -1508,6 +1533,115 @@ typedef NS_ENUM(NSUInteger, DYEdgeMode) {
 @interface AWEVideoPlayerConfiguration : NSObject
 + (void)setHDRBrightnessStrategy:(id)strategy;
 + (double)getHDRBrightnessOffset:(id)configuration brightness:(double)brightness;
+@end
+
+@interface AWEFeedABTestServiceObjc : NSObject
++ (BOOL)enableProfilePreloadHDRBrightnessFilter;
+@end
+
+@interface AWEDPlayerVideoConfig : NSObject
+- (BOOL)enableMetalRenderHDR;
+- (void)setEnableMetalRenderHDR:(BOOL)enableMetalRenderHDR;
+@end
+
+@interface AWEDPlayerVideoController : NSObject
+- (void)configEnableMetalRenderHDRIfNeeded;
+- (void)setEnablePlayHDRModeIfNeeded;
+@end
+
+@interface AWEDPlayerVideoController_Merge : NSObject
+- (void)configEnableMetalRenderHDRIfNeeded;
+- (void)setEnablePlayHDRModeIfNeeded;
+@end
+
+@interface AWEDPlayerPlayControlContainer : NSObject
+- (void)configEnableMetalRenderHDRIfNeeded;
+@end
+
+@interface AWEDPlayerNonSimplayerContainer : NSObject
+- (void)setEnablePlayHDRMode;
+@end
+
+@interface AWEDPlayerSimpleModeContainer : NSObject
+- (void)setEnablePlayHDRModeIfNeeded;
+@end
+
+@interface AWEDPlayerBrightnessContainer : NSObject
+- (BOOL)awe_isCurrentVideoHDR;
+@end
+
+@interface AWEVideoPlayerScreenBrightnessManager : NSObject
+- (BOOL)isHDRVideo;
+- (void)setIsHDRVideo:(BOOL)isHDRVideo;
+@end
+
+@interface ALMOwnPlayerWrapper : NSObject
+- (void)setLutFilter:(id)lutFilter HDRLutImage:(id)HDRLutImage;
+@end
+
+@interface ALMSysPlayerWrapper : NSObject
+- (void)setLutFilter:(id)lutFilter HDRLutImage:(id)HDRLutImage;
+@end
+
+@interface ALMVideoPlayerConfig : NSObject
++ (void)setPlayerEffectHDRLutImageEnable:(BOOL)enable;
+@end
+
+@interface IESVideoPlayerConfig : NSObject
++ (void)setPlayerEffectHDRLutImageEnable:(BOOL)enable;
+@end
+
+@interface AWEIMModuleService : NSObject
+- (BOOL)im_forceHDRToSDR;
+@end
+
+@interface IESIMVideoPlayerWrapper : NSObject
+- (void)setupHDREnable:(BOOL)enable;
+@end
+
+@interface AWEIMVideoBrowserCollectionViewCell : UICollectionViewCell
+- (void)setEnablePlayHDR:(BOOL)enable;
+@end
+
+@interface AWEECOMIMAppSettingsService : NSObject
++ (BOOL)enableVideoPreviewSupportHDR;
+@end
+
+@interface IESLivePlayerController : NSObject
+- (BOOL)isVideoSDR2HDRSupport;
+- (void)setEnableVideoSDR2HDR:(BOOL)enable callTrace:(id)callTrace;
+- (BOOL)enableCloseSDR2HDR;
+@end
+
+@interface AWELivePreStreamPlayer : NSObject
+- (void)changeSDR2HDRWithStrategy;
+@end
+
+@interface HTSLiveStreamPlayer : NSObject
+- (void)setEnableVideoSDR2HDR:(BOOL)enable callTrace:(id)callTrace;
+- (void)changeSDR2HDRWithStrategy;
+@end
+
+@interface IESLiveStreamPlayerVideoAudioEffectPlugin : NSObject
+- (void)setEnableVideoSDR2HDR:(BOOL)enable callTrace:(id)callTrace;
+- (void)changeSDR2HDRWithStrategy;
+@end
+
+@interface TVLManager : NSObject
+- (BOOL)shouldForbidHDR10Render;
+- (void)setShouldForbidHDR10Render:(BOOL)shouldForbid;
+- (void)setupVideoSDR2HDR:(id)config;
+@end
+
+@interface TVLPlayerItemPreferences : NSObject
+- (BOOL)forbidSDR2HDRInPreview;
+- (void)setForbidSDR2HDRInPreview:(BOOL)forbid;
+- (BOOL)enableUseSDR2HDR;
+- (void)setEnableUseSDR2HDR:(BOOL)enable;
+@end
+
+@interface TVLSettingsManager : NSObject
+- (BOOL)enableMetalRenderHDR;
 @end
 
 @interface IESFiltersManager : NSObject

--- a/DYYY.xm
+++ b/DYYY.xm
@@ -207,7 +207,7 @@ static UIImage *DYYYLoadCustomImage(NSString *fileName, CGSize targetSize) {
 }
 
 static BOOL DYYYShouldHandleSpeedFeatures(void) {
-    if (isFloatSpeedButtonEnabled) {
+    if ([[NSUserDefaults standardUserDefaults] boolForKey:@"DYYYEnableFloatSpeedButton"]) {
         return YES;
     }
 
@@ -217,6 +217,92 @@ static BOOL DYYYShouldHandleSpeedFeatures(void) {
     }
 
     return fabsf(defaultSpeed - 1.0f) > FLT_EPSILON;
+}
+
+static __weak AWEPlayInteractionViewController *dyyyActiveSpeedInteractionController = nil;
+
+static void DYYYEnsureFloatSpeedButton(AWEPlayInteractionViewController *interactionController) {
+    [FloatingSpeedButton reloadConfiguration];
+    if (!isFloatSpeedButtonEnabled || !interactionController) {
+        updateSpeedButtonVisibility();
+        return;
+    }
+
+    UIWindow *keyWindow = [DYYYUtils getActiveWindow];
+    if (!keyWindow) {
+        return;
+    }
+
+    if (!speedButton) {
+        CGRect windowBounds = keyWindow.bounds;
+        CGRect initialFrame = CGRectMake((windowBounds.size.width - speedButtonSize) / 2.0, (windowBounds.size.height - speedButtonSize) / 2.0, speedButtonSize, speedButtonSize);
+        speedButton = [[FloatingSpeedButton alloc] initWithFrame:initialFrame];
+        speedButton.interactionController = interactionController;
+        updateSpeedButtonUI();
+    } else if (speedButton.interactionController != interactionController) {
+        speedButton.interactionController = interactionController;
+        [speedButton resetButtonState];
+    }
+
+    if (![speedButton isDescendantOfView:keyWindow]) {
+        [keyWindow addSubview:speedButton];
+        [speedButton loadSavedPosition];
+        [speedButton resetFadeTimer];
+    }
+
+    [keyWindow bringSubviewToFront:speedButton];
+    updateSpeedButtonVisibility();
+}
+
+static BOOL DYYYSetPlaybackRateOnTarget(id target, double speed) {
+    if (!target || ![target respondsToSelector:@selector(setVideoControllerPlaybackRate:)]) {
+        return NO;
+    }
+
+    @try {
+        [(AWEAwemePlayVideoViewController *)target setVideoControllerPlaybackRate:speed];
+        return YES;
+    } @catch (NSException *exception) {
+        return NO;
+    }
+}
+
+static BOOL DYYYApplyPlaybackSpeed(AWEPlayInteractionViewController *interactionController, double speed) {
+    Protocol *speedControllerProtocol = NSProtocolFromString(@"AWEFastSpeedControllerProtocol");
+    if (speedControllerProtocol && [interactionController respondsToSelector:@selector(controllerByProtocol:)]) {
+        @try {
+            id speedController = [interactionController controllerByProtocol:speedControllerProtocol];
+            if ([speedController respondsToSelector:@selector(playVideoViewController)]) {
+                id playVideoViewController = [(AWEPlayInteractionSpeedController *)speedController playVideoViewController];
+                if (DYYYSetPlaybackRateOnTarget(playVideoViewController, speed)) {
+                    return YES;
+                }
+            }
+        } @catch (NSException *exception) {
+        }
+    }
+
+    if ([interactionController respondsToSelector:@selector(videoDelegate)] && DYYYSetPlaybackRateOnTarget([interactionController videoDelegate], speed)) {
+        return YES;
+    }
+
+    UIWindow *window = [DYYYUtils getActiveWindow];
+    UIViewController *rootViewController = window.rootViewController;
+    while (rootViewController.presentedViewController) {
+        rootViewController = rootViewController.presentedViewController;
+    }
+
+    for (UIViewController *viewController in rootViewController ? findViewControllersInHierarchy(rootViewController) : @[]) {
+        if ([viewController isKindOfClass:NSClassFromString(@"AWEAwemePlayVideoViewController")] ||
+            [viewController isKindOfClass:NSClassFromString(@"AWEDPlayerFeedPlayerViewController")] ||
+            [viewController isKindOfClass:NSClassFromString(@"AWEDPlayerViewController_Merge")]) {
+            if (DYYYSetPlaybackRateOnTarget(viewController, speed)) {
+                return YES;
+            }
+        }
+    }
+
+    return NO;
 }
 
 @interface AWEFeedProgressSlider (DYYYProgressLabel)
@@ -7882,54 +7968,21 @@ static Class tabBarButtonClass = nil;
 - (void)viewWillAppear:(BOOL)animated {
     %orig;
     isInPlayInteractionVC = YES;
+    dyyyActiveSpeedInteractionController = self;
     dyyyInteractionViewVisible = YES;
-    updateSpeedButtonVisibility();
+    DYYYEnsureFloatSpeedButton(self);
     updateClearButtonVisibility();
 }
 
 - (void)viewDidLayoutSubviews {
     %orig;
 
-    if (isFloatSpeedButtonEnabled) {
-        BOOL hasRightStack = NO;
-        Class stackClass = NSClassFromString(@"AWEElementStackView");
-        for (UIView *sub in self.view.subviews) {
-            if ([sub isKindOfClass:stackClass] && ([sub.accessibilityLabel isEqualToString:@"right"] || [DYYYUtils containsSubviewOfClass:NSClassFromString(@"AWEPlayInteractionUserAvatarView")
-                                                                                                                              inContainer:self.view])) {
-                hasRightStack = YES;
-                break;
-            }
-        }
-        if (hasRightStack) {
-            if (speedButton == nil) {
-                speedButtonSize = [[NSUserDefaults standardUserDefaults] floatForKey:@"DYYYSpeedButtonSize"] ?: 32.0;
-                CGRect screenBounds = [UIScreen mainScreen].bounds;
-                CGRect initialFrame = CGRectMake((screenBounds.size.width - speedButtonSize) / 2, (screenBounds.size.height - speedButtonSize) / 2, speedButtonSize, speedButtonSize);
-                speedButton = [[FloatingSpeedButton alloc] initWithFrame:initialFrame];
-                speedButton.interactionController = self;
-                showSpeedX = [[NSUserDefaults standardUserDefaults] boolForKey:@"DYYYSpeedButtonShowX"];
-                updateSpeedButtonUI();
-            } else {
-                [speedButton resetButtonState];
-                if (speedButton.interactionController == nil || speedButton.interactionController != self) {
-                    speedButton.interactionController = self;
-                }
-                if (speedButton.frame.size.width != speedButtonSize) {
-                    CGPoint center = speedButton.center;
-                    CGRect newFrame = CGRectMake(0, 0, speedButtonSize, speedButtonSize);
-                    speedButton.frame = newFrame;
-                    speedButton.center = center;
-                    speedButton.layer.cornerRadius = speedButtonSize / 2;
-                }
-            }
-            dyyyInteractionViewVisible = YES;
-            UIWindow *keyWindow = [DYYYUtils getActiveWindow];
-            if (keyWindow && ![speedButton isDescendantOfView:keyWindow]) {
-                [keyWindow addSubview:speedButton];
-                [speedButton loadSavedPosition];
-                [speedButton resetFadeTimer];
-            }
-        }
+    if (self.view.window && !self.view.hidden) {
+        dyyyActiveSpeedInteractionController = self;
+        dyyyInteractionViewVisible = YES;
+        DYYYEnsureFloatSpeedButton(self);
+    } else {
+        [FloatingSpeedButton reloadConfiguration];
     }
 
     UIWindow *keyWindow = [DYYYUtils getActiveWindow];
@@ -8015,16 +8068,8 @@ static Class tabBarButtonClass = nil;
 
 - (void)viewDidDisappear:(BOOL)animated {
     %orig;
-    BOOL hasRightStack = NO;
-    Class stackClass = NSClassFromString(@"AWEElementStackView");
-    for (UIView *sub in self.view.subviews) {
-        if ([sub isKindOfClass:stackClass] && ([sub.accessibilityLabel isEqualToString:@"right"] || [DYYYUtils containsSubviewOfClass:NSClassFromString(@"AWEPlayInteractionUserAvatarView")
-                                                                                                                          inContainer:self.view])) {
-            hasRightStack = YES;
-            break;
-        }
-    }
-    if (hasRightStack) {
+    if (dyyyActiveSpeedInteractionController == self) {
+        dyyyActiveSpeedInteractionController = nil;
         dyyyInteractionViewVisible = NO;
         dyyyCommentViewVisible = self.isCommentVCShowing;
         updateSpeedButtonVisibility();
@@ -8045,21 +8090,7 @@ static Class tabBarButtonClass = nil;
     setCurrentSpeedIndex(newIndex);
 
     float newSpeed = [speeds[newIndex] floatValue];
-
-    NSString *formattedSpeed;
-    if (fmodf(newSpeed, 1.0) == 0) {
-        formattedSpeed = [NSString stringWithFormat:@"%.0f", newSpeed];
-    } else if (fmodf(newSpeed * 10, 1.0) == 0) {
-        formattedSpeed = [NSString stringWithFormat:@"%.1f", newSpeed];
-    } else {
-        formattedSpeed = [NSString stringWithFormat:@"%.2f", newSpeed];
-    }
-
-    if (showSpeedX) {
-        formattedSpeed = [formattedSpeed stringByAppendingString:@"x"];
-    }
-
-    [sender setTitle:formattedSpeed forState:UIControlStateNormal];
+    updateSpeedButtonUI();
 
     [UIView animateWithDuration:0.1
         delay:0
@@ -8077,32 +8108,7 @@ static Class tabBarButtonClass = nil;
                            completion:nil];
         }];
 
-    BOOL speedApplied = NO;
-
-    UIWindow *win = [DYYYUtils getActiveWindow];
-    UIViewController *rootVC = win.rootViewController;
-    while (rootVC && rootVC.presentedViewController) {
-        rootVC = rootVC.presentedViewController;
-    }
-
-    NSArray *viewControllers = rootVC ? findViewControllersInHierarchy(rootVC) : @[];
-
-    for (UIViewController *vc in viewControllers) {
-        if ([vc isKindOfClass:%c(AWEAwemePlayVideoViewController)]) {
-            [(AWEAwemePlayVideoViewController *)vc setVideoControllerPlaybackRate:newSpeed];
-            speedApplied = YES;
-        }
-        if ([vc isKindOfClass:%c(AWEDPlayerFeedPlayerViewController)]) {
-            [(AWEDPlayerFeedPlayerViewController *)vc setVideoControllerPlaybackRate:newSpeed];
-            speedApplied = YES;
-        }
-        if ([vc isKindOfClass:objc_getClass("AWEDPlayerViewController_Merge")]) {
-            [(AWEAwemePlayVideoViewController *)vc setVideoControllerPlaybackRate:newSpeed];
-            speedApplied = YES;
-        }
-    }
-
-    if (!speedApplied) {
+    if (!DYYYApplyPlaybackSpeed(self, newSpeed)) {
         [DYYYUtils showToast:@"无法找到视频控制器"];
     }
 }
@@ -9640,8 +9646,7 @@ static void findTargetViewInView(UIView *view) {
             DYYYGetBool(@"DYYYForceDownloadCommentImage")) {
             %init(EnableStickerSaveMenu);
         }
-        NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-        isFloatSpeedButtonEnabled = [defaults boolForKey:@"DYYYEnableFloatSpeedButton"];
+        [FloatingSpeedButton reloadConfiguration];
 
         // 初始化红包激励挂件容器视图类组
         Class incentivePendantClass = objc_getClass("AWEIncentiveSwiftImplDOUYINLite.IncentivePendantContainerView");

--- a/DYYY.xm
+++ b/DYYY.xm
@@ -672,6 +672,31 @@ static void DYYYDisableExtendedRangeForMetalLayer(CAMetalLayer *metalLayer) {
     return %orig;
 }
 
++ (BOOL)enableProfilePreloadHDRBrightnessFilter {
+    if (DYYYGetBool(@"DYYYDisableAllHDR")) {
+        return NO;
+    }
+    return %orig;
+}
+
++ (BOOL)enableDynamicGaussianBlurHDR {
+    if (DYYYGetBool(@"DYYYDisableAllHDR")) {
+        return NO;
+    }
+    return %orig;
+}
+
+%end
+
+%hook AWEFeedABTestServiceObjc
+
++ (BOOL)enableProfilePreloadHDRBrightnessFilter {
+    if (DYYYGetBool(@"DYYYDisableAllHDR")) {
+        return NO;
+    }
+    return %orig;
+}
+
 %end
 
 %hook BDSimPlayerBizConfig
@@ -783,6 +808,12 @@ static void DYYYDisableExtendedRangeForMetalLayer(CAMetalLayer *metalLayer) {
     }
 }
 
+- (void)buildHDRConfig:(id)config {
+    if (!DYYYGetBool(@"DYYYDisableAllHDR")) {
+        %orig;
+    }
+}
+
 - (id)awe_HDRValueFor:(long long)value enableHDR:(BOOL)enableHDR {
     return %orig(value, DYYYGetBool(@"DYYYDisableAllHDR") ? NO : enableHDR);
 }
@@ -832,6 +863,17 @@ static void DYYYDisableExtendedRangeForMetalLayer(CAMetalLayer *metalLayer) {
     %orig(DYYYGetBool(@"DYYYDisableAllHDR") ? NO : enableHDR);
 }
 
+- (void)setPlayerLutFilter:(id)lutFilter HDRLutImage:(id)HDRLutImage {
+    %orig(lutFilter, DYYYGetBool(@"DYYYDisableAllHDR") ? nil : HDRLutImage);
+}
+
+- (BOOL)awe_isCurrentVideoHDR {
+    if (DYYYGetBool(@"DYYYDisableAllHDR")) {
+        return NO;
+    }
+    return %orig;
+}
+
 %end
 
 %hook AWEDPlayerFeedPlayerViewController
@@ -867,6 +909,179 @@ static void DYYYDisableExtendedRangeForMetalLayer(CAMetalLayer *metalLayer) {
 
 - (void)setEnableHDR10:(BOOL)enableHDR10 {
     %orig(DYYYGetBool(@"DYYYDisableAllHDR") ? NO : enableHDR10);
+}
+
+%end
+
+%hook AWEDPlayerVideoConfig
+
+- (BOOL)enableMetalRenderHDR {
+    if (DYYYShouldDisableAllHDR()) {
+        return NO;
+    }
+    return %orig;
+}
+
+- (void)setEnableMetalRenderHDR:(BOOL)enableMetalRenderHDR {
+    %orig(DYYYShouldDisableAllHDR() ? NO : enableMetalRenderHDR);
+}
+
+%end
+
+%hook AWEDPlayerVideoController
+
+- (void)configEnableMetalRenderHDRIfNeeded {
+    if (!DYYYShouldDisableAllHDR()) {
+        %orig;
+    }
+}
+
+- (void)setEnablePlayHDRModeIfNeeded {
+    if (!DYYYShouldDisableAllHDR()) {
+        %orig;
+    }
+}
+
+%end
+
+%hook AWEDPlayerVideoController_Merge
+
+- (void)configEnableMetalRenderHDRIfNeeded {
+    if (!DYYYShouldDisableAllHDR()) {
+        %orig;
+    }
+}
+
+- (void)setEnablePlayHDRModeIfNeeded {
+    if (!DYYYShouldDisableAllHDR()) {
+        %orig;
+    }
+}
+
+%end
+
+%hook AWEDPlayerPlayControlContainer
+
+- (void)configEnableMetalRenderHDRIfNeeded {
+    if (!DYYYShouldDisableAllHDR()) {
+        %orig;
+    }
+}
+
+%end
+
+%hook AWEDPlayerNonSimplayerContainer
+
+- (void)setEnablePlayHDRMode {
+    if (!DYYYShouldDisableAllHDR()) {
+        %orig;
+    }
+}
+
+%end
+
+%hook AWEDPlayerSimpleModeContainer
+
+- (void)setEnablePlayHDRModeIfNeeded {
+    if (!DYYYShouldDisableAllHDR()) {
+        %orig;
+    }
+}
+
+%end
+
+%hook AWEDPlayerBrightnessContainer
+
+- (BOOL)awe_isCurrentVideoHDR {
+    if (DYYYShouldDisableAllHDR()) {
+        return NO;
+    }
+    return %orig;
+}
+
+%end
+
+%hook AWEVideoPlayerScreenBrightnessManager
+
+- (BOOL)isHDRVideo {
+    if (DYYYShouldDisableAllHDR()) {
+        return NO;
+    }
+    return %orig;
+}
+
+- (void)setIsHDRVideo:(BOOL)isHDRVideo {
+    %orig(DYYYShouldDisableAllHDR() ? NO : isHDRVideo);
+}
+
+%end
+
+%hook ALMOwnPlayerWrapper
+
+- (void)setLutFilter:(id)lutFilter HDRLutImage:(id)HDRLutImage {
+    %orig(lutFilter, DYYYShouldDisableAllHDR() ? nil : HDRLutImage);
+}
+
+%end
+
+%hook ALMSysPlayerWrapper
+
+- (void)setLutFilter:(id)lutFilter HDRLutImage:(id)HDRLutImage {
+    %orig(lutFilter, DYYYShouldDisableAllHDR() ? nil : HDRLutImage);
+}
+
+%end
+
+%hook ALMVideoPlayerConfig
+
++ (void)setPlayerEffectHDRLutImageEnable:(BOOL)enable {
+    %orig(DYYYShouldDisableAllHDR() ? NO : enable);
+}
+
+%end
+
+%hook IESVideoPlayerConfig
+
++ (void)setPlayerEffectHDRLutImageEnable:(BOOL)enable {
+    %orig(DYYYShouldDisableAllHDR() ? NO : enable);
+}
+
+%end
+
+%hook AWEIMModuleService
+
+- (BOOL)im_forceHDRToSDR {
+    if (DYYYShouldDisableAllHDR()) {
+        return YES;
+    }
+    return %orig;
+}
+
+%end
+
+%hook IESIMVideoPlayerWrapper
+
+- (void)setupHDREnable:(BOOL)enable {
+    %orig(DYYYShouldDisableAllHDR() ? NO : enable);
+}
+
+%end
+
+%hook AWEIMVideoBrowserCollectionViewCell
+
+- (void)setEnablePlayHDR:(BOOL)enable {
+    %orig(DYYYShouldDisableAllHDR() ? NO : enable);
+}
+
+%end
+
+%hook AWEECOMIMAppSettingsService
+
++ (BOOL)enableVideoPreviewSupportHDR {
+    if (DYYYShouldDisableAllHDR()) {
+        return NO;
+    }
+    return %orig;
 }
 
 %end
@@ -928,6 +1143,124 @@ static void DYYYDisableExtendedRangeForMetalLayer(CAMetalLayer *metalLayer) {
 
 %end
 
+%hook IESLivePlayerController
+
+- (BOOL)isVideoSDR2HDRSupport {
+    if (DYYYShouldDisableAllHDR()) {
+        return NO;
+    }
+    return %orig;
+}
+
+- (void)setEnableVideoSDR2HDR:(BOOL)enable callTrace:(id)callTrace {
+    %orig(DYYYShouldDisableAllHDR() ? NO : enable, callTrace);
+}
+
+- (BOOL)enableCloseSDR2HDR {
+    if (DYYYShouldDisableAllHDR()) {
+        return YES;
+    }
+    return %orig;
+}
+
+%end
+
+%hook AWELivePreStreamPlayer
+
+- (void)changeSDR2HDRWithStrategy {
+    if (!DYYYShouldDisableAllHDR()) {
+        %orig;
+    }
+}
+
+%end
+
+%hook HTSLiveStreamPlayer
+
+- (void)setEnableVideoSDR2HDR:(BOOL)enable callTrace:(id)callTrace {
+    %orig(DYYYShouldDisableAllHDR() ? NO : enable, callTrace);
+}
+
+- (void)changeSDR2HDRWithStrategy {
+    if (!DYYYShouldDisableAllHDR()) {
+        %orig;
+    }
+}
+
+%end
+
+%hook IESLiveStreamPlayerVideoAudioEffectPlugin
+
+- (void)setEnableVideoSDR2HDR:(BOOL)enable callTrace:(id)callTrace {
+    %orig(DYYYShouldDisableAllHDR() ? NO : enable, callTrace);
+}
+
+- (void)changeSDR2HDRWithStrategy {
+    if (!DYYYShouldDisableAllHDR()) {
+        %orig;
+    }
+}
+
+%end
+
+%hook TVLManager
+
+- (BOOL)shouldForbidHDR10Render {
+    if (DYYYShouldDisableAllHDR()) {
+        return YES;
+    }
+    return %orig;
+}
+
+- (void)setShouldForbidHDR10Render:(BOOL)shouldForbid {
+    %orig(DYYYShouldDisableAllHDR() ? YES : shouldForbid);
+}
+
+- (void)setupVideoSDR2HDR:(id)config {
+    if (!DYYYShouldDisableAllHDR()) {
+        %orig;
+    }
+}
+
+%end
+
+%hook TVLPlayerItemPreferences
+
+- (BOOL)forbidSDR2HDRInPreview {
+    if (DYYYShouldDisableAllHDR()) {
+        return YES;
+    }
+    return %orig;
+}
+
+- (void)setForbidSDR2HDRInPreview:(BOOL)forbid {
+    %orig(DYYYShouldDisableAllHDR() ? YES : forbid);
+}
+
+- (BOOL)enableUseSDR2HDR {
+    if (DYYYShouldDisableAllHDR()) {
+        return NO;
+    }
+    return %orig;
+}
+
+- (void)setEnableUseSDR2HDR:(BOOL)enable {
+    %orig(DYYYShouldDisableAllHDR() ? NO : enable);
+}
+
+%end
+
+%hook TVLSettingsManager
+
+- (BOOL)enableMetalRenderHDR {
+    if (DYYYShouldDisableAllHDR()) {
+        return NO;
+    }
+    return %orig;
+}
+
+%end
+
 %hook BDImageDecoderFactory
 
 + (BOOL)isHDRImageData:(id)data withHeifDecoderClass:(Class)decoderClass {
@@ -946,6 +1279,83 @@ static void DYYYDisableExtendedRangeForMetalLayer(CAMetalLayer *metalLayer) {
         return NO;
     }
     return %orig;
+}
+
+- (id)hdrOptionsFor:(id)image decodedToHDR:(BOOL *)decodedToHDR {
+    if (DYYYShouldDisableAllHDR()) {
+        if (decodedToHDR) {
+            *decodedToHDR = NO;
+        }
+        return nil;
+    }
+    return %orig;
+}
+
+%end
+
+%hook BDImageDecoderHeic
+
++ (BOOL)isHDRData:(id)data {
+    if (DYYYShouldDisableAllHDR()) {
+        return NO;
+    }
+    return %orig;
+}
+
+- (BOOL)isHDR {
+    if (DYYYShouldDisableAllHDR()) {
+        return NO;
+    }
+    return %orig;
+}
+
+- (void)setIsHDR:(BOOL)isHDR {
+    %orig(DYYYShouldDisableAllHDR() ? NO : isHDR);
+}
+
+%end
+
+%hook BDImageDecoderBVC2
+
+- (BOOL)isHDR {
+    if (DYYYShouldDisableAllHDR()) {
+        return NO;
+    }
+    return %orig;
+}
+
+- (void)setIsHDR:(BOOL)isHDR {
+    %orig(DYYYShouldDisableAllHDR() ? NO : isHDR);
+}
+
+%end
+
+%hook BDImageDecoderWebP
+
+- (BOOL)isHDR {
+    if (DYYYShouldDisableAllHDR()) {
+        return NO;
+    }
+    return %orig;
+}
+
+- (void)setIsHDR:(BOOL)isHDR {
+    %orig(DYYYShouldDisableAllHDR() ? NO : isHDR);
+}
+
+%end
+
+%hook BDImage
+
+- (BOOL)isHDR {
+    if (DYYYShouldDisableAllHDR()) {
+        return NO;
+    }
+    return %orig;
+}
+
+- (void)setIsHDR:(BOOL)isHDR {
+    %orig(DYYYShouldDisableAllHDR() ? NO : isHDR);
 }
 
 %end
@@ -5668,16 +6078,29 @@ static NSHashTable *processedParentViews = nil;
         }
     }
 
-    // 检查是否为HDR视频
-    if (filterHDR && self.video && self.video.bitrateModels) {
-        for (id bitrateModel in self.video.bitrateModels) {
-            NSNumber *hdrType = [bitrateModel valueForKey:@"hdrType"];
-            NSNumber *hdrBit = [bitrateModel valueForKey:@"hdrBit"];
+    // 仅过滤推荐流，并优先使用 39.1.0 视频模型上的源 HDR 标记。
+    if (filterHDR && isRecommendFeed && self.video) {
+        AWEVideoModel *video = self.video;
+        if ([video respondsToSelector:@selector(isSourceHDR)] && video.isSourceHDR > 0) {
+            shouldFilterHDR = YES;
+        } else if ([video respondsToSelector:@selector(hasFilterHDR)] && video.hasFilterHDR) {
+            shouldFilterHDR = YES;
+        }
 
-            // 如果hdrType=1且hdrBit=10，则视为HDR视频
-            if (hdrType && [hdrType integerValue] == 1 && hdrBit && [hdrBit integerValue] == 10) {
-                shouldFilterHDR = YES;
-                break;
+        if (!shouldFilterHDR) {
+            for (id bitrateModel in video.bitrateModels) {
+                @try {
+                    NSNumber *hdrType = [bitrateModel valueForKey:@"hdrType"];
+                    NSNumber *hdrBit = [bitrateModel valueForKey:@"hdrBit"];
+
+                    // hdrType 覆盖 HDR10、HLG、HDR Vivid 等类型；无类型字段时保留 10bit 兜底。
+                    if ((hdrType && [hdrType integerValue] > 0) ||
+                        (!hdrType && hdrBit && [hdrBit integerValue] >= 10)) {
+                        shouldFilterHDR = YES;
+                        break;
+                    }
+                } @catch (__unused NSException *exception) {
+                }
             }
         }
     }

--- a/DYYY.xm
+++ b/DYYY.xm
@@ -3630,7 +3630,7 @@ static NSArray *DYYYIMMenuItemsByAddingDownloadAction(NSArray *menuItems, id cel
 
 %hook AWEFeedLiveMarkView
 - (void)setHidden:(BOOL)hidden {
-    if (DYYYGetBool(@"DYYYHideAvatarButton")) {
+    if (DYYYGetBool(@"DYYYHideAvatarLive")) {
         hidden = YES;
     }
 
@@ -3653,7 +3653,14 @@ static UIView *DYYYAvatarViewForSelector(id object, SEL selector) {
     return [value isKindOfClass:[UIView class]] ? value : nil;
 }
 
-static void DYYYHideAvatarViewForSelector(id object, SEL selector) {
+static void DYYYHideAvatarVisualForSelector(id object, SEL selector) {
+    UIView *view = DYYYAvatarViewForSelector(object, selector);
+    if (view) {
+        view.hidden = YES;
+    }
+}
+
+static void DYYYRemoveAvatarViewForSelector(id object, SEL selector) {
     UIView *view = DYYYAvatarViewForSelector(object, selector);
     if (!view) {
         return;
@@ -3662,30 +3669,67 @@ static void DYYYHideAvatarViewForSelector(id object, SEL selector) {
     view.userInteractionEnabled = NO;
 }
 
-static void DYYYMakeAvatarViewInvisibleForSelector(id object, SEL selector) {
-    UIView *view = DYYYAvatarViewForSelector(object, selector);
-    if (view) {
-        view.layer.opacity = 0.0;
+static void DYYYHideAvatarFollowLayerContents(UIView *view) {
+    view.layer.contents = nil;
+    for (CALayer *sublayer in view.layer.sublayers) {
+        sublayer.hidden = YES;
     }
 }
 
+static BOOL DYYYHideAvatarFollowIconInView(UIView *view) {
+    if (!view) {
+        return NO;
+    }
+
+    NSString *className = NSStringFromClass(view.class);
+    if ([className isEqualToString:@"LOTAnimationView"]) {
+        DYYYHideAvatarFollowLayerContents(view);
+        return YES;
+    }
+
+    if ([className isEqualToString:@"AWEPlayInteractionStaticFollowAnimationView"]) {
+        BOOL foundIcon = NO;
+        for (NSString *selectorName in @[ @"plusImageView", @"tickImageView" ]) {
+            UIView *iconView = DYYYAvatarViewForSelector(view, NSSelectorFromString(selectorName));
+            if (iconView) {
+                iconView.hidden = YES;
+                foundIcon = YES;
+            }
+        }
+        if (!foundIcon) {
+            DYYYHideAvatarFollowLayerContents(view);
+        }
+        return YES;
+    }
+
+    BOOL foundIcon = NO;
+    for (UIView *subview in view.subviews) {
+        foundIcon = DYYYHideAvatarFollowIconInView(subview) || foundIcon;
+    }
+    return foundIcon;
+}
+
 static void DYYYApplyAvatarFollowPromptSettings(id owner) {
-    BOOL hideAvatar = DYYYGetBool(@"DYYYHideAvatarButton");
     BOOL hidePlus = DYYYGetBool(@"DYYYHideLOTAnimationView");
     BOOL removePlus = DYYYGetBool(@"DYYYHideFollowPromptView");
-    if (!hideAvatar && !hidePlus && !removePlus) {
+    if (!hidePlus && !removePlus) {
         return;
     }
 
-    DYYYHideAvatarViewForSelector(owner, NSSelectorFromString(@"followAnimationView"));
-    DYYYHideAvatarViewForSelector(owner, NSSelectorFromString(@"unfollowAnimationView"));
-    DYYYHideAvatarViewForSelector(owner, NSSelectorFromString(@"staticFollowAnimationView"));
+    for (NSString *selectorName in @[ @"followAnimationView", @"unfollowAnimationView", @"staticFollowAnimationView" ]) {
+        UIView *animationView = DYYYAvatarViewForSelector(owner, NSSelectorFromString(selectorName));
+        DYYYHideAvatarFollowIconInView(animationView);
+    }
 
-    if (hideAvatar || removePlus) {
-        DYYYHideAvatarViewForSelector(owner, NSSelectorFromString(@"followAddView"));
-        DYYYHideAvatarViewForSelector(owner, NSSelectorFromString(@"followPromptView"));
-    } else if (hidePlus) {
-        DYYYMakeAvatarViewInvisibleForSelector(owner, NSSelectorFromString(@"followAddView"));
+    UIView *followAddView = DYYYAvatarViewForSelector(owner, NSSelectorFromString(@"followAddView"));
+    BOOL foundIcon = DYYYHideAvatarFollowIconInView(followAddView);
+    if (hidePlus && followAddView && !foundIcon) {
+        DYYYHideAvatarFollowLayerContents(followAddView);
+    }
+
+    if (removePlus) {
+        DYYYRemoveAvatarViewForSelector(owner, NSSelectorFromString(@"followAddView"));
+        DYYYRemoveAvatarViewForSelector(owner, NSSelectorFromString(@"followPromptView"));
     }
 }
 
@@ -3708,8 +3752,7 @@ static BOOL DYYYIsLegacyAvatarFollowAnimationView(UIView *view) {
     if (DYYYIsLegacyAvatarFollowAnimationView(self)) {
         // 检查是否需要隐藏加号
         if (DYYYGetBool(@"DYYYHideLOTAnimationView") || DYYYGetBool(@"DYYYHideFollowPromptView")) {
-            self.hidden = YES;
-            self.userInteractionEnabled = NO;
+            DYYYHideAvatarFollowLayerContents(self);
             return;
         }
         // 应用透明度设置
@@ -3725,10 +3768,8 @@ static BOOL DYYYIsLegacyAvatarFollowAnimationView(UIView *view) {
 %hook AWEPlayInteractionStaticFollowAnimationView
 - (void)layoutSubviews {
     %orig;
-    if (DYYYGetBool(@"DYYYHideAvatarButton") || DYYYGetBool(@"DYYYHideLOTAnimationView") || DYYYGetBool(@"DYYYHideFollowPromptView")) {
-        UIView *animationView = (UIView *)self;
-        animationView.hidden = YES;
-        animationView.userInteractionEnabled = NO;
+    if (DYYYGetBool(@"DYYYHideLOTAnimationView") || DYYYGetBool(@"DYYYHideFollowPromptView")) {
+        DYYYHideAvatarFollowIconInView((UIView *)self);
     }
 }
 %end
@@ -4249,7 +4290,7 @@ static BOOL DYYYIsLegacyAvatarFollowAnimationView(UIView *view) {
 - (void)layoutSubviews {
     %orig;
 
-    if (DYYYGetBool(@"DYYYHideAvatarButton") || DYYYGetBool(@"DYYYHideFollowPromptView")) {
+    if (DYYYGetBool(@"DYYYHideFollowPromptView")) {
         self.userInteractionEnabled = NO;
         self.hidden = YES;
         return;
@@ -6553,9 +6594,7 @@ static NSHashTable *processedParentViews = nil;
     %orig;
 
     if (DYYYGetBool(@"DYYYHideAvatarButton")) {
-        self.hidden = YES;
-        self.userInteractionEnabled = NO;
-        return;
+        DYYYHideAvatarVisualForSelector(self, NSSelectorFromString(@"userAvatarView"));
     }
 
     DYYYApplyAvatarFollowPromptSettings(self);
@@ -6629,8 +6668,9 @@ static NSHashTable *processedParentViews = nil;
 - (void)layoutElementView {
     %orig;
     if (DYYYGetBool(@"DYYYHideAvatarButton")) {
-        DYYYHideAvatarViewForSelector(self, NSSelectorFromString(@"avatarPicContainerView"));
-        DYYYHideAvatarViewForSelector(self, NSSelectorFromString(@"avatarPicView"));
+        DYYYHideAvatarVisualForSelector(self, NSSelectorFromString(@"avatarPicView"));
+        id context = DYYYAvatarObjectForSelector(self, NSSelectorFromString(@"userAvatarContext"));
+        DYYYHideAvatarVisualForSelector(context, NSSelectorFromString(@"avatarPicView"));
     }
 }
 %end
@@ -6639,8 +6679,24 @@ static NSHashTable *processedParentViews = nil;
 - (void)layoutElementView {
     %orig;
     if (DYYYGetBool(@"DYYYHideAvatarButton")) {
-        DYYYHideAvatarViewForSelector(self, NSSelectorFromString(@"view"));
-        DYYYHideAvatarViewForSelector(self, NSSelectorFromString(@"getUserAvatarButton"));
+        id context = DYYYAvatarObjectForSelector(self, NSSelectorFromString(@"userAvatarContext"));
+        DYYYHideAvatarVisualForSelector(context, NSSelectorFromString(@"avatarPicView"));
+    }
+}
+%end
+
+%hook AWEPlayInteractionUserAvatarStoryController
+- (void)layoutElementView {
+    %orig;
+    if (DYYYGetBool(@"DYYYHideAvatarRing")) {
+        DYYYHideAvatarVisualForSelector(self, NSSelectorFromString(@"colorRingView"));
+    }
+}
+
+- (void)showStory25RingView {
+    %orig;
+    if (DYYYGetBool(@"DYYYHideAvatarRing")) {
+        DYYYHideAvatarVisualForSelector(self, NSSelectorFromString(@"colorRingView"));
     }
 }
 %end

--- a/DYYY.xm
+++ b/DYYY.xm
@@ -8027,7 +8027,7 @@ static Class tabBarButtonClass = nil;
     dyyyActiveSpeedInteractionController = self;
     dyyyInteractionViewVisible = YES;
     DYYYEnsureFloatSpeedButton(self);
-    updateClearButtonVisibility();
+    reloadClearButtonConfiguration();
 }
 
 - (void)viewDidLayoutSubviews {
@@ -8037,8 +8037,10 @@ static Class tabBarButtonClass = nil;
         dyyyActiveSpeedInteractionController = self;
         dyyyInteractionViewVisible = YES;
         DYYYEnsureFloatSpeedButton(self);
+        reloadClearButtonConfiguration();
     } else {
         [FloatingSpeedButton reloadConfiguration];
+        updateClearButtonVisibility();
     }
 
     UIWindow *keyWindow = [DYYYUtils getActiveWindow];
@@ -8450,11 +8452,13 @@ static Class tabBarButtonClass = nil;
 - (void)viewDidAppear:(BOOL)animated {
     %orig;
     isPureViewVisible = YES;
+    updateClearButtonVisibility();
 }
 
 - (void)viewDidDisappear:(BOOL)animated {
     %orig;
     isPureViewVisible = NO;
+    updateClearButtonVisibility();
 }
 %end
 
@@ -8520,57 +8524,31 @@ static void DYYYRemoveKeyboardObserver(void) {
 
     [[NSUserDefaults standardUserDefaults] addObserver:(NSObject *)self forKeyPath:kDYYYGlobalTransparencyKey options:NSKeyValueObservingOptionNew context:DYYYGlobalTransparencyContext];
 
-    BOOL isEnabled = [[NSUserDefaults standardUserDefaults] boolForKey:@"DYYYEnableFloatClearButton"];
-    if (isEnabled) {
-        if (hideButton) {
-            [hideButton removeFromSuperview];
-            hideButton = nil;
-        }
+    reloadClearButtonConfiguration();
+    DYYYRemoveAppLifecycleObservers();
 
-        CGFloat buttonSize = [[NSUserDefaults standardUserDefaults] floatForKey:@"DYYYEnableFloatClearButtonSize"] ?: 40.0;
-        hideButton = [[HideUIButton alloc] initWithFrame:CGRectMake(0, 0, buttonSize, buttonSize)];
-        hideButton.alpha = 0.5;
+    dyyyWindowKeyObserverToken = [[NSNotificationCenter defaultCenter] addObserverForName:UIWindowDidBecomeKeyNotification
+                                                                                   object:nil
+                                                                                    queue:[NSOperationQueue mainQueue]
+                                                                               usingBlock:^(NSNotification *_Nonnull notification) {
+                                                                                 reloadClearButtonConfiguration();
+                                                                               }];
 
-        NSString *savedPositionString = [[NSUserDefaults standardUserDefaults] objectForKey:@"DYYYHideUIButtonPosition"];
-        if (savedPositionString) {
-            hideButton.center = CGPointFromString(savedPositionString);
-        } else {
-            CGFloat screenWidth = [UIScreen mainScreen].bounds.size.width;
-            CGFloat screenHeight = [UIScreen mainScreen].bounds.size.height;
-            hideButton.center = CGPointMake(screenWidth - buttonSize / 2 - 5, screenHeight / 2);
-        }
+    dyyyDidBecomeActiveToken = [[NSNotificationCenter defaultCenter] addObserverForName:UIApplicationDidBecomeActiveNotification
+                                                                                 object:nil
+                                                                                  queue:[NSOperationQueue mainQueue]
+                                                                             usingBlock:^(NSNotification *_Nonnull notification) {
+                                                                               isAppActive = YES;
+                                                                               reloadClearButtonConfiguration();
+                                                                             }];
 
-        hideButton.hidden = NO;
-        [getKeyWindow() addSubview:hideButton];
-        updateClearButtonVisibility();
-
-        DYYYRemoveAppLifecycleObservers();
-
-        dyyyWindowKeyObserverToken = [[NSNotificationCenter defaultCenter] addObserverForName:UIWindowDidBecomeKeyNotification
-                                                                                       object:nil
-                                                                                        queue:[NSOperationQueue mainQueue]
-                                                                                   usingBlock:^(NSNotification *_Nonnull notification) {
-                                                                                     updateClearButtonVisibility();
-                                                                                   }];
-
-        dyyyDidBecomeActiveToken = [[NSNotificationCenter defaultCenter] addObserverForName:UIApplicationDidBecomeActiveNotification
-                                                                                     object:nil
-                                                                                      queue:[NSOperationQueue mainQueue]
-                                                                                 usingBlock:^(NSNotification *_Nonnull notification) {
-                                                                                   isAppActive = YES;
-                                                                                   updateClearButtonVisibility();
-                                                                                 }];
-
-        dyyyWillResignActiveToken = [[NSNotificationCenter defaultCenter] addObserverForName:UIApplicationWillResignActiveNotification
-                                                                                      object:nil
-                                                                                       queue:[NSOperationQueue mainQueue]
-                                                                                  usingBlock:^(NSNotification *_Nonnull notification) {
-                                                                                    isAppActive = NO;
-                                                                                    updateClearButtonVisibility();
-                                                                                  }];
-    } else {
-        DYYYRemoveAppLifecycleObservers();
-    }
+    dyyyWillResignActiveToken = [[NSNotificationCenter defaultCenter] addObserverForName:UIApplicationWillResignActiveNotification
+                                                                                  object:nil
+                                                                                   queue:[NSOperationQueue mainQueue]
+                                                                              usingBlock:^(NSNotification *_Nonnull notification) {
+                                                                                isAppActive = NO;
+                                                                                updateClearButtonVisibility();
+                                                                              }];
 
     return result;
 }

--- a/DYYY.xm
+++ b/DYYY.xm
@@ -582,25 +582,46 @@ static BOOL DYYYShouldHandleSpeedFeatures(void) {
 
 %end
 
-static void DYYYMigrateSeparatedHDRSettingsIfNeeded(void) {
+static NSString *const kDYYYHDRModeKey = @"DYYYHDRMode";
+static NSString *const kDYYYHDRModeOff = @"关闭";
+static NSString *const kDYYYHDRModeDisable = @"全局屏蔽HDR效果";
+static NSString *const kDYYYHDRModeFilter = @"全局过滤HDR作品";
+
+static void DYYYMigrateCombinedHDRModeIfNeeded(void) {
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-        if ([defaults boolForKey:@"DYYYHDRSettingsSeparatedV1"]) {
+        if ([defaults boolForKey:@"DYYYHDRModeMigratedV1"]) {
             return;
         }
 
-        id previousValue = [defaults objectForKey:@"DYYYFilterFeedHDR"];
-        if (previousValue && ![defaults objectForKey:@"DYYYDisableAllHDR"]) {
-            [defaults setBool:[previousValue boolValue] forKey:@"DYYYDisableAllHDR"];
+        NSString *mode = [defaults stringForKey:kDYYYHDRModeKey];
+        BOOL hasValidMode = [mode isEqualToString:kDYYYHDRModeOff] ||
+                            [mode isEqualToString:kDYYYHDRModeDisable] ||
+                            [mode isEqualToString:kDYYYHDRModeFilter];
+        if (!hasValidMode) {
+            if ([defaults boolForKey:@"DYYYDisableAllHDR"]) {
+                mode = kDYYYHDRModeDisable;
+            } else if ([defaults boolForKey:@"DYYYFilterFeedHDR"]) {
+                mode = kDYYYHDRModeFilter;
+            } else {
+                mode = kDYYYHDRModeOff;
+            }
         }
-        [defaults setBool:NO forKey:@"DYYYFilterFeedHDR"];
-        [defaults setBool:YES forKey:@"DYYYHDRSettingsSeparatedV1"];
+
+        [defaults setObject:mode forKey:kDYYYHDRModeKey];
+        [defaults removeObjectForKey:@"DYYYDisableAllHDR"];
+        [defaults removeObjectForKey:@"DYYYFilterFeedHDR"];
+        [defaults setBool:YES forKey:@"DYYYHDRModeMigratedV1"];
     });
 }
 
 static BOOL DYYYShouldDisableAllHDR(void) {
-    return DYYYGetBool(@"DYYYDisableAllHDR");
+    return [[[NSUserDefaults standardUserDefaults] stringForKey:kDYYYHDRModeKey] isEqualToString:kDYYYHDRModeDisable];
+}
+
+static BOOL DYYYShouldFilterGlobalHDR(void) {
+    return [[[NSUserDefaults standardUserDefaults] stringForKey:kDYYYHDRModeKey] isEqualToString:kDYYYHDRModeFilter];
 }
 
 static id DYYYStandardCADynamicRange(void) {
@@ -633,54 +654,29 @@ static void DYYYDisableExtendedRangeForMetalLayer(CAMetalLayer *metalLayer) {
 
     if (@available(iOS 16.0, *)) {
         metalLayer.wantsExtendedDynamicRangeContent = NO;
-        metalLayer.EDRMetadata = nil;
     }
 }
 
-// 禁用全部视频、图片及动图播放显示链路中的 HDR 效果
-%hook AWEKnowledgeABTestSettings
-
-+ (BOOL)enableHDRAutomaticIdentification {
-    if (DYYYGetBool(@"DYYYDisableAllHDR")) {
-        return NO;
-    }
-    return %orig;
-}
-
-%end
+// 保留 HDR 解码及原生 HDR -> SDR 转换，只关闭亮度增强、SDR -> HDR 和最终 EDR 输出。
 
 %hook AWEFeedABSettings
 
 + (BOOL)enableHDRBrightnessOpt {
-    if (DYYYGetBool(@"DYYYDisableAllHDR")) {
-        return NO;
-    }
-    return %orig;
-}
-
-+ (BOOL)enableHDRFullModelAdaptation {
-    if (DYYYGetBool(@"DYYYDisableAllHDR")) {
-        return NO;
-    }
-    return %orig;
-}
-
-+ (BOOL)hdrAutomaticIdentification {
-    if (DYYYGetBool(@"DYYYDisableAllHDR")) {
+    if (DYYYShouldDisableAllHDR()) {
         return NO;
     }
     return %orig;
 }
 
 + (BOOL)enableProfilePreloadHDRBrightnessFilter {
-    if (DYYYGetBool(@"DYYYDisableAllHDR")) {
+    if (DYYYShouldDisableAllHDR()) {
         return NO;
     }
     return %orig;
 }
 
 + (BOOL)enableDynamicGaussianBlurHDR {
-    if (DYYYGetBool(@"DYYYDisableAllHDR")) {
+    if (DYYYShouldDisableAllHDR()) {
         return NO;
     }
     return %orig;
@@ -691,7 +687,7 @@ static void DYYYDisableExtendedRangeForMetalLayer(CAMetalLayer *metalLayer) {
 %hook AWEFeedABTestServiceObjc
 
 + (BOOL)enableProfilePreloadHDRBrightnessFilter {
-    if (DYYYGetBool(@"DYYYDisableAllHDR")) {
+    if (DYYYShouldDisableAllHDR()) {
         return NO;
     }
     return %orig;
@@ -702,21 +698,7 @@ static void DYYYDisableExtendedRangeForMetalLayer(CAMetalLayer *metalLayer) {
 %hook BDSimPlayerBizConfig
 
 - (BOOL)enableHDRBrightnessOpt {
-    if (DYYYGetBool(@"DYYYDisableAllHDR")) {
-        return NO;
-    }
-    return %orig;
-}
-
-- (BOOL)enableHDRFullModelAdaptation {
-    if (DYYYGetBool(@"DYYYDisableAllHDR")) {
-        return NO;
-    }
-    return %orig;
-}
-
-- (BOOL)hdrAutomaticIdentification {
-    if (DYYYGetBool(@"DYYYDisableAllHDR")) {
+    if (DYYYShouldDisableAllHDR()) {
         return NO;
     }
     return %orig;
@@ -727,21 +709,7 @@ static void DYYYDisableExtendedRangeForMetalLayer(CAMetalLayer *metalLayer) {
 %hook AWEBDSimPlayerBizConfig
 
 - (BOOL)enableHDRBrightnessOpt {
-    if (DYYYGetBool(@"DYYYDisableAllHDR")) {
-        return NO;
-    }
-    return %orig;
-}
-
-- (BOOL)enableHDRFullModelAdaptation {
-    if (DYYYGetBool(@"DYYYDisableAllHDR")) {
-        return NO;
-    }
-    return %orig;
-}
-
-- (BOOL)hdrAutomaticIdentification {
-    if (DYYYGetBool(@"DYYYDisableAllHDR")) {
+    if (DYYYShouldDisableAllHDR()) {
         return NO;
     }
     return %orig;
@@ -752,298 +720,16 @@ static void DYYYDisableExtendedRangeForMetalLayer(CAMetalLayer *metalLayer) {
 %hook AWEVideoPlayerConfiguration
 
 + (void)setHDRBrightnessStrategy:(id)strategy {
-    if (!DYYYGetBool(@"DYYYDisableAllHDR")) {
+    if (!DYYYShouldDisableAllHDR()) {
         %orig;
     }
 }
 
 + (double)getHDRBrightnessOffset:(id)configuration brightness:(double)brightness {
-    if (DYYYGetBool(@"DYYYDisableAllHDR")) {
+    if (DYYYShouldDisableAllHDR()) {
         return 0.0;
     }
     return %orig;
-}
-
-%end
-
-%hook BDSimPlayerHelper
-
-+ (id)hdrValueFor:(long long)value enableHDR:(BOOL)enableHDR {
-    return %orig(value, DYYYGetBool(@"DYYYDisableAllHDR") ? NO : enableHDR);
-}
-
-%end
-
-%hook BDSimStreamContext
-
-- (BOOL)enableHDR {
-    if (DYYYGetBool(@"DYYYDisableAllHDR")) {
-        return NO;
-    }
-    return %orig;
-}
-
-- (void)setEnableHDR:(BOOL)enableHDR {
-    %orig(DYYYGetBool(@"DYYYDisableAllHDR") ? NO : enableHDR);
-}
-
-%end
-
-%hook BDSimMediaPlayer
-
-- (BOOL)enableHDR {
-    if (DYYYGetBool(@"DYYYDisableAllHDR")) {
-        return NO;
-    }
-    return %orig;
-}
-
-- (void)setEnableHDR:(BOOL)enableHDR {
-    %orig(DYYYGetBool(@"DYYYDisableAllHDR") ? NO : enableHDR);
-}
-
-- (void)setEnablePlayHDRMode {
-    if (!DYYYGetBool(@"DYYYDisableAllHDR")) {
-        %orig;
-    }
-}
-
-- (void)buildHDRConfig:(id)config {
-    if (!DYYYGetBool(@"DYYYDisableAllHDR")) {
-        %orig;
-    }
-}
-
-- (id)awe_HDRValueFor:(long long)value enableHDR:(BOOL)enableHDR {
-    return %orig(value, DYYYGetBool(@"DYYYDisableAllHDR") ? NO : enableHDR);
-}
-
-%end
-
-%hook AWEDPlayerVideoDisplayOptState
-
-- (BOOL)enableHDR {
-    if (DYYYGetBool(@"DYYYDisableAllHDR")) {
-        return NO;
-    }
-    return %orig;
-}
-
-- (void)setEnableHDR:(BOOL)enableHDR {
-    %orig(DYYYGetBool(@"DYYYDisableAllHDR") ? NO : enableHDR);
-}
-
-%end
-
-%hook AWEPlayVideoPlayerContext
-
-- (BOOL)enableHDR {
-    if (DYYYGetBool(@"DYYYDisableAllHDR")) {
-        return NO;
-    }
-    return %orig;
-}
-
-- (void)setEnableHDR:(BOOL)enableHDR {
-    %orig(DYYYGetBool(@"DYYYDisableAllHDR") ? NO : enableHDR);
-}
-
-%end
-
-%hook AWEPlayVideoViewController
-
-- (BOOL)enableHDR {
-    if (DYYYGetBool(@"DYYYDisableAllHDR")) {
-        return NO;
-    }
-    return %orig;
-}
-
-- (void)setEnableHDR:(BOOL)enableHDR {
-    %orig(DYYYGetBool(@"DYYYDisableAllHDR") ? NO : enableHDR);
-}
-
-- (void)setPlayerLutFilter:(id)lutFilter HDRLutImage:(id)HDRLutImage {
-    %orig(lutFilter, DYYYGetBool(@"DYYYDisableAllHDR") ? nil : HDRLutImage);
-}
-
-- (BOOL)awe_isCurrentVideoHDR {
-    if (DYYYGetBool(@"DYYYDisableAllHDR")) {
-        return NO;
-    }
-    return %orig;
-}
-
-%end
-
-%hook AWEDPlayerFeedPlayerViewController
-
-- (BOOL)enableHDR {
-    if (DYYYGetBool(@"DYYYDisableAllHDR")) {
-        return NO;
-    }
-    return %orig;
-}
-
-%end
-
-%hook AWEDPlayerViewController_Merge
-
-- (BOOL)enableHDR {
-    if (DYYYGetBool(@"DYYYDisableAllHDR")) {
-        return NO;
-    }
-    return %orig;
-}
-
-%end
-
-%hook TTVideoEngineOwnPlayer
-
-- (BOOL)enableHDR10 {
-    if (DYYYGetBool(@"DYYYDisableAllHDR")) {
-        return NO;
-    }
-    return %orig;
-}
-
-- (void)setEnableHDR10:(BOOL)enableHDR10 {
-    %orig(DYYYGetBool(@"DYYYDisableAllHDR") ? NO : enableHDR10);
-}
-
-%end
-
-%hook AWEDPlayerVideoConfig
-
-- (BOOL)enableMetalRenderHDR {
-    if (DYYYShouldDisableAllHDR()) {
-        return NO;
-    }
-    return %orig;
-}
-
-- (void)setEnableMetalRenderHDR:(BOOL)enableMetalRenderHDR {
-    %orig(DYYYShouldDisableAllHDR() ? NO : enableMetalRenderHDR);
-}
-
-%end
-
-%hook AWEDPlayerVideoController
-
-- (void)configEnableMetalRenderHDRIfNeeded {
-    if (!DYYYShouldDisableAllHDR()) {
-        %orig;
-    }
-}
-
-- (void)setEnablePlayHDRModeIfNeeded {
-    if (!DYYYShouldDisableAllHDR()) {
-        %orig;
-    }
-}
-
-%end
-
-%hook AWEDPlayerVideoController_Merge
-
-- (void)configEnableMetalRenderHDRIfNeeded {
-    if (!DYYYShouldDisableAllHDR()) {
-        %orig;
-    }
-}
-
-- (void)setEnablePlayHDRModeIfNeeded {
-    if (!DYYYShouldDisableAllHDR()) {
-        %orig;
-    }
-}
-
-%end
-
-%hook AWEDPlayerPlayControlContainer
-
-- (void)configEnableMetalRenderHDRIfNeeded {
-    if (!DYYYShouldDisableAllHDR()) {
-        %orig;
-    }
-}
-
-%end
-
-%hook AWEDPlayerNonSimplayerContainer
-
-- (void)setEnablePlayHDRMode {
-    if (!DYYYShouldDisableAllHDR()) {
-        %orig;
-    }
-}
-
-%end
-
-%hook AWEDPlayerSimpleModeContainer
-
-- (void)setEnablePlayHDRModeIfNeeded {
-    if (!DYYYShouldDisableAllHDR()) {
-        %orig;
-    }
-}
-
-%end
-
-%hook AWEDPlayerBrightnessContainer
-
-- (BOOL)awe_isCurrentVideoHDR {
-    if (DYYYShouldDisableAllHDR()) {
-        return NO;
-    }
-    return %orig;
-}
-
-%end
-
-%hook AWEVideoPlayerScreenBrightnessManager
-
-- (BOOL)isHDRVideo {
-    if (DYYYShouldDisableAllHDR()) {
-        return NO;
-    }
-    return %orig;
-}
-
-- (void)setIsHDRVideo:(BOOL)isHDRVideo {
-    %orig(DYYYShouldDisableAllHDR() ? NO : isHDRVideo);
-}
-
-%end
-
-%hook ALMOwnPlayerWrapper
-
-- (void)setLutFilter:(id)lutFilter HDRLutImage:(id)HDRLutImage {
-    %orig(lutFilter, DYYYShouldDisableAllHDR() ? nil : HDRLutImage);
-}
-
-%end
-
-%hook ALMSysPlayerWrapper
-
-- (void)setLutFilter:(id)lutFilter HDRLutImage:(id)HDRLutImage {
-    %orig(lutFilter, DYYYShouldDisableAllHDR() ? nil : HDRLutImage);
-}
-
-%end
-
-%hook ALMVideoPlayerConfig
-
-+ (void)setPlayerEffectHDRLutImageEnable:(BOOL)enable {
-    %orig(DYYYShouldDisableAllHDR() ? NO : enable);
-}
-
-%end
-
-%hook IESVideoPlayerConfig
-
-+ (void)setPlayerEffectHDRLutImageEnable:(BOOL)enable {
-    %orig(DYYYShouldDisableAllHDR() ? NO : enable);
 }
 
 %end
@@ -1059,83 +745,56 @@ static void DYYYDisableExtendedRangeForMetalLayer(CAMetalLayer *metalLayer) {
 
 %end
 
-%hook IESIMVideoPlayerWrapper
+%hook IESLiveAudienceHDRController
 
-- (void)setupHDREnable:(BOOL)enable {
-    %orig(DYYYShouldDisableAllHDR() ? NO : enable);
-}
-
-%end
-
-%hook AWEIMVideoBrowserCollectionViewCell
-
-- (void)setEnablePlayHDR:(BOOL)enable {
-    %orig(DYYYShouldDisableAllHDR() ? NO : enable);
-}
-
-%end
-
-%hook AWEECOMIMAppSettingsService
-
-+ (BOOL)enableVideoPreviewSupportHDR {
++ (BOOL)currentHDRStatusForRoomID:(id)roomID {
     if (DYYYShouldDisableAllHDR()) {
         return NO;
     }
     return %orig;
 }
 
-%end
-
-%hook IESLiveAudienceHDRController
-
-+ (BOOL)currentHDRStatusForRoomID:(id)roomID {
-    if (DYYYGetBool(@"DYYYDisableAllHDR")) {
-        return NO;
-    }
-    return %orig;
-}
-
 + (BOOL)isCurrentRoomSupportHDR:(id)roomID roomModel:(id)roomModel {
-    if (DYYYGetBool(@"DYYYDisableAllHDR")) {
+    if (DYYYShouldDisableAllHDR()) {
         return NO;
     }
     return %orig;
 }
 
 + (BOOL)isFeedCanEnableHDRFeature {
-    if (DYYYGetBool(@"DYYYDisableAllHDR")) {
+    if (DYYYShouldDisableAllHDR()) {
         return NO;
     }
     return %orig;
 }
 
 + (BOOL)isInnerFeedCanEnableHDRFeature {
-    if (DYYYGetBool(@"DYYYDisableAllHDR")) {
+    if (DYYYShouldDisableAllHDR()) {
         return NO;
     }
     return %orig;
 }
 
 + (BOOL)isUserEnableHDR {
-    if (DYYYGetBool(@"DYYYDisableAllHDR")) {
+    if (DYYYShouldDisableAllHDR()) {
         return NO;
     }
     return %orig;
 }
 
 + (BOOL)p_isHDRFeatureEnable {
-    if (DYYYGetBool(@"DYYYDisableAllHDR")) {
+    if (DYYYShouldDisableAllHDR()) {
         return NO;
     }
     return %orig;
 }
 
 + (void)setUserEnableHDR:(BOOL)enableHDR {
-    %orig(DYYYGetBool(@"DYYYDisableAllHDR") ? NO : enableHDR);
+    %orig(DYYYShouldDisableAllHDR() ? NO : enableHDR);
 }
 
 + (BOOL)shouldShowHDRSwitchForRoom:(id)room {
-    if (DYYYGetBool(@"DYYYDisableAllHDR")) {
+    if (DYYYShouldDisableAllHDR()) {
         return NO;
     }
     return %orig;
@@ -1205,17 +864,6 @@ static void DYYYDisableExtendedRangeForMetalLayer(CAMetalLayer *metalLayer) {
 
 %hook TVLManager
 
-- (BOOL)shouldForbidHDR10Render {
-    if (DYYYShouldDisableAllHDR()) {
-        return YES;
-    }
-    return %orig;
-}
-
-- (void)setShouldForbidHDR10Render:(BOOL)shouldForbid {
-    %orig(DYYYShouldDisableAllHDR() ? YES : shouldForbid);
-}
-
 - (void)setupVideoSDR2HDR:(id)config {
     if (!DYYYShouldDisableAllHDR()) {
         %orig;
@@ -1250,137 +898,9 @@ static void DYYYDisableExtendedRangeForMetalLayer(CAMetalLayer *metalLayer) {
 
 %end
 
-%hook TVLSettingsManager
-
-- (BOOL)enableMetalRenderHDR {
-    if (DYYYShouldDisableAllHDR()) {
-        return NO;
-    }
-    return %orig;
-}
-
-%end
-
-%hook BDImageDecoderFactory
-
-+ (BOOL)isHDRImageData:(id)data withHeifDecoderClass:(Class)decoderClass {
-    if (DYYYShouldDisableAllHDR()) {
-        return NO;
-    }
-    return %orig;
-}
-
-%end
-
-%hook BDImageDecoderImageIO
-
-- (BOOL)isHDRCGImage:(CGImageRef)image decodedToHDR:(BOOL)decodedToHDR {
-    if (DYYYShouldDisableAllHDR()) {
-        return NO;
-    }
-    return %orig;
-}
-
-- (id)hdrOptionsFor:(id)image decodedToHDR:(BOOL *)decodedToHDR {
-    if (DYYYShouldDisableAllHDR()) {
-        if (decodedToHDR) {
-            *decodedToHDR = NO;
-        }
-        return nil;
-    }
-    return %orig;
-}
-
-%end
-
-%hook BDImageDecoderHeic
-
-+ (BOOL)isHDRData:(id)data {
-    if (DYYYShouldDisableAllHDR()) {
-        return NO;
-    }
-    return %orig;
-}
-
-- (BOOL)isHDR {
-    if (DYYYShouldDisableAllHDR()) {
-        return NO;
-    }
-    return %orig;
-}
-
-- (void)setIsHDR:(BOOL)isHDR {
-    %orig(DYYYShouldDisableAllHDR() ? NO : isHDR);
-}
-
-%end
-
-%hook BDImageDecoderBVC2
-
-- (BOOL)isHDR {
-    if (DYYYShouldDisableAllHDR()) {
-        return NO;
-    }
-    return %orig;
-}
-
-- (void)setIsHDR:(BOOL)isHDR {
-    %orig(DYYYShouldDisableAllHDR() ? NO : isHDR);
-}
-
-%end
-
-%hook BDImageDecoderWebP
-
-- (BOOL)isHDR {
-    if (DYYYShouldDisableAllHDR()) {
-        return NO;
-    }
-    return %orig;
-}
-
-- (void)setIsHDR:(BOOL)isHDR {
-    %orig(DYYYShouldDisableAllHDR() ? NO : isHDR);
-}
-
-%end
-
-%hook BDImage
-
-- (BOOL)isHDR {
-    if (DYYYShouldDisableAllHDR()) {
-        return NO;
-    }
-    return %orig;
-}
-
-- (void)setIsHDR:(BOOL)isHDR {
-    %orig(DYYYShouldDisableAllHDR() ? NO : isHDR);
-}
-
-%end
-
 %hook HDRMTUIImageView
 
-- (instancetype)initWithFrame:(CGRect)frame hdrEnabled:(BOOL)hdrEnabled {
-    return %orig(frame, DYYYShouldDisableAllHDR() ? NO : hdrEnabled);
-}
-
-- (BOOL)hdrEnabled {
-    if (DYYYShouldDisableAllHDR()) {
-        return NO;
-    }
-    return %orig;
-}
-
-- (void)setHdrEnabled:(BOOL)hdrEnabled {
-    %orig(DYYYShouldDisableAllHDR() ? NO : hdrEnabled);
-}
-
 - (void)setImage:(UIImage *)image {
-    if (DYYYShouldDisableAllHDR()) {
-        self.hdrEnabled = NO;
-    }
     DYYYApplySDRDynamicRangeToImageView(self);
     %orig;
     DYYYApplySDRDynamicRangeToImageView(self);
@@ -1391,8 +911,8 @@ static void DYYYDisableExtendedRangeForMetalLayer(CAMetalLayer *metalLayer) {
 %hook HDRMTImageView
 
 - (void)setMetalLayer:(CAMetalLayer *)metalLayer {
-    DYYYDisableExtendedRangeForMetalLayer(metalLayer);
     %orig;
+    DYYYDisableExtendedRangeForMetalLayer(metalLayer);
 }
 
 - (void)setUpEnv {
@@ -1411,10 +931,7 @@ static void DYYYDisableExtendedRangeForMetalLayer(CAMetalLayer *metalLayer) {
 
 - (void)configHDRContent {
     %orig;
-    if (DYYYShouldDisableAllHDR()) {
-        self.hdrmtImageView.hdrEnabled = NO;
-        DYYYApplySDRDynamicRangeToImageView(self.hdrmtImageView);
-    }
+    DYYYApplySDRDynamicRangeToImageView(self.hdrmtImageView);
 }
 
 %end
@@ -1430,10 +947,6 @@ static void DYYYDisableExtendedRangeForMetalLayer(CAMetalLayer *metalLayer) {
         return NO;
     }
     return %orig;
-}
-
-- (void)setEDRMetadata:(CAEDRMetadata *)EDRMetadata {
-    %orig(DYYYShouldDisableAllHDR() ? nil : EDRMetadata);
 }
 
 %end
@@ -5974,9 +5487,73 @@ static NSHashTable *processedParentViews = nil;
 
 - (id)initWithDictionary:(id)arg1 error:(id *)arg2 {
     id orig = %orig;
-    if (orig && [self contentFilter])
-        return nil;
+    if (orig) {
+        BOOL shouldFilter = [self contentFilter];
+        if (!shouldFilter && DYYYShouldFilterGlobalHDR() &&
+            ![self dyyy_shouldExcludeFromGlobalHDRFilter] &&
+            [self dyyy_containsHDRMetadataInObject:arg1 depth:0]) {
+            shouldFilter = YES;
+        }
+        if (shouldFilter) {
+            return nil;
+        }
+    }
     return orig;
+}
+
+%new
+- (BOOL)dyyy_shouldExcludeFromGlobalHDRFilter {
+    NSString *referString = [self.referString lowercaseString];
+    if (referString.length == 0) {
+        return NO;
+    }
+
+    return [referString isEqualToString:@"chat"] ||
+           [referString containsString:@"chat_room"] ||
+           [referString containsString:@"message"] ||
+           [referString containsString:@"forward"] ||
+           [referString containsString:@"private"] ||
+           [referString containsString:@"share"] ||
+           [referString hasPrefix:@"im_"] ||
+           [referString containsString:@"_im_"];
+}
+
+%new
+- (BOOL)dyyy_containsHDRMetadataInObject:(id)object depth:(NSUInteger)depth {
+    if (!object || depth > 8) {
+        return NO;
+    }
+
+    if ([object isKindOfClass:[NSDictionary class]]) {
+        NSDictionary *dictionary = (NSDictionary *)object;
+        for (id rawKey in dictionary) {
+            id value = dictionary[rawKey];
+            NSString *key = [[rawKey description] lowercaseString];
+            NSInteger numericValue = [value respondsToSelector:@selector(integerValue)] ? [value integerValue] : 0;
+
+            if (([key isEqualToString:@"is_source_hdr"] || [key isEqualToString:@"has_filter_hdr"]) && numericValue > 0) {
+                return YES;
+            }
+            if ([key isEqualToString:@"hdr_type"] && numericValue > 0) {
+                return YES;
+            }
+            if ([key isEqualToString:@"hdr_bit"] && numericValue >= 10) {
+                return YES;
+            }
+            if (([value isKindOfClass:[NSDictionary class]] || [value isKindOfClass:[NSArray class]]) &&
+                [self dyyy_containsHDRMetadataInObject:value depth:depth + 1]) {
+                return YES;
+            }
+        }
+    } else if ([object isKindOfClass:[NSArray class]]) {
+        for (id value in (NSArray *)object) {
+            if ([self dyyy_containsHDRMetadataInObject:value depth:depth + 1]) {
+                return YES;
+            }
+        }
+    }
+
+    return NO;
 }
 
 %new
@@ -5988,7 +5565,7 @@ static NSHashTable *processedParentViews = nil;
     BOOL skipPhotoText = DYYYGetBool(@"DYYYSkipPhotoText");
     BOOL skipMusic = DYYYGetBool(@"DYYYSkipMusic");
     BOOL skipAIInteraction = DYYYGetBool(@"DYYYSkipAIInteraction");
-    BOOL filterHDR = DYYYGetBool(@"DYYYFilterFeedHDR");
+    BOOL filterHDR = DYYYShouldFilterGlobalHDR();
 
     BOOL shouldFilterAds = noAds && (self.isAds);
     BOOL shouldFilterHotSpot = skipHotSpot && self.hotSpotLynxCardModel;
@@ -6078,8 +5655,8 @@ static NSHashTable *processedParentViews = nil;
         }
     }
 
-    // 仅过滤推荐流，并优先使用 39.1.0 视频模型上的源 HDR 标记。
-    if (filterHDR && isRecommendFeed && self.video) {
+    // 全场景过滤 HDR 作品，但保留私信、消息详情和转发链路。
+    if (filterHDR && ![self dyyy_shouldExcludeFromGlobalHDRFilter] && self.video) {
         AWEVideoModel *video = self.video;
         if ([video respondsToSelector:@selector(isSourceHDR)] && video.isSourceHDR > 0) {
             shouldFilterHDR = YES;
@@ -6107,17 +5684,6 @@ static NSHashTable *processedParentViews = nil;
 
     return shouldFilterAds || shouldFilterAllLive || shouldFilterHotSpot || shouldFilterHDR || shouldFilterKeywords || shouldFilterProp ||
            shouldFilterTime || shouldFilterUser;
-}
-
-- (BOOL)awe_enableHDR {
-    if (DYYYGetBool(@"DYYYDisableAllHDR")) {
-        return NO;
-    }
-    return %orig;
-}
-
-- (id)awe_HDRValueFor:(long long)value enableHDR:(BOOL)enableHDR {
-    return %orig(value, DYYYGetBool(@"DYYYDisableAllHDR") ? NO : enableHDR);
 }
 
 - (AWEECommerceLabel *)ecommerceBelowLabel {
@@ -10033,7 +9599,7 @@ static void findTargetViewInView(UIView *view) {
 }
 
 %ctor {
-    DYYYMigrateSeparatedHDRSettingsIfNeeded();
+    DYYYMigrateCombinedHDRModeIfNeeded();
 
     Class interactionBaseLabelClass = objc_getClass("AWECommentSwiftBizUI.CommentInteractionBaseLabel");
     if (interactionBaseLabelClass) {

--- a/DYYYFloatClearButton.h
+++ b/DYYYFloatClearButton.h
@@ -23,6 +23,7 @@ void updateClearButtonVisibility(void);
 void showClearButton(void);
 void hideClearButton(void);
 void initTargetClassNames(void);
+void reloadClearButtonConfiguration(void);
 
 #ifdef __cplusplus
 }
@@ -38,6 +39,7 @@ void initTargetClassNames(void);
 @property(nonatomic, strong) NSTimer *checkTimer;
 @property(nonatomic, strong) NSTimer *fadeTimer;
 - (void)resetFadeTimer;
+- (void)loadSavedPosition;
 - (void)hideUIElements;
 - (void)findAndHideViews:(NSArray *)classNames;
 - (void)safeResetState;

--- a/DYYYFloatClearButton.xm
+++ b/DYYYFloatClearButton.xm
@@ -9,6 +9,8 @@
 #import "DYYYUtils.h"
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
+#import <float.h>
+#import <math.h>
 #import <signal.h>
 
 void updateClearButtonVisibility(void);
@@ -48,9 +50,10 @@ static void DYYYPerformClearButtonMutation(dispatch_block_t block) {
 }
 
 
-HideUIButton *hideButton;
+HideUIButton *hideButton = nil;
 BOOL isAppInTransition = NO;
 NSArray *targetClassNames;
+static NSUInteger dyyyTargetClassConfiguration = NSUIntegerMax;
 static CGFloat DYGetGlobalAlpha(void) {
     NSString *value = [[NSUserDefaults standardUserDefaults] stringForKey:@"DYYYGlobalTransparency"];
     CGFloat a = value.length ? value.floatValue : 1.0;
@@ -65,6 +68,11 @@ static void findViewsOfClassHelper(UIView *view, Class viewClass, NSMutableArray
     }
 }
 UIWindow *getKeyWindow(void) {
+    UIWindow *activeWindow = [DYYYUtils getActiveWindow];
+    if (activeWindow) {
+        return activeWindow;
+    }
+
     UIWindow *keyWindow = nil;
     for (UIWindow *window in [UIApplication sharedApplication].windows) {
         if (window.isKeyWindow) {
@@ -143,21 +151,21 @@ void hideClearButton(void) {
 
 static void forceResetAllUIElements(void) {
     DYYYPerformClearButtonMutation(^{
-        UIWindow *window = getKeyWindow();
-        if (!window)
-            return;
+        initTargetClassNames();
         Class StackViewClass = NSClassFromString(@"AWEElementStackView");
-        for (NSString *className in targetClassNames) {
-            Class viewClass = NSClassFromString(className);
-            if (!viewClass)
-                continue;
-            NSMutableArray *views = [NSMutableArray array];
-            findViewsOfClassHelper(window, viewClass, views);
-            for (UIView *view in views) {
-                if ([view isKindOfClass:StackViewClass]) {
-                    view.alpha = 1.0; // 基础透明度交给全局透明度处理，避免重复乘
-                } else {
-                    view.alpha = 1.0; // 恢复透明度
+        for (UIWindow *window in [UIApplication sharedApplication].windows) {
+            for (NSString *className in targetClassNames) {
+                Class viewClass = NSClassFromString(className);
+                if (!viewClass)
+                    continue;
+                NSMutableArray *views = [NSMutableArray array];
+                findViewsOfClassHelper(window, viewClass, views);
+                for (UIView *view in views) {
+                    if ([view isKindOfClass:StackViewClass]) {
+                        view.alpha = 1.0; // 基础透明度交给全局透明度处理，避免重复乘
+                    } else {
+                        view.alpha = 1.0; // 恢复透明度
+                    }
                 }
             }
         }
@@ -169,32 +177,97 @@ static void reapplyHidingToAllElements(HideUIButton *button) {
     [button hideUIElements];
 }
 void initTargetClassNames(void) {
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    NSUInteger configuration = 0;
+    configuration |= [defaults boolForKey:@"DYYYHideTabBar"] ? (1U << 0) : 0;
+    configuration |= [defaults boolForKey:@"DYYYHideDanmaku"] ? (1U << 1) : 0;
+    configuration |= [defaults boolForKey:@"DYYYHideSlider"] ? (1U << 2) : 0;
+    configuration |= [defaults boolForKey:@"DYYYHideChapter"] ? (1U << 3) : 0;
+    if (targetClassNames && dyyyTargetClassConfiguration == configuration) {
+        return;
+    }
+
     NSMutableArray<NSString *> *list = [@[
         @"AWEHPTopBarCTAContainer", @"AWEHPDiscoverFeedEntranceView", @"AWELeftSideBarEntranceView", @"DUXBadge", @"AWEBaseElementView", @"AWEElementStackView", @"AWEPlayInteractionDescriptionLabel",
         @"AWEUserNameLabel", @"ACCEditTagStickerView", @"AWEFeedTemplateAnchorView", @"AWESearchFeedTagView", @"AWEPlayInteractionSearchAnchorView", @"AFDRecommendToFriendTagView",
         @"AWELandscapeFeedEntryView", @"AWEFeedAnchorContainerView", @"AFDAIbumFolioView", @"DUXPopover", @"AWEMixVideoPanelMoreView", @"AWEHotSearchInnerBottomView", @"AWEHPSegmentControlScrollView"
     ] mutableCopy];
-    if ([[NSUserDefaults standardUserDefaults] boolForKey:@"DYYYHideTabBar"]) {
+    if (configuration & (1U << 0)) {
         [list addObject:@"AWENormalModeTabBar"];
     }
-    if ([[NSUserDefaults standardUserDefaults] boolForKey:@"DYYYHideDanmaku"]) {
+    if (configuration & (1U << 1)) {
         [list addObject:@"AWEVideoPlayDanmakuContainerView"];
         [list addObject:@"AWEDanmakuContainerView"];
     }
-    if ([[NSUserDefaults standardUserDefaults] boolForKey:@"DYYYHideSlider"]) {
+    if (configuration & (1U << 2)) {
         [list addObject:@"AWEStoryProgressSlideView"];
         [list addObject:@"AWEStoryProgressContainerView"];
     }
-    if ([[NSUserDefaults standardUserDefaults] boolForKey:@"DYYYHideChapter"]) {
+    if (configuration & (1U << 3)) {
         [list addObject:@"AWEDemaciaChapterProgressSlider"];
     }
 
     targetClassNames = [list copy];
+    dyyyTargetClassConfiguration = configuration;
+}
+
+void reloadClearButtonConfiguration(void) {
+    if (![NSThread isMainThread]) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+          reloadClearButtonConfiguration();
+        });
+        return;
+    }
+
+    initTargetClassNames();
+
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    BOOL isEnabled = [defaults boolForKey:@"DYYYEnableFloatClearButton"];
+    if (!isEnabled) {
+        if (hideButton) {
+            if (hideButton.isElementsHidden) {
+                [hideButton safeResetState];
+            }
+            [hideButton removeFromSuperview];
+            hideButton = nil;
+        }
+        return;
+    }
+
+    UIWindow *activeWindow = [DYYYUtils getActiveWindow];
+    if (!activeWindow) {
+        return;
+    }
+
+    CGFloat buttonSize = [defaults floatForKey:@"DYYYEnableFloatClearButtonSize"];
+    if (buttonSize <= 0.0) {
+        buttonSize = 40.0;
+    }
+    buttonSize = MIN(MAX(buttonSize, 20.0), 60.0);
+
+    if (!hideButton) {
+        hideButton = [[HideUIButton alloc] initWithFrame:CGRectMake(0, 0, buttonSize, buttonSize)];
+    } else if (fabs(hideButton.bounds.size.width - buttonSize) > FLT_EPSILON) {
+        hideButton.bounds = CGRectMake(0, 0, buttonSize, buttonSize);
+        hideButton.layer.cornerRadius = buttonSize / 2.0;
+    }
+
+    if (![hideButton isDescendantOfView:activeWindow]) {
+        [activeWindow addSubview:hideButton];
+        [hideButton loadSavedPosition];
+    }
+
+    [activeWindow bringSubviewToFront:hideButton];
+    if (hideButton.isElementsHidden) {
+        [hideButton hideUIElements];
+    }
+    updateClearButtonVisibility();
 }
 @implementation HideUIButton
 - (instancetype)initWithFrame:(CGRect)frame {
     self = [super initWithFrame:frame];
     if (self) {
+        self.accessibilityLabel = @"DYYYClearScreenButton";
         self.backgroundColor = [UIColor clearColor];
         self.layer.cornerRadius = frame.size.width / 2;
         self.layer.masksToBounds = YES;
@@ -423,6 +496,7 @@ void initTargetClassNames(void) {
         return;
     [self resetFadeTimer];
     if (!self.isElementsHidden) {
+        initTargetClassNames();
         [self hideUIElements];
         self.isElementsHidden = YES;
         self.selected = YES;
@@ -485,6 +559,7 @@ void initTargetClassNames(void) {
 }
 - (void)hideUIElements {
     DYYYPerformClearButtonMutation(^{
+        initTargetClassNames();
         [self.hiddenViewsList removeAllObjects];
         [self findAndHideViews:targetClassNames];
         [self hideAWEPlayInteractionProgressContainerView];
@@ -548,6 +623,7 @@ void initTargetClassNames(void) {
 }
 - (void)safeResetState {
     forceResetAllUIElements();
+    [self restoreAWEPlayInteractionProgressContainerView];
     self.isElementsHidden = NO;
     [self.hiddenViewsList removeAllObjects];
     self.selected = NO;

--- a/DYYYFloatSpeedButton.h
+++ b/DYYYFloatSpeedButton.h
@@ -10,6 +10,7 @@
 @property(nonatomic, strong) NSTimer *statusCheckTimer;
 @property(nonatomic, strong) NSTimer *fadeTimer;
 @property(nonatomic, assign) CGFloat originalAlpha;
++ (void)reloadConfiguration;
 - (void)saveButtonPosition;
 - (void)loadSavedPosition;
 - (void)resetButtonState;

--- a/DYYYFloatSpeedButton.m
+++ b/DYYYFloatSpeedButton.m
@@ -3,6 +3,8 @@
 #import "DYYYFloatSpeedButton.h"
 #import "DYYYUtils.h"
 #import <UIKit/UIKit.h>
+#import <float.h>
+#import <math.h>
 #import <objc/runtime.h>
 
 @class AWEFeedCellViewController;
@@ -61,7 +63,23 @@ static BOOL DYYYShouldHideSpeedButton(void) {
 
 NSArray *getSpeedOptions() {
     NSString *speedConfig = [[NSUserDefaults standardUserDefaults] stringForKey:@"DYYYSpeedSettings"] ?: @"1.0,1.25,1.5,2.0";
-    return [speedConfig componentsSeparatedByString:@","];
+    NSMutableArray<NSString *> *validSpeeds = [NSMutableArray array];
+    NSCharacterSet *whitespace = [NSCharacterSet whitespaceAndNewlineCharacterSet];
+
+    for (NSString *component in [speedConfig componentsSeparatedByString:@","]) {
+        NSString *trimmedValue = [component stringByTrimmingCharactersInSet:whitespace];
+        if (trimmedValue.length == 0) {
+            continue;
+        }
+
+        NSScanner *scanner = [NSScanner scannerWithString:trimmedValue];
+        double speed = 0.0;
+        if ([scanner scanDouble:&speed] && scanner.isAtEnd && isfinite(speed) && speed > 0.0) {
+            [validSpeeds addObject:trimmedValue];
+        }
+    }
+
+    return validSpeeds.count > 0 ? validSpeeds : @[ @"1.0", @"1.25", @"1.5", @"2.0" ];
 }
 
 NSInteger getCurrentSpeedIndex() {
@@ -92,6 +110,9 @@ void setCurrentSpeedIndex(NSInteger index) {
     if (speeds.count == 0)
         return;
     index = index % speeds.count;
+    if (index < 0) {
+        index += speeds.count;
+    }
 
     [[NSUserDefaults standardUserDefaults] setInteger:index forKey:@"DYYYCurrentSpeedIndex"];
 }
@@ -160,13 +181,41 @@ void hideSpeedButton(void) {
 }
 
 void updateSpeedButtonVisibility() {
-    if (!speedButton || !isFloatSpeedButtonEnabled)
+    if (!speedButton)
         return;
 
-    DYYYApplySpeedButtonHiddenState(speedButton, DYYYShouldHideSpeedButton());
+    DYYYApplySpeedButtonHiddenState(speedButton, !isFloatSpeedButtonEnabled || DYYYShouldHideSpeedButton());
 }
 
 @implementation FloatingSpeedButton
+
++ (void)reloadConfiguration {
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    isFloatSpeedButtonEnabled = [defaults boolForKey:@"DYYYEnableFloatSpeedButton"];
+    showSpeedX = [defaults boolForKey:@"DYYYSpeedButtonShowX"];
+
+    CGFloat configuredSize = [defaults floatForKey:@"DYYYSpeedButtonSize"];
+    if (configuredSize <= 0.0) {
+        configuredSize = 32.0;
+    }
+    speedButtonSize = MIN(MAX(configuredSize, 20.0), 60.0);
+
+    void (^applyBlock)(void) = ^{
+      if (speedButton && fabs(speedButton.bounds.size.width - speedButtonSize) > FLT_EPSILON) {
+          speedButton.bounds = CGRectMake(0, 0, speedButtonSize, speedButtonSize);
+          speedButton.layer.cornerRadius = speedButtonSize / 2.0;
+          [speedButton loadSavedPosition];
+      }
+      updateSpeedButtonUI();
+      updateSpeedButtonVisibility();
+    };
+
+    if ([NSThread isMainThread]) {
+        applyBlock();
+    } else {
+        dispatch_async(dispatch_get_main_queue(), applyBlock);
+    }
+}
 
 - (instancetype)initWithFrame:(CGRect)frame {
     self = [super initWithFrame:frame];
@@ -206,6 +255,9 @@ void updateSpeedButtonVisibility() {
     for (UIGestureRecognizer *recognizer in [self.gestureRecognizers copy]) {
         [self removeGestureRecognizer:recognizer];
     }
+    [self removeTarget:self action:@selector(handleTouchUpInside:) forControlEvents:UIControlEventTouchUpInside];
+    [self removeTarget:self action:@selector(handleTouchDown:) forControlEvents:UIControlEventTouchDown];
+    [self removeTarget:self action:@selector(handleTouchUpOutside:) forControlEvents:UIControlEventTouchUpOutside];
 
     UIPanGestureRecognizer *panGesture = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(handlePan:)];
     [self addGestureRecognizer:panGesture];
@@ -405,7 +457,13 @@ void updateSpeedButtonVisibility() {
     self.isLocked = [defaults boolForKey:@"DYYYSpeedButtonLocked"];
 
     if (centerXPercent > 0 && centerYPercent > 0 && self.superview) {
-        self.center = CGPointMake(centerXPercent * self.superview.bounds.size.width, centerYPercent * self.superview.bounds.size.height);
+        CGFloat halfWidth = self.bounds.size.width / 2.0;
+        CGFloat halfHeight = self.bounds.size.height / 2.0;
+        CGFloat centerX = centerXPercent * self.superview.bounds.size.width;
+        CGFloat centerY = centerYPercent * self.superview.bounds.size.height;
+        centerX = MAX(halfWidth, MIN(centerX, self.superview.bounds.size.width - halfWidth));
+        centerY = MAX(halfHeight, MIN(centerY, self.superview.bounds.size.height - halfHeight));
+        self.center = CGPointMake(centerX, centerY);
     }
 }
 
@@ -442,7 +500,6 @@ void updateSpeedButtonVisibility() {
 - (void)checkAndRecoverButtonStatus {
     if (!self.isResponding) {
         [self resetButtonState];
-        [self setupGestureRecognizers];
         self.isResponding = YES;
     }
 

--- a/DYYYSettingViewController.m
+++ b/DYYYSettingViewController.m
@@ -2,6 +2,7 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 #import "DYYYConstants.h"
+#import "DYYYFloatSpeedButton.h"
 
 typedef NS_ENUM(NSInteger, DYYYSettingItemType) { DYYYSettingItemTypeSwitch, DYYYSettingItemTypeTextField, DYYYSettingItemTypePicker };
 
@@ -736,6 +737,9 @@ typedef NS_ENUM(NSInteger, DYYYSettingItemType) { DYYYSettingItemTypeSwitch, DYY
     DYYYSettingItem *item = self.settingSections[indexPath.section][indexPath.row];
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
     [defaults setBool:sender.isOn forKey:item.key];
+    if ([item.key isEqualToString:@"DYYYEnableFloatSpeedButton"] || [item.key isEqualToString:@"DYYYSpeedButtonShowX"]) {
+        [FloatingSpeedButton reloadConfiguration];
+    }
 
     if (sender.isOn) {
         NSString *conflictingKey = nil;
@@ -756,6 +760,9 @@ typedef NS_ENUM(NSInteger, DYYYSettingItemType) { DYYYSettingItemTypeSwitch, DYY
     NSIndexPath *indexPath = [NSIndexPath indexPathForRow:textField.tag % 1000 inSection:textField.tag / 1000];
     DYYYSettingItem *item = self.settingSections[indexPath.section][indexPath.row];
     [[NSUserDefaults standardUserDefaults] setObject:textField.text forKey:item.key];
+    if ([item.key isEqualToString:@"DYYYSpeedSettings"] || [item.key isEqualToString:@"DYYYSpeedButtonSize"]) {
+        [FloatingSpeedButton reloadConfiguration];
+    }
 }
 
 - (void)headerTapped:(UIButton *)sender {

--- a/DYYYSettingViewController.m
+++ b/DYYYSettingViewController.m
@@ -2,6 +2,7 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 #import "DYYYConstants.h"
+#import "DYYYFloatClearButton.h"
 #import "DYYYFloatSpeedButton.h"
 
 typedef NS_ENUM(NSInteger, DYYYSettingItemType) { DYYYSettingItemTypeSwitch, DYYYSettingItemTypeTextField, DYYYSettingItemTypePicker };
@@ -740,6 +741,16 @@ typedef NS_ENUM(NSInteger, DYYYSettingItemType) { DYYYSettingItemTypeSwitch, DYY
     if ([item.key isEqualToString:@"DYYYEnableFloatSpeedButton"] || [item.key isEqualToString:@"DYYYSpeedButtonShowX"]) {
         [FloatingSpeedButton reloadConfiguration];
     }
+    if ([item.key isEqualToString:@"DYYYEnableFloatClearButton"] ||
+        [item.key isEqualToString:@"DYYYHideDanmaku"] ||
+        [item.key isEqualToString:@"DYYYRemoveTimeProgress"] ||
+        [item.key isEqualToString:@"DYYYHideTimeProgress"] ||
+        [item.key isEqualToString:@"DYYYHideSlider"] ||
+        [item.key isEqualToString:@"DYYYHideTabBar"] ||
+        [item.key isEqualToString:@"DYYYHideSpeed"] ||
+        [item.key isEqualToString:@"DYYYHideChapter"]) {
+        reloadClearButtonConfiguration();
+    }
 
     if (sender.isOn) {
         NSString *conflictingKey = nil;
@@ -762,6 +773,9 @@ typedef NS_ENUM(NSInteger, DYYYSettingItemType) { DYYYSettingItemTypeSwitch, DYY
     [[NSUserDefaults standardUserDefaults] setObject:textField.text forKey:item.key];
     if ([item.key isEqualToString:@"DYYYSpeedSettings"] || [item.key isEqualToString:@"DYYYSpeedButtonSize"]) {
         [FloatingSpeedButton reloadConfiguration];
+    }
+    if ([item.key isEqualToString:@"DYYYEnableFloatClearButtonSize"]) {
+        reloadClearButtonConfiguration();
     }
 }
 

--- a/DYYYSettingViewController.m
+++ b/DYYYSettingViewController.m
@@ -148,7 +148,7 @@ typedef NS_ENUM(NSInteger, DYYYSettingItemType) { DYYYSettingItemTypeSwitch, DYY
             [DYYYSettingItem itemWithTitle:@"推荐过滤热点" key:@"DYYYSkipHotSpot" type:DYYYSettingItemTypeSwitch],
             [DYYYSettingItem itemWithTitle:@"推荐过滤低赞" key:@"DYYYFilterLowLikes" type:DYYYSettingItemTypeTextField placeholder:@"填0关闭"],
             [DYYYSettingItem itemWithTitle:@"推荐视频时限" key:@"DYYYFilterTimeLimit" type:DYYYSettingItemTypeTextField placeholder:@"填0关闭，单位为天"],
-            [DYYYSettingItem itemWithTitle:@"推荐过滤HDR" key:@"DYYYFilterFeedHDR" type:DYYYSettingItemTypeSwitch],
+            [DYYYSettingItem itemWithTitle:@"全局HDR设置" key:@"DYYYHDRMode" type:DYYYSettingItemTypePicker],
             [DYYYSettingItem itemWithTitle:@"启用首页净化" key:@"DYYYEnablePure" type:DYYYSettingItemTypeSwitch],
             [DYYYSettingItem itemWithTitle:@"启用首页全屏" key:@"DYYYEnableFullScreen" type:DYYYSettingItemTypeSwitch],
             [DYYYSettingItem itemWithTitle:@"启用屏蔽广告" key:@"DYYYNoAds" type:DYYYSettingItemTypeSwitch],
@@ -167,7 +167,6 @@ typedef NS_ENUM(NSInteger, DYYYSettingItemType) { DYYYSettingItemTypeSwitch, DYY
             [DYYYSettingItem itemWithTitle:@"收藏二次确认" key:@"DYYYCollectTips" type:DYYYSettingItemTypeSwitch],
             [DYYYSettingItem itemWithTitle:@"默认直播画质" key:@"DYYYLiveQuality" type:DYYYSettingItemTypePicker],
             [DYYYSettingItem itemWithTitle:@"提高视频画质" key:@"DYYYEnableVideoHighestQuality" type:DYYYSettingItemTypeSwitch],
-            [DYYYSettingItem itemWithTitle:@"禁用全部视频图文HDR效果" key:@"DYYYDisableAllHDR" type:DYYYSettingItemTypeSwitch],
             [DYYYSettingItem itemWithTitle:@"禁用直播PCDN功能" key:@"DYYYDisableLivePCDN" type:DYYYSettingItemTypeSwitch]
         ],
         @[
@@ -433,6 +432,8 @@ typedef NS_ENUM(NSInteger, DYYYSettingItemType) { DYYYSettingItemTypeSwitch, DYY
     } else if ([key isEqualToString:@"DYYYLiveQuality"]) {
         // 直播清晰度选项
         return @[ @"蓝光帧彩", @"蓝光", @"超清", @"高清", @"标清", @"自动" ];
+    } else if ([key isEqualToString:@"DYYYHDRMode"]) {
+        return @[ @"关闭", @"全局屏蔽HDR效果", @"全局过滤HDR作品" ];
     }
     return @[];
 }
@@ -445,6 +446,8 @@ typedef NS_ENUM(NSInteger, DYYYSettingItemType) { DYYYSettingItemTypeSwitch, DYY
     } else if ([key isEqualToString:@"DYYYLiveQuality"]) {
         // 直播清晰度直接显示
         return value ?: @"自动";
+    } else if ([key isEqualToString:@"DYYYHDRMode"]) {
+        return value ?: @"关闭";
     }
     return [NSString stringWithFormat:@"%@", value];
 }
@@ -454,6 +457,8 @@ typedef NS_ENUM(NSInteger, DYYYSettingItemType) { DYYYSettingItemTypeSwitch, DYY
         return @1.0;
     } else if ([key isEqualToString:@"DYYYLiveQuality"]) {
         return @"自动";
+    } else if ([key isEqualToString:@"DYYYHDRMode"]) {
+        return @"关闭";
     }
     return nil;
 }
@@ -734,11 +739,7 @@ typedef NS_ENUM(NSInteger, DYYYSettingItemType) { DYYYSettingItemTypeSwitch, DYY
 
     if (sender.isOn) {
         NSString *conflictingKey = nil;
-        if ([item.key isEqualToString:@"DYYYFilterFeedHDR"]) {
-            conflictingKey = @"DYYYDisableAllHDR";
-        } else if ([item.key isEqualToString:@"DYYYDisableAllHDR"]) {
-            conflictingKey = @"DYYYFilterFeedHDR";
-        } else if ([item.key isEqualToString:@"DYYYHideLOTAnimationView"]) {
+        if ([item.key isEqualToString:@"DYYYHideLOTAnimationView"]) {
             conflictingKey = @"DYYYHideFollowPromptView";
         } else if ([item.key isEqualToString:@"DYYYHideFollowPromptView"]) {
             conflictingKey = @"DYYYHideLOTAnimationView";

--- a/DYYYSettings.xm
+++ b/DYYYSettings.xm
@@ -14,6 +14,7 @@
 #import "DYYYOptionsSelectionView.h"
 
 #import "DYYYConstants.h"
+#import "DYYYFloatClearButton.h"
 #import "DYYYFloatSpeedButton.h"
 #import "DYYYSettingsHelper.h"
 #import "DYYYUtils.h"
@@ -3119,7 +3120,7 @@ void showDYYYSettingsVC(UIViewController *rootVC, BOOL hasAgreed) {
       clearButtonSizeItem.colorStyle = 0;
       clearButtonSizeItem.isEnable = YES;
       clearButtonSizeItem.cellTappedBlock = ^{
-        NSString *currentValue = [NSString stringWithFormat:@"%.0f", currentClearButtonSize];
+        NSString *currentValue = clearButtonSizeItem.detail ?: @"40";
         [DYYYSettingsHelper showTextInputAlert:@"设置清屏按钮大小"
                                    defaultText:currentValue
                                    placeholder:@"请输入20-60之间的数值"
@@ -3130,6 +3131,7 @@ void showDYYYSettingsVC(UIViewController *rootVC, BOOL hasAgreed) {
                                            [[NSUserDefaults standardUserDefaults] setFloat:size forKey:@"DYYYEnableFloatClearButtonSize"];
                                            clearButtonSizeItem.detail = [NSString stringWithFormat:@"%.0f", (CGFloat)size];
                                            [clearButtonSizeItem refreshCell];
+                                           reloadClearButtonConfiguration();
                                        } else {
                                            [DYYYUtils showToast:@"请输入20-60之间的有效数值"];
                                        }
@@ -3209,13 +3211,33 @@ void showDYYYSettingsVC(UIViewController *rootVC, BOOL hasAgreed) {
           @"imageName" : @"ic_eyeslash_outlined_16"
       }];
       [clearButtonItems addObject:hideSpeedButton];
-      // 获取清屏按钮的当前开关状态
-      BOOL isEnabled = [DYYYSettingsHelper getUserDefaults:@"DYYYEnableFloatClearButton"];
+      NSMutableArray<AWESettingItemModel *> *clearDependentItems = [NSMutableArray array];
       for (AWESettingItemModel *item in clearButtonItems) {
-          if (item == enableClearButton) {
+          if (item != enableClearButton) {
+              [clearDependentItems addObject:item];
+          }
+      }
+      void (^refreshClearDependentItems)(void) = ^{
+        for (AWESettingItemModel *item in clearDependentItems) {
+            [DYYYSettingsHelper applyDependencyRulesForItem:item];
+            [item refreshCell];
+        }
+      };
+
+      refreshClearDependentItems();
+
+      for (AWESettingItemModel *item in clearButtonItems) {
+          void (^originalClearSwitchChangedBlock)(void) = item.switchChangedBlock;
+          if (!originalClearSwitchChangedBlock) {
               continue;
           }
-          item.isEnable = isEnabled;
+          item.switchChangedBlock = ^{
+            originalClearSwitchChangedBlock();
+            reloadClearButtonConfiguration();
+            if (item == enableClearButton) {
+                refreshClearDependentItems();
+            }
+          };
       }
 
       // 创建并组织所有section

--- a/DYYYSettings.xm
+++ b/DYYYSettings.xm
@@ -14,6 +14,7 @@
 #import "DYYYOptionsSelectionView.h"
 
 #import "DYYYConstants.h"
+#import "DYYYFloatSpeedButton.h"
 #import "DYYYSettingsHelper.h"
 #import "DYYYUtils.h"
 
@@ -2991,8 +2992,9 @@ void showDYYYSettingsVC(UIViewController *rootVC, BOOL hasAgreed) {
                                        // 保存用户输入的倍速值
                                        NSString *trimmedText = [text stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
                                        [[NSUserDefaults standardUserDefaults] setObject:trimmedText forKey:@"DYYYSpeedSettings"];
-speedSettingsItem.detail = trimmedText;
+                                       speedSettingsItem.detail = trimmedText;
                                        [speedSettingsItem refreshCell];
+                                       [FloatingSpeedButton reloadConfiguration];
                                      }
                                       onCancel:nil];
       };
@@ -3029,7 +3031,8 @@ speedSettingsItem.detail = trimmedText;
         BOOL newValue = !showXItem.isSwitchOn;
         showXItem.isSwitchOn = newValue;
         [[NSUserDefaults standardUserDefaults] setBool:newValue forKey:@"DYYYSpeedButtonShowX"];
-};
+        [FloatingSpeedButton reloadConfiguration];
+      };
       [speedButtonItems addObject:showXItem];
       // 添加按钮大小配置项
       AWESettingItemModel *buttonSizeItem = [[%c(AWESettingItemModel) alloc] init];
@@ -3044,7 +3047,7 @@ speedSettingsItem.detail = trimmedText;
       buttonSizeItem.colorStyle = 0;
       buttonSizeItem.isEnable = YES;
       buttonSizeItem.cellTappedBlock = ^{
-        NSString *currentValue = [NSString stringWithFormat:@"%.0f", currentButtonSize];
+        NSString *currentValue = buttonSizeItem.detail ?: @"32";
         [DYYYSettingsHelper showTextInputAlert:@"设置按钮大小"
                                    defaultText:currentValue
                                    placeholder:@"请输入20-60之间的数值"
@@ -3054,6 +3057,7 @@ speedSettingsItem.detail = trimmedText;
                                            [[NSUserDefaults standardUserDefaults] setFloat:size forKey:@"DYYYSpeedButtonSize"];
                                            buttonSizeItem.detail = [NSString stringWithFormat:@"%.0f", (CGFloat)size];
                                            [buttonSizeItem refreshCell];
+                                           [FloatingSpeedButton reloadConfiguration];
                                        } else {
                                            [DYYYUtils showToast:@"请输入20-60之间的有效数值"];
                                        }
@@ -3085,6 +3089,7 @@ speedSettingsItem.detail = trimmedText;
         if (originalSpeedSwitchChangedBlock) {
             originalSpeedSwitchChangedBlock();
         }
+        [FloatingSpeedButton reloadConfiguration];
         refreshSpeedDependentItems();
       };
 

--- a/DYYYSettings.xm
+++ b/DYYYSettings.xm
@@ -520,12 +520,6 @@ void showDYYYSettingsVC(UIViewController *rootVC, BOOL hasAgreed) {
             @"detail" : @"",
             @"cellType" : @6,
             @"imageName" : @"ic_squaretriangletwo_outlined_20"},
-          @{@"identifier" : @"DYYYDisableAllHDR",
-            @"title" : @"禁用全部视频图文HDR效果",
-            @"subTitle" : @"开启后全部视频图文将禁用 HDR 效果。与推荐过滤HDR不能同时打开。",
-            @"detail" : @"",
-            @"cellType" : @37,
-            @"imageName" : @"ic_sun_outlined"},
           @{@"identifier" : @"DYYYHideStatusbar",
             @"title" : @"隐藏系统顶栏",
             @"subTitle" : @"隐藏系统状态栏",
@@ -640,11 +634,11 @@ void showDYYYSettingsVC(UIViewController *rootVC, BOOL hasAgreed) {
               @"cellType" : @20,
               @"imageName" : @"ic_playertime_outlined_20"
           },
-          @{@"identifier" : @"DYYYFilterFeedHDR",
-            @"title" : @"推荐过滤HDR",
-            @"subTitle" : @"开启后推荐流会屏蔽 HDR 视频。与禁用全部视频图文HDR效果不能同时打开。",
-            @"detail" : @"",
-            @"cellType" : @37,
+          @{@"identifier" : @"DYYYHDRMode",
+            @"title" : @"全局HDR设置",
+            @"subTitle" : @"开启并选择后全局屏蔽HDR效果/过滤HDR作品。",
+            @"detail" : @"关闭",
+            @"cellType" : @26,
             @"imageName" : @"ic_sun_outlined"},
           @{@"identifier" : @"DYYYNoAds",
             @"title" : @"启用屏蔽广告",
@@ -762,6 +756,20 @@ void showDYYYSettingsVC(UIViewController *rootVC, BOOL hasAgreed) {
                   [item refreshCell];
                 };
                 [keywordListView show];
+              };
+          } else if ([item.identifier isEqualToString:@"DYYYHDRMode"]) {
+              NSString *savedMode = [[NSUserDefaults standardUserDefaults] stringForKey:@"DYYYHDRMode"] ?: @"关闭";
+              item.detail = savedMode;
+              item.cellTappedBlock = ^{
+                NSArray *options = @[ @"关闭", @"全局屏蔽HDR效果", @"全局过滤HDR作品" ];
+                [DYYYOptionsSelectionView showWithPreferenceKey:@"DYYYHDRMode"
+                                                   optionsArray:options
+                                                     headerText:@"选择 HDR 处理模式"
+                                                 onPresentingVC:topView()
+                                               selectionChanged:^(NSString *selectedValue) {
+                                                 item.detail = selectedValue;
+                                                 [item refreshCell];
+                                               }];
               };
           }
           [filterItems addObject:item];

--- a/DYYYSettingsHelper.m
+++ b/DYYYSettingsHelper.m
@@ -86,8 +86,6 @@
               @"DYYYSkipAllLive" : @[ @"DYYYSkipLive" ],
               @"DYYYHideEntry" : @[ @"DYYYRemoveEntry" ],
               @"DYYYRemoveEntry" : @[ @"DYYYHideEntry" ],
-              @"DYYYFilterFeedHDR" : @[ @"DYYYDisableAllHDR" ],
-              @"DYYYDisableAllHDR" : @[ @"DYYYFilterFeedHDR" ],
           },
 
           // ===== 互斥激活配置 =====


### PR DESCRIPTION
## 修复摘要

完善全局 HDR 处理策略，并修复快捷倍速、一键清屏、头像加号及头像光圈等功能在新版页面与播放控制结构下失效的问题。

## 具体修复

- 将“全局屏蔽 HDR”与“过滤 HDR 作品”合并为三态全局设置，支持关闭、全局屏蔽 HDR 效果和全局过滤 HDR 作品，并自动迁移旧开关配置。
- 补齐视频、图文、直播等场景的 HDR 处理；保留原生 HDR 解码及 HDR 转 SDR 链路，仅关闭亮度增强、SDR 转 HDR 和最终 EDR 输出，修复部分作品转为 SDR 时出现黑屏的问题。
- 扩大全局 HDR 作品过滤范围，并排除私信、消息详情及转发链路等不应过滤的场景。
- 适配新版播放控制器结构，恢复快捷倍速按钮及倍速切换；增强自定义倍速参数校验，并支持开关、显示样式、按钮大小和倍速配置即时生效。
- 修复一键清屏按钮在活动窗口切换及页面生命周期变化后失效的问题，恢复弹幕、进度条、底栏、章节等关联元素的隐藏与还原。
- 优化头像加号、关注动画及头像光圈的识别和隐藏逻辑，兼容静态图标、动画图层和新版头像控制器结构。

## 提交范围

本次请求基于最新上游 `main`，仅包含以下 5 个提交：

- `4577c20` 补齐 39.1.0 全场景 HDR 禁用与推荐过滤
- `56e5524` 合并全局 HDR 三态设置并修复 SDR 黑屏
- `04ccd16` 修复 39.1.0 快捷倍速按钮失效
- `8d30ea5` 优化头像加号与光圈隐藏逻辑
- `d430a8b` 修复 39.1.0 一键清屏按钮及下属功能失效

已核对 PR 差异，仅涉及对应功能源码文件，不包含本地未提交的 MonkeyDev 工程文件或构建产物。