### PR TITLE
完善 Deb 自动构建与 GitHub Release 发布流程

### DIFF
--- a/.github/scripts/generate-release-notes.sh
+++ b/.github/scripts/generate-release-notes.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+notes_file="${1:-release-notes.md}"
+head_sha="${GITHUB_SHA:-HEAD}"
+repository="${GITHUB_REPOSITORY:-$(git config --get remote.origin.url | sed -E 's#(git@github.com:|https://github.com/)##; s#\.git$##')}"
+server_url="${GITHUB_SERVER_URL:-https://github.com}"
+zero_sha="0000000000000000000000000000000000000000"
+
+features_file=$(mktemp)
+improvements_file=$(mktemp)
+fixes_file=$(mktemp)
+trap 'rm -f "$features_file" "$improvements_file" "$fixes_file"' EXIT
+
+if [[ -n "${PUSH_BEFORE:-}" && "$PUSH_BEFORE" != "$zero_sha" ]] &&
+   git cat-file -e "${PUSH_BEFORE}^{commit}" 2>/dev/null; then
+    commit_range="${PUSH_BEFORE}..${head_sha}"
+else
+    previous_tag=$(git tag --list 'DYYY_*-build.*' --sort=-version:refname | head -n 1)
+    if [[ -n "$previous_tag" ]]; then
+        commit_range="${previous_tag}..${head_sha}"
+    elif git rev-parse "${head_sha}^" >/dev/null 2>&1; then
+        commit_range="${head_sha}^..${head_sha}"
+    else
+        commit_range="$head_sha"
+    fi
+fi
+
+commit_count=$(git rev-list --count "$commit_range")
+
+while IFS=$'\t' read -r hash subject; do
+    [[ -n "$hash" ]] || continue
+
+    short_hash=${hash:0:8}
+    entry="- **${subject}** ([\`${short_hash}\`](${server_url}/${repository}/commit/${hash}))"
+
+    case "$subject" in
+        新增*|增加*|添加*|支持*|引入*|实现*)
+            printf '%s\n' "$entry" >> "$features_file"
+            ;;
+        修复*|解决*|恢复*|纠正*)
+            printf '%s\n' "$entry" >> "$fixes_file"
+            ;;
+        *)
+            printf '%s\n' "$entry" >> "$improvements_file"
+            ;;
+    esac
+done < <(git log --reverse --format=$'%H\t%s' "$commit_range")
+
+cat > "$notes_file" <<EOF
+# 更新日志
+
+本次构建包含本次推送中的 ${commit_count} 项变更，以下为详细更新内容：
+EOF
+
+append_section() {
+    local title=$1
+    local section_file=$2
+
+    if [[ -s "$section_file" ]]; then
+        printf '\n## %s\n\n' "$title" >> "$notes_file"
+        cat "$section_file" >> "$notes_file"
+    fi
+}
+
+append_section "新增功能" "$features_file"
+append_section "体验优化与调整" "$improvements_file"
+append_section "问题修复" "$fixes_file"
+
+cat >> "$notes_file" <<'EOF'
+
+---
+
+本 Release 包含 Rootful、Rootless 和 Roothide 三个 Deb 安装包。
+EOF
+
+cat "$notes_file"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,16 +37,19 @@ jobs:
           path: ${{ github.workspace }}/theos
           key: ${{ runner.os }}-${{ env.upstream_heads }}
 
-      - name: Configure Homebrew tap trust
+      - name: Remove unused Homebrew taps
         env:
           HOMEBREW_NO_REQUIRE_TAP_TRUST: "1"
+          HOMEBREW_NO_AUTOREMOVE: "1"
         run: |
-          if brew tap | grep -Fxq "aws/tap"; then
-            brew untap aws/tap
+          if brew list --formula | grep -Fxq "bicep"; then
+            brew uninstall --formula --ignore-dependencies bicep
           fi
-          if brew tap | grep -Fxq "azure/bicep"; then
-            brew trust --formula azure/bicep/bicep
-          fi
+          for tap in aws/tap azure/bicep; do
+            if brew tap | grep -Fxq "$tap"; then
+              brew untap "$tap"
+            fi
+          done
 
       - name: Prepare Theos
         uses: huami1314/theos-action@main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,11 +90,13 @@ jobs:
       - name: Prepare release metadata
         id: release
         run: |
