### PR TITLE
完善一键清屏进度条处理与快捷倍速同步

### DIFF
--- a/DYYY.xm
+++ b/DYYY.xm
@@ -221,6 +221,7 @@ static BOOL DYYYShouldHandleSpeedFeatures(void) {
 
 static __weak AWEPlayInteractionViewController *dyyyActiveSpeedInteractionController = nil;
 static __weak AWEAwemeModel *dyyyCurrentSpeedAweme = nil;
+static NSString *dyyyLastAutoRestoredSpeedAwemeIdentifier = nil;
 
 static CGFloat DYYYViewControllerVisibilityScore(UIViewController *viewController) {
     if (!viewController || !viewController.isViewLoaded) {
@@ -258,6 +259,34 @@ static BOOL DYYYAwemeModelsMatch(AWEAwemeModel *lhs, AWEAwemeModel *rhs) {
     NSString *lhsItemID = lhs.itemID;
     NSString *rhsItemID = rhs.itemID;
     return lhsItemID.length > 0 && rhsItemID.length > 0 && [lhsItemID isEqualToString:rhsItemID];
+}
+
+static NSString *DYYYSpeedAwemeIdentifier(AWEAwemeModel *aweme) {
+    if (!aweme) {
+        return nil;
+    }
+    if (aweme.itemID.length > 0) {
+        return aweme.itemID;
+    }
+    return [NSString stringWithFormat:@"%p", aweme];
+}
+
+static void DYYYRestoreFloatSpeedButtonForAwemeIfNeeded(AWEAwemeModel *aweme) {
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    BOOL shouldAutoRestore = [defaults boolForKey:@"DYYYEnableFloatSpeedButton"] && [defaults boolForKey:@"DYYYAutoRestoreSpeed"];
+    if (!shouldAutoRestore) {
+        dyyyLastAutoRestoredSpeedAwemeIdentifier = nil;
+        return;
+    }
+
+    NSString *awemeIdentifier = DYYYSpeedAwemeIdentifier(aweme);
+    if (awemeIdentifier.length == 0 || [awemeIdentifier isEqualToString:dyyyLastAutoRestoredSpeedAwemeIdentifier]) {
+        return;
+    }
+
+    dyyyLastAutoRestoredSpeedAwemeIdentifier = [awemeIdentifier copy];
+    setCurrentSpeedIndex(0);
+    updateSpeedButtonUI();
 }
 
 static NSArray<AWEPlayInteractionViewController *> *DYYYSpeedInteractionControllers(AWEPlayInteractionViewController *preferredController) {
@@ -330,6 +359,7 @@ static void DYYYEnsureFloatSpeedButton(AWEPlayInteractionViewController *interac
 
     dyyyActiveSpeedInteractionController = currentController;
     dyyyInteractionViewVisible = YES;
+    DYYYRestoreFloatSpeedButtonForAwemeIfNeeded(currentController.model);
 
     if (!speedButton) {
         CGRect windowBounds = keyWindow.bounds;
@@ -488,11 +518,7 @@ static void DYYYHandleCurrentSpeedAwemeChanged(id aweme) {
         return;
     }
 
-    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-    if ([defaults boolForKey:@"DYYYEnableFloatSpeedButton"] && [defaults boolForKey:@"DYYYAutoRestoreSpeed"]) {
-        setCurrentSpeedIndex(0);
-        updateSpeedButtonUI();
-    }
+    DYYYRestoreFloatSpeedButtonForAwemeIfNeeded(dyyyCurrentSpeedAweme);
 
     DYYYBindAndApplyCurrentPlaybackSpeed();
     dispatch_async(dispatch_get_main_queue(), ^{
@@ -8225,6 +8251,8 @@ static Class tabBarButtonClass = nil;
 - (void)viewWillAppear:(BOOL)animated {
     %orig;
     isInPlayInteractionVC = YES;
+    dyyyCurrentSpeedAweme = self.model;
+    DYYYRestoreFloatSpeedButtonForAwemeIfNeeded(self.model);
     DYYYEnsureFloatSpeedButton(self);
     reloadClearButtonConfiguration();
 }

--- a/DYYY.xm
+++ b/DYYY.xm
@@ -220,10 +220,105 @@ static BOOL DYYYShouldHandleSpeedFeatures(void) {
 }
 
 static __weak AWEPlayInteractionViewController *dyyyActiveSpeedInteractionController = nil;
+static __weak AWEAwemeModel *dyyyCurrentSpeedAweme = nil;
+
+static CGFloat DYYYViewControllerVisibilityScore(UIViewController *viewController) {
+    if (!viewController || !viewController.isViewLoaded) {
+        return -1.0;
+    }
+
+    UIView *view = viewController.view;
+    UIWindow *window = view.window;
+    if (!window || view.hidden || view.alpha <= 0.01 || CGRectIsEmpty(view.bounds)) {
+        return -1.0;
+    }
+
+    CGRect frameInWindow = [view convertRect:view.bounds toView:window];
+    CGRect visibleFrame = CGRectIntersection(frameInWindow, window.bounds);
+    if (CGRectIsNull(visibleFrame) || CGRectIsEmpty(visibleFrame)) {
+        return -1.0;
+    }
+
+    CGFloat visibleArea = CGRectGetWidth(visibleFrame) * CGRectGetHeight(visibleFrame);
+    CGFloat totalArea = CGRectGetWidth(frameInWindow) * CGRectGetHeight(frameInWindow);
+    CGFloat visibleRatio = totalArea > 0.0 ? visibleArea / totalArea : 0.0;
+    CGPoint windowCenter = CGPointMake(CGRectGetMidX(window.bounds), CGRectGetMidY(window.bounds));
+    CGFloat centerBonus = CGRectContainsPoint(visibleFrame, windowCenter) ? 1000000000.0 : 0.0;
+    return centerBonus + visibleRatio * 1000000.0 + visibleArea;
+}
+
+static BOOL DYYYAwemeModelsMatch(AWEAwemeModel *lhs, AWEAwemeModel *rhs) {
+    if (!lhs || !rhs) {
+        return NO;
+    }
+    if (lhs == rhs) {
+        return YES;
+    }
+
+    NSString *lhsItemID = lhs.itemID;
+    NSString *rhsItemID = rhs.itemID;
+    return lhsItemID.length > 0 && rhsItemID.length > 0 && [lhsItemID isEqualToString:rhsItemID];
+}
+
+static NSArray<AWEPlayInteractionViewController *> *DYYYSpeedInteractionControllers(AWEPlayInteractionViewController *preferredController) {
+    NSMutableArray<AWEPlayInteractionViewController *> *controllers = [NSMutableArray array];
+    Class interactionControllerClass = NSClassFromString(@"AWEPlayInteractionViewController");
+    UIWindow *window = [DYYYUtils getActiveWindow];
+    UIViewController *rootViewController = window.rootViewController;
+    while (rootViewController.presentedViewController) {
+        rootViewController = rootViewController.presentedViewController;
+    }
+
+    for (UIViewController *viewController in rootViewController ? findViewControllersInHierarchy(rootViewController) : @[]) {
+        if (interactionControllerClass && [viewController isKindOfClass:interactionControllerClass]) {
+            [controllers addObject:(AWEPlayInteractionViewController *)viewController];
+        }
+    }
+
+    if (preferredController && ![controllers containsObject:preferredController]) {
+        [controllers addObject:preferredController];
+    }
+    return controllers;
+}
+
+static AWEPlayInteractionViewController *DYYYResolveCurrentSpeedInteractionController(AWEPlayInteractionViewController *preferredController) {
+    AWEPlayInteractionViewController *bestModelMatch = nil;
+    AWEPlayInteractionViewController *bestVisibleController = nil;
+    CGFloat bestModelMatchScore = -1.0;
+    CGFloat bestVisibleScore = -1.0;
+
+    for (AWEPlayInteractionViewController *controller in DYYYSpeedInteractionControllers(preferredController)) {
+        CGFloat visibilityScore = DYYYViewControllerVisibilityScore(controller);
+        if (visibilityScore < 0.0) {
+            continue;
+        }
+
+        if (visibilityScore > bestVisibleScore) {
+            bestVisibleScore = visibilityScore;
+            bestVisibleController = controller;
+        }
+        if (DYYYAwemeModelsMatch(controller.model, dyyyCurrentSpeedAweme) && visibilityScore > bestModelMatchScore) {
+            bestModelMatchScore = visibilityScore;
+            bestModelMatch = controller;
+        }
+    }
+
+    return bestModelMatch ?: bestVisibleController;
+}
+
+id DYYYCurrentSpeedInteractionController(void) {
+    return DYYYResolveCurrentSpeedInteractionController(dyyyActiveSpeedInteractionController);
+}
 
 static void DYYYEnsureFloatSpeedButton(AWEPlayInteractionViewController *interactionController) {
     [FloatingSpeedButton reloadConfiguration];
-    if (!isFloatSpeedButtonEnabled || !interactionController) {
+    if (!isFloatSpeedButtonEnabled) {
+        updateSpeedButtonVisibility();
+        return;
+    }
+
+    AWEPlayInteractionViewController *currentController = DYYYResolveCurrentSpeedInteractionController(interactionController);
+    if (!currentController) {
         updateSpeedButtonVisibility();
         return;
     }
@@ -233,14 +328,17 @@ static void DYYYEnsureFloatSpeedButton(AWEPlayInteractionViewController *interac
         return;
     }
 
+    dyyyActiveSpeedInteractionController = currentController;
+    dyyyInteractionViewVisible = YES;
+
     if (!speedButton) {
         CGRect windowBounds = keyWindow.bounds;
         CGRect initialFrame = CGRectMake((windowBounds.size.width - speedButtonSize) / 2.0, (windowBounds.size.height - speedButtonSize) / 2.0, speedButtonSize, speedButtonSize);
         speedButton = [[FloatingSpeedButton alloc] initWithFrame:initialFrame];
-        speedButton.interactionController = interactionController;
+        speedButton.interactionController = currentController;
         updateSpeedButtonUI();
-    } else if (speedButton.interactionController != interactionController) {
-        speedButton.interactionController = interactionController;
+    } else if (speedButton.interactionController != currentController) {
+        speedButton.interactionController = currentController;
         [speedButton resetButtonState];
     }
 
@@ -268,6 +366,11 @@ static BOOL DYYYSetPlaybackRateOnTarget(id target, double speed) {
 }
 
 static BOOL DYYYApplyPlaybackSpeed(AWEPlayInteractionViewController *interactionController, double speed) {
+    interactionController = DYYYResolveCurrentSpeedInteractionController(interactionController);
+    if (!interactionController) {
+        return NO;
+    }
+
     Protocol *speedControllerProtocol = NSProtocolFromString(@"AWEFastSpeedControllerProtocol");
     if (speedControllerProtocol && [interactionController respondsToSelector:@selector(controllerByProtocol:)]) {
         @try {
@@ -292,17 +395,109 @@ static BOOL DYYYApplyPlaybackSpeed(AWEPlayInteractionViewController *interaction
         rootViewController = rootViewController.presentedViewController;
     }
 
+    UIViewController *bestPlayerViewController = nil;
+    CGFloat bestPlayerVisibilityScore = -1.0;
     for (UIViewController *viewController in rootViewController ? findViewControllersInHierarchy(rootViewController) : @[]) {
         if ([viewController isKindOfClass:NSClassFromString(@"AWEAwemePlayVideoViewController")] ||
             [viewController isKindOfClass:NSClassFromString(@"AWEDPlayerFeedPlayerViewController")] ||
             [viewController isKindOfClass:NSClassFromString(@"AWEDPlayerViewController_Merge")]) {
-            if (DYYYSetPlaybackRateOnTarget(viewController, speed)) {
-                return YES;
+            CGFloat visibilityScore = DYYYViewControllerVisibilityScore(viewController);
+            if (visibilityScore > bestPlayerVisibilityScore) {
+                bestPlayerVisibilityScore = visibilityScore;
+                bestPlayerViewController = viewController;
             }
         }
     }
 
-    return NO;
+    return DYYYSetPlaybackRateOnTarget(bestPlayerViewController, speed);
+}
+
+static double DYYYConfiguredPlaybackSpeed(void) {
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    if ([defaults boolForKey:@"DYYYEnableFloatSpeedButton"]) {
+        return getCurrentSpeed();
+    }
+
+    if ([defaults boolForKey:@"DYYYUserAgreementAccepted"]) {
+        double defaultSpeed = [defaults doubleForKey:@"DYYYDefaultSpeed"];
+        if (isfinite(defaultSpeed) && defaultSpeed > 0.0) {
+            return defaultSpeed;
+        }
+    }
+    return 1.0;
+}
+
+static double DYYYPreparedPlaybackSpeed(void) {
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    if ([defaults boolForKey:@"DYYYEnableFloatSpeedButton"] && [defaults boolForKey:@"DYYYAutoRestoreSpeed"]) {
+        NSArray *speeds = getSpeedOptions();
+        if (speeds.count > 0) {
+            double defaultSpeed = [speeds.firstObject doubleValue];
+            if (isfinite(defaultSpeed) && defaultSpeed > 0.0) {
+                return defaultSpeed;
+            }
+        }
+        return 1.0;
+    }
+    return DYYYConfiguredPlaybackSpeed();
+}
+
+static void DYYYApplyPreparedPlaybackSpeedToPlayer(id playerViewController) {
+    if (!DYYYShouldHandleSpeedFeatures() || !playerViewController) {
+        return;
+    }
+
+    double speed = DYYYPreparedPlaybackSpeed();
+    void (^applyBlock)(void) = ^{
+      DYYYSetPlaybackRateOnTarget(playerViewController, speed);
+    };
+    if ([NSThread isMainThread]) {
+        applyBlock();
+    } else {
+        dispatch_async(dispatch_get_main_queue(), applyBlock);
+    }
+}
+
+static void DYYYBindAndApplyCurrentPlaybackSpeed(void) {
+    if (!DYYYShouldHandleSpeedFeatures()) {
+        return;
+    }
+
+    AWEPlayInteractionViewController *currentController = DYYYResolveCurrentSpeedInteractionController(nil);
+    if (!currentController) {
+        return;
+    }
+
+    DYYYEnsureFloatSpeedButton(currentController);
+    DYYYApplyPlaybackSpeed(currentController, DYYYConfiguredPlaybackSpeed());
+}
+
+static void DYYYHandleCurrentSpeedAwemeChanged(id aweme) {
+    if (![NSThread isMainThread]) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+          DYYYHandleCurrentSpeedAwemeChanged(aweme);
+        });
+        return;
+    }
+
+    Class awemeClass = NSClassFromString(@"AWEAwemeModel");
+    if (awemeClass && [aweme isKindOfClass:awemeClass]) {
+        dyyyCurrentSpeedAweme = (AWEAwemeModel *)aweme;
+    }
+    if (!DYYYShouldHandleSpeedFeatures()) {
+        return;
+    }
+
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    if ([defaults boolForKey:@"DYYYEnableFloatSpeedButton"] && [defaults boolForKey:@"DYYYAutoRestoreSpeed"]) {
+        setCurrentSpeedIndex(0);
+        updateSpeedButtonUI();
+    }
+
+    DYYYBindAndApplyCurrentPlaybackSpeed();
+    dispatch_async(dispatch_get_main_queue(), ^{
+      DYYYBindAndApplyCurrentPlaybackSpeed();
+    });
 }
 
 @interface AWEFeedProgressSlider (DYYYProgressLabel)
@@ -8030,8 +8225,6 @@ static Class tabBarButtonClass = nil;
 - (void)viewWillAppear:(BOOL)animated {
     %orig;
     isInPlayInteractionVC = YES;
-    dyyyActiveSpeedInteractionController = self;
-    dyyyInteractionViewVisible = YES;
     DYYYEnsureFloatSpeedButton(self);
     reloadClearButtonConfiguration();
 }
@@ -8040,8 +8233,6 @@ static Class tabBarButtonClass = nil;
     %orig;
 
     if (self.view.window && !self.view.hidden) {
-        dyyyActiveSpeedInteractionController = self;
-        dyyyInteractionViewVisible = YES;
         DYYYEnsureFloatSpeedButton(self);
         reloadClearButtonConfiguration();
     } else {
@@ -8133,10 +8324,18 @@ static Class tabBarButtonClass = nil;
 - (void)viewDidDisappear:(BOOL)animated {
     %orig;
     if (dyyyActiveSpeedInteractionController == self) {
-        dyyyActiveSpeedInteractionController = nil;
-        dyyyInteractionViewVisible = NO;
-        dyyyCommentViewVisible = self.isCommentVCShowing;
-        updateSpeedButtonVisibility();
+        AWEPlayInteractionViewController *replacementController = DYYYResolveCurrentSpeedInteractionController(nil);
+        if (replacementController && replacementController != self) {
+            DYYYEnsureFloatSpeedButton(replacementController);
+        } else {
+            dyyyActiveSpeedInteractionController = nil;
+            dyyyInteractionViewVisible = NO;
+            dyyyCommentViewVisible = self.isCommentVCShowing;
+            updateSpeedButtonVisibility();
+            dispatch_async(dispatch_get_main_queue(), ^{
+              DYYYEnsureFloatSpeedButton(nil);
+            });
+        }
         updateClearButtonVisibility();
     }
 }
@@ -8172,7 +8371,11 @@ static Class tabBarButtonClass = nil;
                            completion:nil];
         }];
 
-    if (!DYYYApplyPlaybackSpeed(self, newSpeed)) {
+    AWEPlayInteractionViewController *currentController = DYYYResolveCurrentSpeedInteractionController(self);
+    if (currentController) {
+        speedButton.interactionController = currentController;
+    }
+    if (!DYYYApplyPlaybackSpeed(currentController, newSpeed)) {
         [DYYYUtils showToast:@"无法找到视频控制器"];
     }
 }
@@ -8201,25 +8404,7 @@ static Class tabBarButtonClass = nil;
 
 - (void)setIsAutoPlay:(BOOL)arg0 {
     %orig(arg0);
-    if (!DYYYShouldHandleSpeedFeatures()) {
-        return;
-    }
-    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-      if ([[NSUserDefaults standardUserDefaults] boolForKey:@"DYYYUserAgreementAccepted"]) {
-          float defaultSpeed = [[NSUserDefaults standardUserDefaults] floatForKey:@"DYYYDefaultSpeed"];
-          if (defaultSpeed > 0 && defaultSpeed != 1) {
-              dispatch_async(dispatch_get_main_queue(), ^{
-                [self setVideoControllerPlaybackRate:defaultSpeed];
-              });
-          }
-      }
-      float speed = getCurrentSpeed();
-      if (speed != 1.0) {
-          dispatch_async(dispatch_get_main_queue(), ^{
-            [self adjustPlaybackSpeed:speed];
-          });
-      }
-    });
+    DYYYApplyPreparedPlaybackSpeedToPlayer(self);
 }
 
 - (void)prepareForDisplay {
@@ -8228,14 +8413,7 @@ static Class tabBarButtonClass = nil;
         return;
     }
 
-    BOOL autoRestoreSpeed = [[NSUserDefaults standardUserDefaults] boolForKey:@"DYYYAutoRestoreSpeed"];
-    if (autoRestoreSpeed) {
-        setCurrentSpeedIndex(0);
-    }
-    float speed = getCurrentSpeed();
-    if (speed != 1.0) {
-        [self adjustPlaybackSpeed:speed];
-    }
+    DYYYApplyPreparedPlaybackSpeedToPlayer(self);
     updateSpeedButtonUI();
 }
 
@@ -8269,25 +8447,7 @@ static Class tabBarButtonClass = nil;
 
 - (void)setIsAutoPlay:(BOOL)arg0 {
     %orig(arg0);
-    if (!DYYYShouldHandleSpeedFeatures()) {
-        return;
-    }
-    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-      if ([[NSUserDefaults standardUserDefaults] boolForKey:@"DYYYUserAgreementAccepted"]) {
-          float defaultSpeed = [[NSUserDefaults standardUserDefaults] floatForKey:@"DYYYDefaultSpeed"];
-          if (defaultSpeed > 0 && defaultSpeed != 1) {
-              dispatch_async(dispatch_get_main_queue(), ^{
-                [self setVideoControllerPlaybackRate:defaultSpeed];
-              });
-          }
-      }
-      float speed = getCurrentSpeed();
-      if (speed != 1.0) {
-          dispatch_async(dispatch_get_main_queue(), ^{
-            [self adjustPlaybackSpeed:speed];
-          });
-      }
-    });
+    DYYYApplyPreparedPlaybackSpeedToPlayer(self);
 }
 
 - (void)prepareForDisplay {
@@ -8295,14 +8455,7 @@ static Class tabBarButtonClass = nil;
     if (!DYYYShouldHandleSpeedFeatures()) {
         return;
     }
-    BOOL autoRestoreSpeed = [[NSUserDefaults standardUserDefaults] boolForKey:@"DYYYAutoRestoreSpeed"];
-    if (autoRestoreSpeed) {
-        setCurrentSpeedIndex(0);
-    }
-    float speed = getCurrentSpeed();
-    if (speed != 1.0) {
-        [self adjustPlaybackSpeed:speed];
-    }
+    DYYYApplyPreparedPlaybackSpeedToPlayer(self);
     updateSpeedButtonUI();
 }
 
@@ -8336,25 +8489,7 @@ static Class tabBarButtonClass = nil;
 
 - (void)setIsAutoPlay:(BOOL)arg0 {
     %orig(arg0);
-    if (!DYYYShouldHandleSpeedFeatures()) {
-        return;
-    }
-    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-      if ([[NSUserDefaults standardUserDefaults] boolForKey:@"DYYYUserAgreementAccepted"]) {
-          float defaultSpeed = [[NSUserDefaults standardUserDefaults] floatForKey:@"DYYYDefaultSpeed"];
-          if (defaultSpeed > 0 && defaultSpeed != 1) {
-              dispatch_async(dispatch_get_main_queue(), ^{
-                [self setVideoControllerPlaybackRate:defaultSpeed];
-              });
-          }
-      }
-      float speed = getCurrentSpeed();
-      if (speed != 1.0) {
-          dispatch_async(dispatch_get_main_queue(), ^{
-            [self adjustPlaybackSpeed:speed];
-          });
-      }
-    });
+    DYYYApplyPreparedPlaybackSpeedToPlayer(self);
 }
 
 - (void)prepareForDisplay {
@@ -8362,14 +8497,7 @@ static Class tabBarButtonClass = nil;
     if (!DYYYShouldHandleSpeedFeatures()) {
         return;
     }
-    BOOL autoRestoreSpeed = [[NSUserDefaults standardUserDefaults] boolForKey:@"DYYYAutoRestoreSpeed"];
-    if (autoRestoreSpeed) {
-        setCurrentSpeedIndex(0);
-    }
-    float speed = getCurrentSpeed();
-    if (speed != 1.0) {
-        [self adjustPlaybackSpeed:speed];
-    }
+    DYYYApplyPreparedPlaybackSpeedToPlayer(self);
     updateSpeedButtonUI();
 }
 
@@ -8481,6 +8609,7 @@ static Class tabBarButtonClass = nil;
         [hideButton hideUIElements];
     }
     %orig;