+          timestamp=$(TZ=Asia/Shanghai date +%Y%m%d%H%M%S)
           version=$(awk -F': ' '$1 == "Version" { print $2; exit }' control)
           if [ -z "$version" ]; then
             echo "Unable to read package version from control" >&2
             exit 1
           fi
+          echo "timestamp=$timestamp" >> "$GITHUB_OUTPUT"
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "tag=DYYY_${version}-build.${GITHUB_RUN_NUMBER}" >> "$GITHUB_OUTPUT"
           echo "title=DYYY_${version}#${GITHUB_RUN_NUMBER}" >> "$GITHUB_OUTPUT"
@@ -130,7 +132,7 @@ jobs:
       - name: Upload specific Deb packages
         uses: actions/upload-artifact@v7
         with:
-          name: DYYY-${{ steps.release.outputs.version }}-${{ github.run_number }}
+          name: DYYY-${{ steps.release.outputs.timestamp }}
           path: ${{ github.workspace }}/packages/*.deb
 
       - name: Publish GitHub Release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: true
+          fetch-depth: 0
 
       - name: Check cache
         run: |
@@ -121,6 +122,11 @@ jobs:
 
           printf 'Release asset: %s\n' "${deb_files[@]}"
 
+      - name: Generate release notes
+        env:
+          PUSH_BEFORE: ${{ github.event.before }}
+        run: .github/scripts/generate-release-notes.sh
+
       - name: Upload specific Deb packages
         uses: actions/upload-artifact@v7
         with:
@@ -136,5 +142,5 @@ jobs:
           gh release create "$RELEASE_TAG" packages/*.deb \
             --target "$GITHUB_SHA" \
             --title "$RELEASE_TITLE" \
-            --notes "自动构建版本，包含 Rootful、Rootless 和 Roothide 三个 Deb 安装包。" \
+            --notes-file release-notes.md \
             --latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,10 @@ on:
           - rootful
           - rootless
           - roothide
-          
+
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: macos-latest
@@ -83,16 +86,55 @@ jobs:
             [ -f "$f" ] && [[ "$f" != *"-root"*".deb" ]] && mv "$f" "${f%.deb}-roothide.deb"
           done
           
-      # 【新增】生成时间戳并写入环境变量
-      - name: Generate Timestamp
-        id: timestamp
+      - name: Prepare release metadata
+        id: release
         run: |
-          ts=$(TZ=Asia/Shanghai date +%Y%m%d%H%M%S)
-          echo "value=$ts" >> $GITHUB_OUTPUT
-          echo "⏰ 构建时间: $ts (Asia/Shanghai)"
-          
+          version=$(awk -F': ' '$1 == "Version" { print $2; exit }' control)
+          if [ -z "$version" ]; then
+            echo "Unable to read package version from control" >&2
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "tag=DYYY_${version}-build.${GITHUB_RUN_NUMBER}" >> "$GITHUB_OUTPUT"
+          echo "title=DYYY_${version}#${GITHUB_RUN_NUMBER}" >> "$GITHUB_OUTPUT"
+
+      - name: Verify Deb packages
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+
+          deb_files=(packages/*.deb)
+          if [ "${#deb_files[@]}" -ne 3 ]; then
+            echo "Expected 3 Deb packages, found ${#deb_files[@]}:" >&2
+            printf '  %s\n' "${deb_files[@]}" >&2
+            exit 1
+          fi
+
+          for scheme in rootful rootless roothide; do
+            scheme_files=(packages/*-"${scheme}".deb)
+            if [ "${#scheme_files[@]}" -ne 1 ]; then
+              echo "Expected exactly one ${scheme} package, found ${#scheme_files[@]}" >&2
+              exit 1
+            fi
+          done
+
+          printf 'Release asset: %s\n' "${deb_files[@]}"
+
       - name: Upload specific Deb packages
         uses: actions/upload-artifact@v7
         with:
-          name: DYYY-${{ steps.timestamp.outputs.value }}
+          name: DYYY-${{ steps.release.outputs.version }}-${{ github.run_number }}
           path: ${{ github.workspace }}/packages/*.deb
+
+      - name: Publish GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
+          RELEASE_TITLE: ${{ steps.release.outputs.title }}
+        run: |
+          gh release create "$RELEASE_TAG" packages/*.deb \
+            --target "$GITHUB_SHA" \
+            --title "$RELEASE_TITLE" \
+            --notes "自动构建版本，包含 Rootful、Rootless 和 Roothide 三个 Deb 安装包。" \
+            --latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v4 #.2.2
+      - uses: actions/checkout@v6
         with:
           submodules: true
 
@@ -32,10 +32,20 @@ jobs:
 
       - name: Use cache
         id: cache
-        uses: actions/cache@v4 #.2.1
+        uses: actions/cache@v5
         with:
           path: ${{ github.workspace }}/theos
           key: ${{ runner.os }}-${{ env.upstream_heads }}
+
+      - name: Remove unused Homebrew taps
+        env:
+          HOMEBREW_NO_REQUIRE_TAP_TRUST: "1"
+        run: |
+          for tap in aws/tap azure/bicep; do
+            if brew tap | grep -Fxq "$tap"; then
+              brew untap --force "$tap"
+            fi
+          done
 
       - name: Prepare Theos
         uses: huami1314/theos-action@main
@@ -78,7 +88,7 @@ jobs:
           echo "⏰ 构建时间: $ts (Asia/Shanghai)"
           
       - name: Upload specific Deb packages
-        uses: actions/upload-artifact@v4 #.6.0
+        uses: actions/upload-artifact@v7
         with:
           name: DYYY-${{ steps.timestamp.outputs.value }}
           path: ${{ github.workspace }}/packages/*.deb

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,15 +37,16 @@ jobs:
           path: ${{ github.workspace }}/theos
           key: ${{ runner.os }}-${{ env.upstream_heads }}
 
-      - name: Remove unused Homebrew taps
+      - name: Configure Homebrew tap trust
         env:
           HOMEBREW_NO_REQUIRE_TAP_TRUST: "1"
         run: |
-          for tap in aws/tap azure/bicep; do
-            if brew tap | grep -Fxq "$tap"; then
-              brew untap --force "$tap"
-            fi
-          done
+          if brew tap | grep -Fxq "aws/tap"; then
+            brew untap aws/tap
+          fi
+          if brew tap | grep -Fxq "azure/bicep"; then
+            brew trust --formula azure/bicep/bicep
+          fi
 
       - name: Prepare Theos
         uses: huami1314/theos-action@main


### PR DESCRIPTION
## 改动摘要

完善 `main` 分支的 Deb 自动构建流程，在保留 Rootful、Rootless 和 Roothide 三种打包方案的基础上，补充构建环境清理、产物校验、GitHub Release 自动发布及分类更新日志。

## 具体调整

- 升级 `checkout`、`cache` 和 `upload-artifact` GitHub Actions，消除旧版依赖警告。
- 构建前清理 macOS Runner 中无用的 `aws/tap`、`azure/bicep` 及 Bicep Formula，兼容不支持 `brew trust` 的 Homebrew 环境。
- 从 `control` 读取插件版本，并结合 Actions 运行编号生成唯一 Release 标签和标题。
- 发布前严格校验 Rootful、Rootless、Roothide 三种 Deb 是否各自存在且数量正确。
- 构建成功后自动将三种 Deb 上传至 GitHub Releases，并将最新构建标记为 Latest。
- 新增 Release 更新日志脚本，根据本次推送范围收集提交并分类为新增功能、体验优化与问题修复。
- 为每项更新附带对应提交链接，并在 Release 正文中注明包含的安装包类型。
- Artifact 名称继续使用上海时区的构建时间戳，便于按生成时间识别和下载。

## 验证

- 工作流 YAML 与更新日志脚本语法检查通过。
- Fork 仓库已完成三种 Deb 构建、分类更新日志生成和 GitHub Release 自动发布。