+    DYYYHandleCurrentSpeedAwemeChanged(arg1);
 }
 
 - (void)viewWillLayoutSubviews {

--- a/DYYY.xm
+++ b/DYYY.xm
@@ -1823,6 +1823,7 @@ static void DYYYDisableExtendedRangeForMetalLayer(CAMetalLayer *metalLayer) {
 %hook AWEPlayInteractionProgressContainerView
 - (void)layoutSubviews {
     %orig;
+    DYYYApplyFloatClearProgressStateToView(self);
 
     if (![[NSUserDefaults standardUserDefaults] boolForKey:@"DYYYEnableFullScreen"]) {
         return;
@@ -1849,6 +1850,11 @@ static void DYYYDisableExtendedRangeForMetalLayer(CAMetalLayer *metalLayer) {
 %end
 
 %hook AWEFeedProgressSlider
+
+- (void)layoutSubviews {
+    %orig;
+    DYYYApplyFloatClearProgressStateToView(self);
+}
 
 - (void)setAlpha:(CGFloat)alpha {
     if (DYYYGetBool(@"DYYYShowScheduleDisplay")) {
@@ -9580,6 +9586,7 @@ static NSString *const kHideRecentUsersKey = @"DYYYHideSidebarRecentUsers";
 
 - (void)layoutSubviews {
     %orig;
+    DYYYApplyFloatClearProgressStateToView(self);
 
     if (![[NSUserDefaults standardUserDefaults] boolForKey:@"DYYYEnableFullScreen"]) {
         return;

--- a/DYYYFloatClearButton.h
+++ b/DYYYFloatClearButton.h
@@ -24,6 +24,7 @@ void showClearButton(void);
 void hideClearButton(void);
 void initTargetClassNames(void);
 void reloadClearButtonConfiguration(void);
+void DYYYApplyFloatClearProgressStateToView(UIView *view);
 
 #ifdef __cplusplus
 }

--- a/DYYYFloatClearButton.xm
+++ b/DYYYFloatClearButton.xm
@@ -11,6 +11,7 @@
 #import <UIKit/UIKit.h>
 #import <float.h>
 #import <math.h>
+#import <objc/runtime.h>
 #import <signal.h>
 
 void updateClearButtonVisibility(void);
@@ -54,11 +55,117 @@ HideUIButton *hideButton = nil;
 BOOL isAppInTransition = NO;
 NSArray *targetClassNames;
 static NSUInteger dyyyTargetClassConfiguration = NSUIntegerMax;
-static CGFloat DYGetGlobalAlpha(void) {
-    NSString *value = [[NSUserDefaults standardUserDefaults] stringForKey:@"DYYYGlobalTransparency"];
-    CGFloat a = value.length ? value.floatValue : 1.0;
-    return (a >= 0.0 && a <= 1.0) ? a : 1.0;
+
+typedef NS_ENUM(NSInteger, DYYYClearProgressMode) {
+    DYYYClearProgressModeNone = 0,
+    DYYYClearProgressModeRemove,
+    DYYYClearProgressModeHide,
+};
+
+static char dyyyProgressModeKey;
+static char dyyyProgressOriginalHiddenKey;
+static char dyyyProgressOriginalInteractionKey;
+static char dyyyProgressOriginalLayerOpacityKey;
+
+static DYYYClearProgressMode DYYYCurrentClearProgressMode(void) {
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    if ([defaults boolForKey:@"DYYYRemoveTimeProgress"]) {
+        return DYYYClearProgressModeRemove;
+    }
+    if ([defaults boolForKey:@"DYYYHideTimeProgress"]) {
+        return DYYYClearProgressModeHide;
+    }
+    return DYYYClearProgressModeNone;
 }
+
+static BOOL DYYYIsClearProgressView(UIView *view) {
+    static NSArray<NSString *> *classNames;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+      classNames = @[
+          @"AWEPlayInteractionProgressContainerView",
+          @"AWEDPlayerProgressContainerView",
+          @"AWEFeedProgressSlider",
+          @"AWEFeedProgressSliderForLongPress",
+          @"AWEFakeProgressSliderView",
+          @"AWEProgressContainerView",
+          @"AWEProgressPlayBackSlider",
+      ];
+    });
+
+    for (NSString *className in classNames) {
+        Class progressClass = NSClassFromString(className);
+        if (progressClass && [view isKindOfClass:progressClass]) {
+            return YES;
+        }
+    }
+    return NO;
+}
+
+static void DYYYRestoreClearProgressViewState(UIView *view) {
+    NSNumber *appliedMode = objc_getAssociatedObject(view, &dyyyProgressModeKey);
+    if (!appliedMode) {
+        return;
+    }
+
+    NSNumber *originalLayerOpacity = objc_getAssociatedObject(view, &dyyyProgressOriginalLayerOpacityKey);
+    if (originalLayerOpacity) {
+        view.layer.opacity = originalLayerOpacity.floatValue;
+    }
+
+    if (appliedMode.integerValue == DYYYClearProgressModeRemove) {
+        NSNumber *originalHidden = objc_getAssociatedObject(view, &dyyyProgressOriginalHiddenKey);
+        NSNumber *originalInteraction = objc_getAssociatedObject(view, &dyyyProgressOriginalInteractionKey);
+        if (originalHidden) {
+            view.hidden = originalHidden.boolValue;
+        }
+        if (originalInteraction) {
+            view.userInteractionEnabled = originalInteraction.boolValue;
+        }
+    }
+
+    objc_setAssociatedObject(view, &dyyyProgressModeKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(view, &dyyyProgressOriginalHiddenKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(view, &dyyyProgressOriginalInteractionKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(view, &dyyyProgressOriginalLayerOpacityKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+static void DYYYApplyClearProgressViewState(UIView *view, DYYYClearProgressMode mode) {
+    NSNumber *appliedMode = objc_getAssociatedObject(view, &dyyyProgressModeKey);
+    if (appliedMode && appliedMode.integerValue != mode) {
+        DYYYRestoreClearProgressViewState(view);
+        appliedMode = nil;
+    }
+
+    if (mode == DYYYClearProgressModeNone) {
+        DYYYRestoreClearProgressViewState(view);
+        return;
+    }
+
+    if (!appliedMode) {
+        objc_setAssociatedObject(view, &dyyyProgressModeKey, @(mode), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        objc_setAssociatedObject(view, &dyyyProgressOriginalLayerOpacityKey, @(view.layer.opacity), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        if (mode == DYYYClearProgressModeRemove) {
+            objc_setAssociatedObject(view, &dyyyProgressOriginalHiddenKey, @(view.hidden), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+            objc_setAssociatedObject(view, &dyyyProgressOriginalInteractionKey, @(view.userInteractionEnabled), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        }
+    }
+
+    view.layer.opacity = 0.0f;
+    if (mode == DYYYClearProgressModeRemove) {
+        view.hidden = YES;
+        view.userInteractionEnabled = NO;
+    }
+}
+
+void DYYYApplyFloatClearProgressStateToView(UIView *view) {
+    if (!view || !DYYYIsClearProgressView(view)) {
+        return;
+    }
+    DYYYClearProgressMode mode = hideButton.isElementsHidden ? DYYYCurrentClearProgressMode() : DYYYClearProgressModeNone;
+    DYYYApplyClearProgressViewState(view, mode);
+}
+
 static void findViewsOfClassHelper(UIView *view, Class viewClass, NSMutableArray *result) {
     if ([view isKindOfClass:viewClass]) {
         [result addObject:view];
@@ -506,9 +613,9 @@ void reloadClearButtonConfiguration(void) {
             hideSpeedButton();
         }
     } else {
+        self.isElementsHidden = NO;
         forceResetAllUIElements();
         [self restoreAWEPlayInteractionProgressContainerView];
-        self.isElementsHidden = NO;
         [self.hiddenViewsList removeAllObjects];
         self.selected = NO;
 
@@ -520,23 +627,16 @@ void reloadClearButtonConfiguration(void) {
 }
 
 - (void)restoreAWEPlayInteractionProgressContainerView {
-    if ([[NSUserDefaults standardUserDefaults] boolForKey:@"DYYYRemoveTimeProgress"] || [[NSUserDefaults standardUserDefaults] boolForKey:@"DYYYHideTimeProgress"]) {
-        DYYYPerformClearButtonMutation(^{
-            for (UIWindow *window in [UIApplication sharedApplication].windows) {
-                [self recursivelyRestoreAWEPlayInteractionProgressContainerViewInView:window];
-            }
-        });
-    }
+    DYYYPerformClearButtonMutation(^{
+        for (UIWindow *window in [UIApplication sharedApplication].windows) {
+            [self recursivelyRestoreAWEPlayInteractionProgressContainerViewInView:window];
+        }
+    });
 }
 
 - (void)recursivelyRestoreAWEPlayInteractionProgressContainerViewInView:(UIView *)view {
-    if ([view isKindOfClass:NSClassFromString(@"AWEPlayInteractionProgressContainerView")]) {
-        if ([[NSUserDefaults standardUserDefaults] boolForKey:@"DYYYRemoveTimeProgress"]) {
-            view.hidden = NO;
-        } else {
-            view.alpha = DYGetGlobalAlpha();
-        }
-        return;
+    if (DYYYIsClearProgressView(view)) {
+        DYYYRestoreClearProgressViewState(view);
     }
 
     for (UIView *subview in view.subviews) {
@@ -573,23 +673,15 @@ void reloadClearButtonConfiguration(void) {
 }
 
 - (void)hideAWEPlayInteractionProgressContainerView {
-    if ([[NSUserDefaults standardUserDefaults] boolForKey:@"DYYYRemoveTimeProgress"] || [[NSUserDefaults standardUserDefaults] boolForKey:@"DYYYHideTimeProgress"]) {
-        for (UIWindow *window in [UIApplication sharedApplication].windows) {
-            [self recursivelyHideAWEPlayInteractionProgressContainerViewInView:window];
-        }
+    for (UIWindow *window in [UIApplication sharedApplication].windows) {
+        [self recursivelyHideAWEPlayInteractionProgressContainerViewInView:window];
     }
 }
 
 - (void)recursivelyHideAWEPlayInteractionProgressContainerViewInView:(UIView *)view {
-    if ([view isKindOfClass:NSClassFromString(@"AWEPlayInteractionProgressContainerView")]) {
-        if ([[NSUserDefaults standardUserDefaults] boolForKey:@"DYYYRemoveTimeProgress"]) {
-            view.hidden = YES;
-        } else {
-            view.tag = DYYY_IGNORE_GLOBAL_ALPHA_TAG;
-            view.alpha = 0.0;
-        }
+    if (DYYYIsClearProgressView(view)) {
+        DYYYApplyClearProgressViewState(view, DYYYCurrentClearProgressMode());
         [self.hiddenViewsList addObject:view];
-        return;
     }
 
     for (UIView *subview in view.subviews) {
@@ -622,9 +714,9 @@ void reloadClearButtonConfiguration(void) {
     }
 }
 - (void)safeResetState {
+    self.isElementsHidden = NO;
     forceResetAllUIElements();
     [self restoreAWEPlayInteractionProgressContainerView];
-    self.isElementsHidden = NO;
     [self.hiddenViewsList removeAllObjects];
     self.selected = NO;
 

--- a/DYYYFloatSpeedButton.h
+++ b/DYYYFloatSpeedButton.h
@@ -42,6 +42,7 @@ extern NSInteger getCurrentSpeedIndex(void);
 extern void setCurrentSpeedIndex(NSInteger index);
 extern void updateSpeedButtonUI(void);
 extern void updateSpeedButtonVisibility(void);
+extern id DYYYCurrentSpeedInteractionController(void);
 
 #ifdef __cplusplus
 }

--- a/DYYYFloatSpeedButton.m
+++ b/DYYYFloatSpeedButton.m
@@ -305,6 +305,11 @@ void updateSpeedButtonVisibility() {
                            }];
         }];
 
+    id currentController = DYYYCurrentSpeedInteractionController();
+    if (currentController) {
+        self.interactionController = currentController;
+    }
+
     if (self.interactionController) {
         @try {
             [self.interactionController speedButtonTapped:self];
@@ -504,21 +509,7 @@ void updateSpeedButtonVisibility() {
     }
 
     if (!self.interactionController) {
-        UIWindow *win = [DYYYUtils getActiveWindow];
-        UIViewController *topVC = win.rootViewController;
-        while (topVC && topVC.presentedViewController) {
-            topVC = topVC.presentedViewController;
-        }
-
-        if (topVC) {
-            Class PlayVCClass = NSClassFromString(@"AWEPlayInteractionViewController");
-            for (UIViewController *vc in findViewControllersInHierarchy(topVC)) {
-                if (PlayVCClass && [vc isKindOfClass:PlayVCClass]) {
-                    self.interactionController = vc;
-                    break;
-                }
-            }
-        }
+        self.interactionController = DYYYCurrentSpeedInteractionController();
     }
 }
 


### PR DESCRIPTION
## 修复摘要

完善一键清屏对进度条组件的隐藏与恢复逻辑，并修复快捷倍速切换延迟、控制目标错误以及自动恢复后按钮数值不同步的问题。

## 具体修复

- 扩展一键清屏对多种进度条、播放滑块及长按进度组件的识别，修复部分页面清屏后进度条仍然显示的问题。
- 区分“移除进度条”和“隐藏进度条”两种处理方式：移除时同步关闭触摸交互，隐藏时仅调整图层透明度。
- 保存进度组件原有的显示、触摸及透明度状态，在取消清屏或切换模式时准确恢复，避免进度条无法操作或状态残留。
- 在进度组件重新布局后持续同步清屏状态，防止切换视频或页面刷新时进度条再次出现。
- 根据当前作品模型、页面可见范围和控制器层级定位实际播放中的视频，避免快捷倍速作用于预加载或已离屏的播放器。
- 快捷倍速按钮切换后立即向当前播放控制器设置速度，修复倍速延迟生效及按钮显示与实际速度不一致的问题。
- 视频及页面切换时重新绑定悬浮按钮与当前播放控制器，旧控制器消失后自动寻找新的可见播放目标。
- 为每个作品记录自动恢复状态，仅在真正切换作品时恢复首个预设倍速，并同步刷新按钮数值，避免布局回调重复重置。