### PR TITLE
完善自动发布判定、发布协调与播放体验修复

### DIFF
--- a/.github/scripts/build-relevance.sh
+++ b/.github/scripts/build-relevance.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+zero_sha="0000000000000000000000000000000000000000"
+
+is_direct_build_path() {
+    local path=$1
+
+    case "$path" in
+        DYYY.plist|control|Resources/*|layout/*)
+            return 0
+            ;;
+    esac
+
+    if [[ "$path" != */* ]]; then
+        case "$path" in
+            *.h|*.m|*.mm|*.x|*.xm|*.c|*.cc|*.cpp|*.s|*.S)
+                return 0
+                ;;
+        esac
+    fi
+
+    return 1
+}
+
+normalize_makefile_revision() {
+    local revision=$1
+    local makefile_content
+
+    if ! makefile_content=$(git show "${revision}:Makefile" 2>/dev/null); then
+        return 0
+    fi
+
+    printf '%s\n' "$makefile_content" |
+        awk '
+            BEGIN {
+                skip_device_block = 0
+                skip_after_package = 0
+            }
+
+            skip_device_block {
+                if ($0 ~ /^[[:space:]]*THEOS_DEVICE_PORT[[:space:]]*[:+?]?=/) {
+                    skip_device_block = 0
+                }
+                next
+            }
+
+            /^[[:space:]]*ifeq[[:space:]]*\(\$\(shell whoami\),huami\)/ {
+                skip_device_block = 1
+                next
+            }
+
+            skip_after_package {
+                line = $0
+                gsub(/^[[:space:]]+|[[:space:]\\]+$/, "", line)
+                if (line == "fi") {
+                    skip_after_package = 0
+                }
+                next
+            }
+
+            /^after-package::[[:space:]]*$/ {
+                skip_after_package = 1
+                next
+            }
+
+            /^[[:space:]]*THEOS_DEVICE_(IP|PORT)[[:space:]]*[:+?]?=/ {
+                next
+            }
+
+            {
+                line = $0
+                sub(/[[:space:]]*#.*/, "", line)
+                gsub(/[[:space:]]+/, " ", line)
+                sub(/^ /, "", line)
+                sub(/ $/, "", line)
+
+                if (line == "" || line == "-include Makefile.local") {
+                    next
+                }
+
+                print line
+            }
+        '
+}
+
+makefile_affects_build() {
+    local before=$1
+    local after=$2
+    local before_file
+    local after_file
+    local result
+
+    before_file=$(mktemp)
+    after_file=$(mktemp)
+
+    normalize_makefile_revision "$before" > "$before_file"
+    normalize_makefile_revision "$after" > "$after_file"
+
+    if cmp -s "$before_file" "$after_file"; then
+        result=1
+    else
+        result=0
+    fi
+
+    rm -f "$before_file" "$after_file"
+    return "$result"
+}
+
+commit_touches_path() {
+    local hash=$1
+    local expected_path=$2
+
+    git diff-tree --root --no-commit-id --name-only -r "$hash" |
+        grep -Fxq "$expected_path"
+}
+
+commit_touches_direct_build_path() {
+    local hash=$1
+    local path
+
+    while IFS= read -r path; do
+        if is_direct_build_path "$path"; then
+            return 0
+        fi
+    done < <(git diff-tree --root --no-commit-id --name-only -r "$hash")
+
+    return 1
+}
+
+commit_affects_build() {
+    local hash=$1
+    local parent
+
+    if commit_touches_direct_build_path "$hash"; then
+        return 0
+    fi
+
+    if ! commit_touches_path "$hash" "Makefile"; then
+        return 1
+    fi
+
+    parent=$(git rev-parse "${hash}^" 2>/dev/null || git hash-object -t tree /dev/null)
+    makefile_affects_build "$parent" "$hash"
+}
+
+range_affects_build() {
+    local before=$1
+    local after=$2
+    local path
+    local makefile_changed=false
+
+    if [[ -z "$before" || "$before" == "$zero_sha" ]] ||
+       ! git cat-file -e "${before}^{commit}" 2>/dev/null; then
+        before=$(git hash-object -t tree /dev/null)
+    fi
+
+    while IFS= read -r path; do
+        if is_direct_build_path "$path"; then
+            return 0
+        fi
+
+        if [[ "$path" == "Makefile" ]]; then
+            makefile_changed=true
+        fi
+    done < <(git diff --name-only "$before" "$after")
+
+    if [[ "$makefile_changed" == true ]]; then
+        makefile_affects_build "$before" "$after"
+        return
+    fi
+
+    return 1
+}
+
+main() {
+    local command=${1:-}
+
+    case "$command" in
+        commit)
+            commit_affects_build "$2"
+            ;;
+        range)
+            range_affects_build "$2" "$3"
+            ;;
+        makefile)
+            makefile_affects_build "$2" "$3"
+            ;;
+        *)
+            echo "Usage: $0 {commit <sha>|range <before> <after>|makefile <before> <after>}" >&2
+            exit 2
+            ;;
+    esac
+}
+
+if [[ "${BASH_SOURCE[0]:-$0}" == "$0" ]]; then
+    main "$@"
+fi

--- a/.github/scripts/generate-release-notes.sh
+++ b/.github/scripts/generate-release-notes.sh
@@ -11,13 +11,14 @@ zero_sha="0000000000000000000000000000000000000000"
 features_file=$(mktemp)
 improvements_file=$(mktemp)
 fixes_file=$(mktemp)
-trap 'rm -f "$features_file" "$improvements_file" "$fixes_file"' EXIT
+package_file=$(mktemp)
+trap 'rm -f "$features_file" "$improvements_file" "$fixes_file" "$package_file"' EXIT
 
 is_plugin_file() {
     local path=$1
 
     case "$path" in
-        DYYY.plist|Resources/*|layout/*)
+        DYYY.plist|control|Resources/*|layout/*)
             return 0
             ;;
     esac
@@ -31,6 +32,13 @@ is_plugin_file() {
     fi
 
     return 1
+}
+
+commit_touches_control() {
+    local hash=$1
+
+    git diff-tree --root --no-commit-id --name-only -r "$hash" |
+        grep -Fxq 'control'
 }
 
 commit_touches_plugin() {
@@ -74,6 +82,28 @@ while IFS=$'\t' read -r hash subject; do
     short_hash=${hash:0:8}
     entry="- **${subject}** ([\`${short_hash}\`](${server_url}/${repository}/commit/${hash}))"
 
+    if commit_touches_control "$hash"; then
+        previous_version=$(
+            git show "${hash}^:control" 2>/dev/null |
+                awk -F': ' '$1 == "Version" { print $2; exit }' || true
+        )
+        current_version=$(
+            git show "${hash}:control" 2>/dev/null |
+                awk -F': ' '$1 == "Version" { print $2; exit }' || true
+        )
+
+        if [[ -n "$current_version" && "$previous_version" != "$current_version" ]]; then
+            if [[ -n "$previous_version" ]]; then
+                entry="- **版本更新：\`${previous_version}\` → \`${current_version}\`** ([\`${short_hash}\`](${server_url}/${repository}/commit/${hash}))"
+            else
+                entry="- **版本设置为 \`${current_version}\`** ([\`${short_hash}\`](${server_url}/${repository}/commit/${hash}))"
+            fi
+        fi
+
+        printf '%s\n' "$entry" >> "$package_file"
+        continue
+    fi
+
     case "$subject" in
         新增*|增加*|添加*|支持*|引入*|实现*|feat:*|feat\(*|Feature*|Add*)
             printf '%s\n' "$entry" >> "$features_file"
@@ -90,7 +120,7 @@ done < <(git log --reverse --format=$'%H\t%s' "$commit_range")
 cat > "$notes_file" <<EOF
 # 更新日志
 
-本次构建包含 ${relevant_count} 项插件功能变更，以下为详细更新内容：
+本次构建包含 ${relevant_count} 项插件或版本变更，以下为详细更新内容：
 EOF
 
 append_section() {
@@ -106,9 +136,10 @@ append_section() {
 append_section "新增功能" "$features_file"
 append_section "体验优化与调整" "$improvements_file"
 append_section "问题修复" "$fixes_file"
+append_section "版本与打包信息" "$package_file"
 
 if (( relevant_count == 0 )); then
-    printf '\n本次手动构建未检测到新的插件功能变更。\n' >> "$notes_file"
+    printf '\n本次手动构建未检测到新的插件功能或版本变更。\n' >> "$notes_file"
 fi
 
 cat >> "$notes_file" <<'EOF'

--- a/.github/scripts/generate-release-notes.sh
+++ b/.github/scripts/generate-release-notes.sh
@@ -2,11 +2,13 @@
 
 set -euo pipefail
 
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+source "${script_dir}/build-relevance.sh"
+
 notes_file="${1:-release-notes.md}"
 head_sha="${GITHUB_SHA:-HEAD}"
 repository="${GITHUB_REPOSITORY:-$(git config --get remote.origin.url | sed -E 's#(git@github.com:|https://github.com/)##; s#\.git$##')}"
 server_url="${GITHUB_SERVER_URL:-https://github.com}"
-zero_sha="0000000000000000000000000000000000000000"
 
 features_file=$(mktemp)
 improvements_file=$(mktemp)
@@ -14,44 +16,10 @@ fixes_file=$(mktemp)
 package_file=$(mktemp)
 trap 'rm -f "$features_file" "$improvements_file" "$fixes_file" "$package_file"' EXIT
 
-is_plugin_file() {
-    local path=$1
-
-    case "$path" in
-        DYYY.plist|control|Resources/*|layout/*)
-            return 0
-            ;;
-    esac
-
-    if [[ "$path" != */* ]]; then
-        case "$path" in
-            *.h|*.m|*.mm|*.x|*.xm|*.c|*.cc|*.cpp|*.s|*.S)
-                return 0
-                ;;
-        esac
-    fi
-
-    return 1
-}
-
 commit_touches_control() {
     local hash=$1
 
-    git diff-tree --root --no-commit-id --name-only -r "$hash" |
-        grep -Fxq 'control'
-}
-
-commit_touches_plugin() {
-    local hash=$1
-    local path
-
-    while IFS= read -r path; do
-        if is_plugin_file "$path"; then
-            return 0
-        fi
-    done < <(git diff-tree --root --no-commit-id --name-only -r "$hash")
-
-    return 1
+    commit_touches_path "$hash" "control"
 }
 
 if [[ -n "${PUSH_BEFORE:-}" && "$PUSH_BEFORE" != "$zero_sha" ]] &&
@@ -74,7 +42,7 @@ while IFS=$'\t' read -r hash subject; do
     [[ -n "$hash" ]] || continue
 
     parent_count=$(git rev-list --parents -n 1 "$hash" | awk '{ print NF - 1 }')
-    if (( parent_count > 1 )) || ! commit_touches_plugin "$hash"; then
+    if (( parent_count > 1 )) || ! commit_affects_build "$hash"; then
         continue
     fi
 
@@ -104,6 +72,12 @@ while IFS=$'\t' read -r hash subject; do
         continue
     fi
 
+    if commit_touches_path "$hash" "Makefile" &&
+       ! commit_touches_direct_build_path "$hash"; then
+        printf '%s\n' "$entry" >> "$package_file"
+        continue
+    fi
+
     case "$subject" in
         新增*|增加*|添加*|支持*|引入*|实现*|feat:*|feat\(*|Feature*|Add*)
             printf '%s\n' "$entry" >> "$features_file"
@@ -120,7 +94,7 @@ done < <(git log --reverse --format=$'%H\t%s' "$commit_range")
 cat > "$notes_file" <<EOF
 # 更新日志
 
-本次构建包含 ${relevant_count} 项插件或版本变更，以下为详细更新内容：
+本次构建包含 ${relevant_count} 项插件、版本或构建配置变更，以下为详细更新内容：
 EOF
 
 append_section() {
@@ -136,10 +110,10 @@ append_section() {
 append_section "新增功能" "$features_file"
 append_section "体验优化与调整" "$improvements_file"
 append_section "问题修复" "$fixes_file"
-append_section "版本与打包信息" "$package_file"
+append_section "版本与构建信息" "$package_file"
 
 if (( relevant_count == 0 )); then
-    printf '\n本次手动构建未检测到新的插件功能或版本变更。\n' >> "$notes_file"
+    printf '\n本次手动构建未检测到新的插件、版本或构建配置变更。\n' >> "$notes_file"
 fi
 
 cat >> "$notes_file" <<'EOF'

--- a/.github/scripts/generate-release-notes.sh
+++ b/.github/scripts/generate-release-notes.sh
@@ -13,6 +13,39 @@ improvements_file=$(mktemp)
 fixes_file=$(mktemp)
 trap 'rm -f "$features_file" "$improvements_file" "$fixes_file"' EXIT
 
+is_plugin_file() {
+    local path=$1
+
+    case "$path" in
+        DYYY.plist|Resources/*|layout/*)
+            return 0
+            ;;
+    esac
+
+    if [[ "$path" != */* ]]; then
+        case "$path" in
+            *.h|*.m|*.mm|*.x|*.xm|*.c|*.cc|*.cpp|*.s|*.S)
+                return 0
+                ;;
+        esac
+    fi
+
+    return 1
+}
+
+commit_touches_plugin() {
+    local hash=$1
+    local path
+
+    while IFS= read -r path; do
+        if is_plugin_file "$path"; then
+            return 0
+        fi
+    done < <(git diff-tree --root --no-commit-id --name-only -r "$hash")
+
+    return 1
+}
+
 if [[ -n "${PUSH_BEFORE:-}" && "$PUSH_BEFORE" != "$zero_sha" ]] &&
    git cat-file -e "${PUSH_BEFORE}^{commit}" 2>/dev/null; then
     commit_range="${PUSH_BEFORE}..${head_sha}"
@@ -27,19 +60,25 @@ else
     fi
 fi
 
-commit_count=$(git rev-list --count "$commit_range")
+relevant_count=0
 
 while IFS=$'\t' read -r hash subject; do
     [[ -n "$hash" ]] || continue
 
+    parent_count=$(git rev-list --parents -n 1 "$hash" | awk '{ print NF - 1 }')
+    if (( parent_count > 1 )) || ! commit_touches_plugin "$hash"; then
+        continue
+    fi
+
+    relevant_count=$((relevant_count + 1))
     short_hash=${hash:0:8}
     entry="- **${subject}** ([\`${short_hash}\`](${server_url}/${repository}/commit/${hash}))"
 
     case "$subject" in
-        新增*|增加*|添加*|支持*|引入*|实现*)
+        新增*|增加*|添加*|支持*|引入*|实现*|feat:*|feat\(*|Feature*|Add*)
             printf '%s\n' "$entry" >> "$features_file"
             ;;
-        修复*|解决*|恢复*|纠正*)
+        修复*|解决*|恢复*|纠正*|fix:*|fix\(*|Fix*|Bugfix*)
             printf '%s\n' "$entry" >> "$fixes_file"
             ;;
         *)
@@ -51,7 +90,7 @@ done < <(git log --reverse --format=$'%H\t%s' "$commit_range")
 cat > "$notes_file" <<EOF
 # 更新日志
 
-本次构建包含本次推送中的 ${commit_count} 项变更，以下为详细更新内容：
+本次构建包含 ${relevant_count} 项插件功能变更，以下为详细更新内容：
 EOF
 
 append_section() {
@@ -67,6 +106,10 @@ append_section() {
 append_section "新增功能" "$features_file"
 append_section "体验优化与调整" "$improvements_file"
 append_section "问题修复" "$fixes_file"
+
+if (( relevant_count == 0 )); then
+    printf '\n本次手动构建未检测到新的插件功能变更。\n' >> "$notes_file"
+fi
 
 cat >> "$notes_file" <<'EOF'
 

--- a/.github/scripts/release-coordinator.sh
+++ b/.github/scripts/release-coordinator.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+workflow_file=${WORKFLOW_FILE:-build.yml}
+branch=${GITHUB_REF_NAME:-main}
+max_wait_seconds=${RELEASE_COORDINATOR_MAX_WAIT_SECONDS:-3600}
+poll_interval_seconds=${RELEASE_COORDINATOR_POLL_INTERVAL_SECONDS:-30}
+settle_seconds=${RELEASE_COORDINATOR_SETTLE_SECONDS:-30}
+start_time=$(date +%s)
+
+require_env() {
+    local name=$1
+
+    if [[ -z "${!name:-}" ]]; then
+        echo "Missing required environment variable: ${name}" >&2
+        exit 2
+    fi
+}
+
+set_should_publish() {
+    local value=$1
+
+    if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+        echo "should_publish=${value}" >> "$GITHUB_OUTPUT"
+    fi
+
+    echo "should_publish=${value}"
+}
+
+workflow_runs_json() {
+    local attempt
+
+    for attempt in 1 2 3; do
+        if gh api -X GET \
+            "repos/${GITHUB_REPOSITORY}/actions/workflows/${workflow_file}/runs" \
+            -f branch="${branch}" \
+            -f per_page=100; then
+            return 0
+        fi
+
+        echo "Failed to fetch workflow runs (attempt ${attempt}/3)." >&2
+        sleep 5
+    done
+
+    return 1
+}
+
+fetch_branch_head() {
+    git fetch --no-tags origin "${branch}" >/dev/null 2>&1 || true
+}
+
+newer_run_is_build_relevant() {
+    local event=$1
+    local head_sha=$2
+
+    if [[ "$event" == "workflow_dispatch" ]]; then
+        return 0
+    fi
+
+    fetch_branch_head
+
+    if ! git cat-file -e "${head_sha}^{commit}" 2>/dev/null; then
+        echo "Unable to inspect newer run ${head_sha}; treating it as build-relevant." >&2
+        return 0
+    fi
+
+    "${script_dir}/build-relevance.sh" range "$GITHUB_SHA" "$head_sha"
+}
+
+has_newer_build_relevant_run() {
+    local runs_json=$1
+    local run_id
+    local run_number
+    local status
+    local event
+    local head_sha
+
+    while IFS=$'\t' read -r run_id run_number status event head_sha; do
+        [[ -n "${run_id:-}" ]] || continue
+
+        if newer_run_is_build_relevant "$event" "$head_sha"; then
+            echo "Newer build-relevant ${workflow_file} run #${run_number} (${status}, ${head_sha}) exists; this run will not publish a Release."
+            return 0
+        fi
+    done < <(
+        jq -r \
+            --argjson current_run_number "$GITHUB_RUN_NUMBER" \
+            --arg current_run_id "$GITHUB_RUN_ID" \
+            '.workflow_runs[]
+             | select((.id | tostring) != $current_run_id)
+             | select(.run_number > $current_run_number)
+             | select(.event == "push" or .event == "workflow_dispatch")
+             | [.id, .run_number, .status, .event, .head_sha]
+             | @tsv' <<< "$runs_json"
+    )
+
+    return 1
+}
+
+active_older_run_count() {
+    local runs_json=$1
+
+    jq -r \
+        --argjson current_run_number "$GITHUB_RUN_NUMBER" \
+        --arg current_run_id "$GITHUB_RUN_ID" \
+        '.workflow_runs
+         | map(select((.id | tostring) != $current_run_id)
+               | select(.run_number < $current_run_number)
+               | select(.event == "push" or .event == "workflow_dispatch")
+               | select(.status != "completed"))
+         | length' <<< "$runs_json"
+}
+
+main() {
+    local quiet_period_seen=false
+    local runs_json
+    local older_count
+    local now
+    local elapsed
+
+    require_env GITHUB_REPOSITORY
+    require_env GITHUB_RUN_ID
+    require_env GITHUB_RUN_NUMBER
+    require_env GITHUB_SHA
+
+    while true; do
+        runs_json=$(workflow_runs_json)
+
+        if has_newer_build_relevant_run "$runs_json"; then
+            set_should_publish false
+            return 0
+        fi
+
+        older_count=$(active_older_run_count "$runs_json")
+        if [[ "$older_count" == "0" ]]; then
+            if [[ "$quiet_period_seen" == false && "$settle_seconds" -gt 0 ]]; then
+                quiet_period_seen=true
+                echo "No older active build deb runs remain; waiting ${settle_seconds}s for the run list to settle."
+                sleep "$settle_seconds"
+                continue
+            fi
+
+            echo "This is the latest build-relevant completed packaging run; publishing Release."
+            set_should_publish true
+            return 0
+        fi
+
+        now=$(date +%s)
+        elapsed=$((now - start_time))
+        if (( elapsed >= max_wait_seconds )); then
+            echo "Timed out waiting for older build deb runs to finish after ${elapsed}s." >&2
+            exit 1
+        fi
+
+        echo "Waiting for ${older_count} older build deb run(s) to finish before publishing Release."
+        sleep "$poll_interval_seconds"
+    done
+}
+
+main "$@"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,7 @@ on:
       - '*.s'
       - '*.S'
       - 'DYYY.plist'
+      - 'control'
       - 'Resources/**'
       - 'layout/**'
   workflow_dispatch:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,7 @@ on:
       - '*.S'
       - 'DYYY.plist'
       - 'control'
+      - 'Makefile'
       - 'Resources/**'
       - 'layout/**'
   workflow_dispatch:
@@ -36,7 +37,33 @@ permissions:
   contents: write
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      should_build: ${{ steps.relevance.outputs.should_build }}
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Detect build-relevant changes
+        id: relevance
+        env:
+          PUSH_BEFORE: ${{ github.event.before }}
+        run: |
+          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]] ||
+             .github/scripts/build-relevance.sh range "$PUSH_BEFORE" "$GITHUB_SHA"; then
+            echo "should_build=true" >> "$GITHUB_OUTPUT"
+            echo "Build-relevant plugin, package, or Makefile changes detected."
+          else
+            echo "should_build=false" >> "$GITHUB_OUTPUT"
+            echo "Only non-build Makefile settings changed; skipping Deb build and Release."
+          fi
+
   build:
+    needs: changes
+    if: needs.changes.outputs.should_build == 'true'
     runs-on: macos-latest
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,20 @@ on:
   push:
     branches:
       - main
+    paths:
+      - '*.h'
+      - '*.m'
+      - '*.mm'
+      - '*.x'
+      - '*.xm'
+      - '*.c'
+      - '*.cc'
+      - '*.cpp'
+      - '*.s'
+      - '*.S'
+      - 'DYYY.plist'
+      - 'Resources/**'
+      - 'layout/**'
   workflow_dispatch:
     inputs:
       scheme:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,7 @@ on:
           - roothide
 
 permissions:
+  actions: read
   contents: write
 
 jobs:
@@ -166,18 +167,25 @@ jobs:
 
           printf 'Release asset: %s\n' "${deb_files[@]}"
 
-      - name: Generate release notes
-        env:
-          PUSH_BEFORE: ${{ github.event.before }}
-        run: .github/scripts/generate-release-notes.sh
-
       - name: Upload specific Deb packages
         uses: actions/upload-artifact@v7
         with:
           name: DYYY-${{ steps.release.outputs.timestamp }}
           path: ${{ github.workspace }}/packages/*.deb
 
+      - name: Coordinate Release publication
+        id: release_gate
+        env:
+          GH_TOKEN: ${{ github.token }}
+          WORKFLOW_FILE: build.yml
+        run: .github/scripts/release-coordinator.sh
+
+      - name: Generate release notes
+        if: steps.release_gate.outputs.should_publish == 'true'
+        run: .github/scripts/generate-release-notes.sh
+
       - name: Publish GitHub Release
+        if: steps.release_gate.outputs.should_publish == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ steps.release.outputs.tag }}

--- a/AwemeHeaders.h
+++ b/AwemeHeaders.h
@@ -1372,6 +1372,14 @@ typedef NS_ENUM(NSUInteger, DYEdgeMode) {
 @end
 
 @interface AWEPlayInteractionUserAvatarView : UIView
+@property(retain, nonatomic) UIView *followPromptView;
+@property(retain, nonatomic) UIView *followAnimationView;
+@property(retain, nonatomic) UIView *unfollowAnimationView;
+@property(retain, nonatomic) UIView *staticFollowAnimationView;
+- (void)updateRightContainerElement;
+- (void)p_resetFollowAnimation;
+- (void)playFollowAnimation:(id)completion;
+- (void)playUnFollowAnimation;
 @end
 
 @interface AWEPlayInteractionStaticFollowAnimationView : UIView
@@ -1428,9 +1436,22 @@ typedef NS_ENUM(NSUInteger, DYEdgeMode) {
 
 @interface AWEPlayInteractionUserAvatarFollowPromptController : NSObject
 @property(retain, nonatomic) AWEPlayInteractionUserAvatarContext *userAvatarContext;
+@property(retain, nonatomic) UIView *followPromptView;
+@property(retain, nonatomic) UIView *followAddView;
+@property(retain, nonatomic) UIView *followAnimationView;
+@property(retain, nonatomic) UIView *unfollowAnimationView;
+@property(retain, nonatomic) AWEPlayInteractionStaticFollowAnimationView *staticFollowAnimationView;
 - (void)onFollowViewClicked:(id)gesture;
 - (void)layoutElementView;
 - (void)showFollowAddView:(BOOL)show;
+- (void)viewController_willDisplay;
+- (void)viewController_viewDidAppear;
+- (void)updateFollowStatus;
+- (void)followStatusChanged:(id)arg1;
+- (void)playFollowAnimation;
+- (void)playFollowAnimation:(id)completion;
+- (void)playUnFollowAnimation;
+- (void)_ensureStaticFollowAnimationView;
 @end
 
 @interface AWEPlayInteractionUserAvatarMainBusinessController : NSObject
@@ -1442,6 +1463,9 @@ typedef NS_ENUM(NSUInteger, DYEdgeMode) {
 @interface AWEPlayInteractionUserAvatarOptElementElement : NSObject
 @property(retain, nonatomic) AWEPlayInteractionUserAvatarContext *userAvatarContext;
 - (void)layoutElementView;
+- (void)viewController_willDisplay;
+- (void)viewController_viewDidAppear;
+- (void)setAppear:(BOOL)appear;
 @end
 
 @interface AWEPlayInteractionUserAvatarStoryController : NSObject

--- a/AwemeHeaders.h
+++ b/AwemeHeaders.h
@@ -1416,7 +1416,10 @@ typedef NS_ENUM(NSUInteger, DYEdgeMode) {
 
 @interface AWEPlayInteractionUserAvatarContext : NSObject
 @property(retain, nonatomic) AWEAwemeModel *model;
+@property(nonatomic, weak) UIView *elementView;
+@property(nonatomic, weak) UIView *avatarPicContainerView;
 @property(nonatomic, weak) UIView *avatarPicView;
+@property(nonatomic, weak) UIView *avatarPicAvatarButton;
 @end
 
 @interface AWEPlayInteractionUserAvatarFollowController : UIViewController
@@ -1445,6 +1448,14 @@ typedef NS_ENUM(NSUInteger, DYEdgeMode) {
 @property(nonatomic, weak) UIView *colorRingView;
 - (void)layoutElementView;
 - (void)showStory25RingView;
+@end
+
+@interface AWEPlayInteractionUserAvatarDecorationController : NSObject
+@property(retain, nonatomic) AWEPlayInteractionUserAvatarContext *userAvatarContext;
+@property(retain, nonatomic) UIImageView *decorationView;
+- (void)layoutElementView;
+- (void)viewController_willDisplay;
+- (void)setDecorationStyle:(long long)style;
 @end
 
 @interface AWECodeGenCommonAnchorBasicInfoModel : UIViewController

--- a/DYYY.xm
+++ b/DYYY.xm
@@ -4088,8 +4088,7 @@ static void DYYYHideAvatarVisualForSelector(id object, SEL selector) {
     }
 }
 
-static void DYYYRemoveAvatarViewForSelector(id object, SEL selector) {
-    UIView *view = DYYYAvatarViewForSelector(object, selector);
+static void DYYYRemoveAvatarView(UIView *view) {
     if (!view) {
         return;
     }
@@ -4097,11 +4096,27 @@ static void DYYYRemoveAvatarViewForSelector(id object, SEL selector) {
     view.userInteractionEnabled = NO;
 }
 
+static void DYYYRemoveAvatarViewForSelector(id object, SEL selector) {
+    UIView *view = DYYYAvatarViewForSelector(object, selector);
+    DYYYRemoveAvatarView(view);
+}
+
 static void DYYYHideAvatarFollowLayerContents(UIView *view) {
     view.layer.contents = nil;
     for (CALayer *sublayer in view.layer.sublayers) {
         sublayer.hidden = YES;
     }
+}
+
+static BOOL DYYYIsLegacyAvatarFollowAnimationView(UIView *view) {
+    Class promptClass = NSClassFromString(@"AWEPlayInteractionFollowPromptView");
+    UIView *ancestor = view.superview;
+    for (NSInteger depth = 0; ancestor && depth < 6; depth++, ancestor = ancestor.superview) {
+        if (promptClass && [ancestor isKindOfClass:promptClass]) {
+            return YES;
+        }
+    }
+    return NO;
 }
 
 static BOOL DYYYHideAvatarFollowIconInView(UIView *view) {
@@ -4137,6 +4152,74 @@ static BOOL DYYYHideAvatarFollowIconInView(UIView *view) {
     return foundIcon;
 }
 
+static BOOL DYYYIsAvatarFollowContainerView(UIView *view) {
+    NSString *className = NSStringFromClass(view.class);
+    return [className containsString:@"Follow"] || [className containsString:@"follow"] || [className containsString:@"Prompt"] || [className containsString:@"Add"];
+}
+
+static BOOL DYYYIsSmallAvatarFollowBadgeView(UIView *view) {
+    CGFloat width = CGRectGetWidth(view.bounds);
+    CGFloat height = CGRectGetHeight(view.bounds);
+    return width > 0.0 && height > 0.0 && width <= 52.0 && height <= 52.0;
+}
+
+static UIView *DYYYAvatarFollowRemovalTargetForView(UIView *view, UIView *rootView) {
+    UIView *target = view;
+    UIView *ancestor = view.superview;
+    while (ancestor && ancestor != rootView) {
+        if (DYYYIsAvatarFollowContainerView(ancestor) || DYYYIsSmallAvatarFollowBadgeView(ancestor)) {
+            target = ancestor;
+            ancestor = ancestor.superview;
+            continue;
+        }
+        break;
+    }
+    return target;
+}
+
+static BOOL DYYYApplyAvatarFollowSettingsInView(UIView *view, UIView *rootView) {
+    if (!view) {
+        return NO;
+    }
+
+    BOOL hidePlus = DYYYGetBool(@"DYYYHideLOTAnimationView");
+    BOOL removePlus = DYYYGetBool(@"DYYYHideFollowPromptView");
+    if (!hidePlus && !removePlus) {
+        return NO;
+    }
+
+    NSString *className = NSStringFromClass(view.class);
+    BOOL isStaticFollowView = [className isEqualToString:@"AWEPlayInteractionStaticFollowAnimationView"];
+    BOOL isLegacyFollowAnimation = [className isEqualToString:@"LOTAnimationView"] && DYYYIsLegacyAvatarFollowAnimationView(view);
+    BOOL isLegacyPromptContainer = [className isEqualToString:@"AWEPlayInteractionFollowPromptView"];
+    BOOL handled = NO;
+
+    if (isStaticFollowView || isLegacyFollowAnimation) {
+        if (removePlus) {
+            DYYYRemoveAvatarView(DYYYAvatarFollowRemovalTargetForView(view, rootView));
+        } else {
+            DYYYHideAvatarFollowIconInView(view);
+        }
+        handled = YES;
+    } else if (removePlus && isLegacyPromptContainer) {
+        view.hidden = YES;
+        view.userInteractionEnabled = NO;
+        handled = YES;
+    }
+
+    for (UIView *subview in [view.subviews copy]) {
+        handled = DYYYApplyAvatarFollowSettingsInView(subview, rootView) || handled;
+    }
+    return handled;
+}
+
+static void DYYYApplyAvatarFollowSettingsForContext(id context) {
+    UIView *elementView = DYYYAvatarViewForSelector(context, NSSelectorFromString(@"elementView"));
+    if (elementView) {
+        DYYYApplyAvatarFollowSettingsInView(elementView, elementView);
+    }
+}
+
 static void DYYYApplyAvatarFollowPromptSettings(id owner) {
     BOOL hidePlus = DYYYGetBool(@"DYYYHideLOTAnimationView");
     BOOL removePlus = DYYYGetBool(@"DYYYHideFollowPromptView");
@@ -4159,17 +4242,11 @@ static void DYYYApplyAvatarFollowPromptSettings(id owner) {
         DYYYRemoveAvatarViewForSelector(owner, NSSelectorFromString(@"followAddView"));
         DYYYRemoveAvatarViewForSelector(owner, NSSelectorFromString(@"followPromptView"));
     }
-}
 
-static BOOL DYYYIsLegacyAvatarFollowAnimationView(UIView *view) {
-    Class promptClass = NSClassFromString(@"AWEPlayInteractionFollowPromptView");
-    UIView *ancestor = view.superview;
-    for (NSInteger depth = 0; ancestor && depth < 6; depth++, ancestor = ancestor.superview) {
-        if (promptClass && [ancestor isKindOfClass:promptClass]) {
-            return YES;
-        }
+    if ([owner isKindOfClass:[UIView class]]) {
+        DYYYApplyAvatarFollowSettingsInView((UIView *)owner, (UIView *)owner);
     }
-    return NO;
+    DYYYApplyAvatarFollowSettingsForContext(DYYYAvatarObjectForSelector(owner, NSSelectorFromString(@"userAvatarContext")));
 }
 
 // 隐藏头像加号和透明
@@ -7126,6 +7203,23 @@ static NSHashTable *processedParentViews = nil;
     if (DYYYGetBool(@"DYYYHideAvatarRing")) {
         DYYYHideAvatarVisualForSelector(self, NSSelectorFromString(@"colorRingView"));
     }
+}
+%end
+
+%hook AWEPlayInteractionUserAvatarDecorationController
+- (void)layoutElementView {
+    %orig;
+    DYYYApplyAvatarFollowPromptSettings(self);
+}
+
+- (void)viewController_willDisplay {
+    %orig;
+    DYYYApplyAvatarFollowPromptSettings(self);
+}
+
+- (void)setDecorationStyle:(long long)style {
+    %orig(style);
+    DYYYApplyAvatarFollowPromptSettings(self);
 }
 %end
 

--- a/DYYY.xm
+++ b/DYYY.xm
@@ -223,6 +223,7 @@ static BOOL DYYYShouldHandleSpeedFeatures(void) {
 static __weak AWEPlayInteractionViewController *dyyyActiveSpeedInteractionController = nil;
 static __weak AWEAwemeModel *dyyyCurrentSpeedAweme = nil;
 static NSString *dyyyLastAutoRestoredSpeedAwemeIdentifier = nil;
+static BOOL dyyyLongPressFastSpeedActive = NO;
 
 static CGFloat DYYYViewControllerVisibilityScore(UIViewController *viewController) {
     if (!viewController || !viewController.isViewLoaded) {
@@ -476,7 +477,7 @@ static double DYYYPreparedPlaybackSpeed(void) {
 }
 
 static void DYYYApplyPreparedPlaybackSpeedToPlayer(id playerViewController) {
-    if (!DYYYShouldHandleSpeedFeatures() || !playerViewController) {
+    if (!DYYYShouldHandleSpeedFeatures() || !playerViewController || dyyyLongPressFastSpeedActive) {
         return;
     }
 
@@ -492,7 +493,7 @@ static void DYYYApplyPreparedPlaybackSpeedToPlayer(id playerViewController) {
 }
 
 static void DYYYBindAndApplyCurrentPlaybackSpeed(void) {
-    if (!DYYYShouldHandleSpeedFeatures()) {
+    if (!DYYYShouldHandleSpeedFeatures() || dyyyLongPressFastSpeedActive) {
         return;
     }
 
@@ -3419,7 +3420,6 @@ static NSArray<NSString *> *dyyy_qualityRank = nil;
 
 %hook AWEPlayInteractionSpeedController
 
-static BOOL hasChangedSpeed = NO;
 static CGFloat currentLongPressSpeed = 0;
 static CGFloat initialTouchX = 0;
 static BOOL isGestureActive = NO;
@@ -3440,38 +3440,45 @@ static BOOL isGestureActive = NO;
         return;
     }
 
-    if (speed == 2.0) {
-        if (!hasChangedSpeed) {
-            if (longPressSpeed != 0 && longPressSpeed != 2.0) {
-                hasChangedSpeed = YES;
-                %orig(longPressSpeed);
-                return;
-            }
-        } else {
-            hasChangedSpeed = NO;
-            %orig(1.0);
-            return;
-        }
-    }
-
-    if (longPressSpeed == 0 || longPressSpeed == 2) {
-        %orig(speed);
+    if (speed == 2.0 && longPressSpeed != 0 && longPressSpeed != 2.0) {
+        %orig(longPressSpeed);
         return;
     }
+
+    %orig(speed);
 }
 
 - (void)handleLongPressFastSpeed:(UILongPressGestureRecognizer *)gesture {
+    BOOL enableSpeedGesture = DYYYGetBool(@"DYYYEnableLongPressSpeedGesture");
+    CGPoint location = [gesture locationInView:gesture.view];
+    static CGFloat initialTouchY = 0;
+    BOOL isBeginning = gesture.state == UIGestureRecognizerStateBegan;
+    BOOL isEnding = gesture.state == UIGestureRecognizerStateEnded ||
+                    gesture.state == UIGestureRecognizerStateCancelled ||
+                    gesture.state == UIGestureRecognizerStateFailed;
+
+    if (isBeginning) {
+        dyyyLongPressFastSpeedActive = YES;
+    } else if (isEnding) {
+        isGestureActive = NO;
+        currentLongPressSpeed = 0;
+        initialTouchY = 0;
+        dyyyLongPressFastSpeedActive = NO;
+    }
+
     %orig;
 
-    if (!DYYYGetBool(@"DYYYEnableLongPressSpeedGesture")) {
+    if (isEnding) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+          DYYYBindAndApplyCurrentPlaybackSpeed();
+        });
+    }
+
+    if (!enableSpeedGesture) {
         return;
     }
 
-    CGPoint location = [gesture locationInView:gesture.view];
-
-    static CGFloat initialTouchY = 0;
-
-    if (gesture.state == UIGestureRecognizerStateBegan) {
+    if (isBeginning) {
         initialTouchY = location.y;
         isGestureActive = YES;
 
@@ -3499,12 +3506,24 @@ static BOOL isGestureActive = NO;
             }
         }
     }
-    else if (gesture.state == UIGestureRecognizerStateEnded ||
-             gesture.state == UIGestureRecognizerStateCancelled) {
-        isGestureActive = NO;
-        currentLongPressSpeed = 0;
-        initialTouchY = 0;
-    }
+}
+
+- (void)handleLongPressLockedSpeedBegan {
+    dyyyLongPressFastSpeedActive = YES;
+    %orig;
+}
+
+- (void)handleLongPressLockedDoubleSpeedChanged:(id)arg1 gesture:(UIGestureRecognizer *)gesture {
+    dyyyLongPressFastSpeedActive = YES;
+    %orig(arg1, gesture);
+}
+
+- (void)handleLongPressLockedDoubleSpeedEnded:(id)arg1 gesture:(UIGestureRecognizer *)gesture {
+    %orig(arg1, gesture);
+    dyyyLongPressFastSpeedActive = NO;
+    dispatch_async(dispatch_get_main_queue(), ^{
+      DYYYBindAndApplyCurrentPlaybackSpeed();
+    });
 }
 %end
 

--- a/DYYY.xm
+++ b/DYYY.xm
@@ -858,11 +858,6 @@ static void DYYYClearFeedNowPlayingSystemInfoThrottled(void) {
         if ([center respondsToSelector:@selector(setNowPlayingInfo:)]) {
             ((void (*)(id, SEL, id))objc_msgSend)(center, @selector(setNowPlayingInfo:), nil);
         }
-
-        SEL setPlaybackStateSelector = NSSelectorFromString(@"setPlaybackState:");
-        if ([center respondsToSelector:setPlaybackStateSelector]) {
-            ((void (*)(id, SEL, NSInteger))objc_msgSend)(center, setPlaybackStateSelector, 0);
-        }
     } @catch (__unused NSException *exception) {
     } @finally {
         dyyyClearingFeedNowPlayingSystemInfo = NO;
@@ -883,7 +878,6 @@ static BOOL DYYYShouldBlockFeedNowPlayingPlayer(id player) {
 - (id)nowPlayingInfo {
     if (DYYYGetBool(@"DYYYDisableFeedNowPlayingInfo")) {
         DYYYClearFeedNowPlayingSystemInfoThrottled();
-        return nil;
     }
 
     return %orig;
@@ -891,6 +885,7 @@ static BOOL DYYYShouldBlockFeedNowPlayingPlayer(id player) {
 
 - (void)refreshNowPlayingInfoIfNeeded {
     if (DYYYGetBool(@"DYYYDisableFeedNowPlayingInfo")) {
+        %orig;
         DYYYClearFeedNowPlayingSystemInfoThrottled();
         return;
     }
@@ -900,6 +895,7 @@ static BOOL DYYYShouldBlockFeedNowPlayingPlayer(id player) {
 
 - (void)updateNowPlayingInfoPlayback {
     if (DYYYGetBool(@"DYYYDisableFeedNowPlayingInfo")) {
+        %orig;
         DYYYClearFeedNowPlayingSystemInfoThrottled();
         return;
     }
@@ -913,12 +909,11 @@ static BOOL DYYYShouldBlockFeedNowPlayingPlayer(id player) {
 %hook AWENowPlayingInfoCenter
 
 - (void)becomePlayingPlayer:(id)player {
+    %orig;
+
     if (DYYYShouldBlockFeedNowPlayingPlayer(player)) {
         DYYYClearFeedNowPlayingSystemInfoThrottled();
-        return;
     }
-
-    %orig;
 }
 
 - (void)setNowPlayingInfo:(id)nowPlayingInfo {
@@ -4081,6 +4076,12 @@ static UIView *DYYYAvatarViewForSelector(id object, SEL selector) {
     return [value isKindOfClass:[UIView class]] ? value : nil;
 }
 
+static char kDYYYAvatarFollowDeferredApplyKey;
+
+static BOOL DYYYAvatarFollowOptionsEnabled(void) {
+    return DYYYGetBool(@"DYYYHideLOTAnimationView") || DYYYGetBool(@"DYYYHideFollowPromptView");
+}
+
 static void DYYYHideAvatarVisualForSelector(id object, SEL selector) {
     UIView *view = DYYYAvatarViewForSelector(object, selector);
     if (view) {
@@ -4229,24 +4230,56 @@ static void DYYYApplyAvatarFollowPromptSettings(id owner) {
 
     for (NSString *selectorName in @[ @"followAnimationView", @"unfollowAnimationView", @"staticFollowAnimationView" ]) {
         UIView *animationView = DYYYAvatarViewForSelector(owner, NSSelectorFromString(selectorName));
-        DYYYHideAvatarFollowIconInView(animationView);
+        if (!animationView) {
+            continue;
+        }
+        if (removePlus) {
+            DYYYRemoveAvatarView(DYYYAvatarFollowRemovalTargetForView(animationView, nil));
+        } else {
+            DYYYHideAvatarFollowIconInView(animationView);
+        }
     }
 
     UIView *followAddView = DYYYAvatarViewForSelector(owner, NSSelectorFromString(@"followAddView"));
-    BOOL foundIcon = DYYYHideAvatarFollowIconInView(followAddView);
-    if (hidePlus && followAddView && !foundIcon) {
-        DYYYHideAvatarFollowLayerContents(followAddView);
+    if (removePlus) {
+        DYYYRemoveAvatarView(followAddView);
+    } else {
+        BOOL foundIcon = DYYYHideAvatarFollowIconInView(followAddView);
+        if (hidePlus && followAddView && !foundIcon) {
+            DYYYHideAvatarFollowLayerContents(followAddView);
+        }
     }
 
+    UIView *followPromptView = DYYYAvatarViewForSelector(owner, NSSelectorFromString(@"followPromptView"));
     if (removePlus) {
-        DYYYRemoveAvatarViewForSelector(owner, NSSelectorFromString(@"followAddView"));
-        DYYYRemoveAvatarViewForSelector(owner, NSSelectorFromString(@"followPromptView"));
+        DYYYRemoveAvatarView(followPromptView);
+    } else {
+        DYYYApplyAvatarFollowSettingsInView(followPromptView, followPromptView);
     }
 
     if ([owner isKindOfClass:[UIView class]]) {
         DYYYApplyAvatarFollowSettingsInView((UIView *)owner, (UIView *)owner);
+    } else if ([owner isKindOfClass:[UIViewController class]]) {
+        DYYYApplyAvatarFollowSettingsInView(((UIViewController *)owner).view, ((UIViewController *)owner).view);
     }
     DYYYApplyAvatarFollowSettingsForContext(DYYYAvatarObjectForSelector(owner, NSSelectorFromString(@"userAvatarContext")));
+}
+
+static void DYYYApplyAvatarFollowPromptSettingsWithRetry(id owner) {
+    DYYYApplyAvatarFollowPromptSettings(owner);
+    if (!owner || !DYYYAvatarFollowOptionsEnabled() || objc_getAssociatedObject(owner, &kDYYYAvatarFollowDeferredApplyKey)) {
+        return;
+    }
+
+    objc_setAssociatedObject(owner, &kDYYYAvatarFollowDeferredApplyKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    id target = owner;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        DYYYApplyAvatarFollowPromptSettings(target);
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.2 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+            DYYYApplyAvatarFollowPromptSettings(target);
+            objc_setAssociatedObject(target, &kDYYYAvatarFollowDeferredApplyKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        });
+    });
 }
 
 // 隐藏头像加号和透明
@@ -4256,8 +4289,13 @@ static void DYYYApplyAvatarFollowPromptSettings(id owner) {
     // 旧版加号动画可能被额外容器包裹，沿父视图向上识别关注提示视图。
     if (DYYYIsLegacyAvatarFollowAnimationView(self)) {
         // 检查是否需要隐藏加号
-        if (DYYYGetBool(@"DYYYHideLOTAnimationView") || DYYYGetBool(@"DYYYHideFollowPromptView")) {
-            DYYYHideAvatarFollowLayerContents(self);
+        if (DYYYAvatarFollowOptionsEnabled()) {
+            if (DYYYGetBool(@"DYYYHideFollowPromptView")) {
+                DYYYRemoveAvatarView(DYYYAvatarFollowRemovalTargetForView(self, nil));
+            } else {
+                DYYYHideAvatarFollowLayerContents(self);
+            }
+            DYYYApplyAvatarFollowPromptSettingsWithRetry(self.superview ?: self);
             return;
         }
         // 应用透明度设置
@@ -4273,8 +4311,9 @@ static void DYYYApplyAvatarFollowPromptSettings(id owner) {
 %hook AWEPlayInteractionStaticFollowAnimationView
 - (void)layoutSubviews {
     %orig;
-    if (DYYYGetBool(@"DYYYHideLOTAnimationView") || DYYYGetBool(@"DYYYHideFollowPromptView")) {
-        DYYYHideAvatarFollowIconInView((UIView *)self);
+    if (DYYYAvatarFollowOptionsEnabled()) {
+        DYYYApplyAvatarFollowSettingsInView((UIView *)self, nil);
+        DYYYApplyAvatarFollowPromptSettingsWithRetry(self.superview ?: self);
     }
 }
 %end
@@ -4795,9 +4834,27 @@ static void DYYYApplyAvatarFollowPromptSettings(id owner) {
 - (void)layoutSubviews {
     %orig;
 
-    if (DYYYGetBool(@"DYYYHideFollowPromptView")) {
-        self.userInteractionEnabled = NO;
-        self.hidden = YES;
+    if (DYYYAvatarFollowOptionsEnabled()) {
+        DYYYApplyAvatarFollowPromptSettingsWithRetry(self);
+        if (DYYYGetBool(@"DYYYHideFollowPromptView")) {
+            return;
+        }
+    }
+}
+
+- (void)didMoveToWindow {
+    %orig;
+
+    if (DYYYAvatarFollowOptionsEnabled()) {
+        DYYYApplyAvatarFollowPromptSettingsWithRetry(self);
+    }
+}
+
+- (void)didMoveToSuperview {
+    %orig;
+
+    if (DYYYAvatarFollowOptionsEnabled()) {
+        DYYYApplyAvatarFollowPromptSettingsWithRetry(self);
         return;
     }
 }
@@ -7102,7 +7159,37 @@ static NSHashTable *processedParentViews = nil;
         DYYYHideAvatarVisualForSelector(self, NSSelectorFromString(@"userAvatarView"));
     }
 
-    DYYYApplyAvatarFollowPromptSettings(self);
+    DYYYApplyAvatarFollowPromptSettingsWithRetry(self);
+}
+
+- (void)didMoveToWindow {
+    %orig;
+    DYYYApplyAvatarFollowPromptSettingsWithRetry(self);
+}
+
+- (void)didMoveToSuperview {
+    %orig;
+    DYYYApplyAvatarFollowPromptSettingsWithRetry(self);
+}
+
+- (void)updateRightContainerElement {
+    %orig;
+    DYYYApplyAvatarFollowPromptSettingsWithRetry(self);
+}
+
+- (void)p_resetFollowAnimation {
+    %orig;
+    DYYYApplyAvatarFollowPromptSettingsWithRetry(self);
+}
+
+- (void)playFollowAnimation:(id)completion {
+    %orig(completion);
+    DYYYApplyAvatarFollowPromptSettingsWithRetry(self);
+}
+
+- (void)playUnFollowAnimation {
+    %orig;
+    DYYYApplyAvatarFollowPromptSettingsWithRetry(self);
 }
 %end
 
@@ -7160,12 +7247,52 @@ static NSHashTable *processedParentViews = nil;
 
 - (void)layoutElementView {
     %orig;
-    DYYYApplyAvatarFollowPromptSettings(self);
+    DYYYApplyAvatarFollowPromptSettingsWithRetry(self);
 }
 
 - (void)showFollowAddView:(BOOL)show {
     %orig(show);
-    DYYYApplyAvatarFollowPromptSettings(self);
+    DYYYApplyAvatarFollowPromptSettingsWithRetry(self);
+}
+
+- (void)viewController_willDisplay {
+    %orig;
+    DYYYApplyAvatarFollowPromptSettingsWithRetry(self);
+}
+
+- (void)viewController_viewDidAppear {
+    %orig;
+    DYYYApplyAvatarFollowPromptSettingsWithRetry(self);
+}
+
+- (void)updateFollowStatus {
+    %orig;
+    DYYYApplyAvatarFollowPromptSettingsWithRetry(self);
+}
+
+- (void)followStatusChanged:(id)arg1 {
+    %orig(arg1);
+    DYYYApplyAvatarFollowPromptSettingsWithRetry(self);
+}
+
+- (void)playFollowAnimation {
+    %orig;
+    DYYYApplyAvatarFollowPromptSettingsWithRetry(self);
+}
+
+- (void)playFollowAnimation:(id)completion {
+    %orig(completion);
+    DYYYApplyAvatarFollowPromptSettingsWithRetry(self);
+}
+
+- (void)playUnFollowAnimation {
+    %orig;
+    DYYYApplyAvatarFollowPromptSettingsWithRetry(self);
+}
+
+- (void)_ensureStaticFollowAnimationView {
+    %orig;
+    DYYYApplyAvatarFollowPromptSettingsWithRetry(self);
 }
 %end
 
@@ -7177,6 +7304,7 @@ static NSHashTable *processedParentViews = nil;
         id context = DYYYAvatarObjectForSelector(self, NSSelectorFromString(@"userAvatarContext"));
         DYYYHideAvatarVisualForSelector(context, NSSelectorFromString(@"avatarPicView"));
     }
+    DYYYApplyAvatarFollowPromptSettingsWithRetry(self);
 }
 %end
 
@@ -7187,6 +7315,22 @@ static NSHashTable *processedParentViews = nil;
         id context = DYYYAvatarObjectForSelector(self, NSSelectorFromString(@"userAvatarContext"));
         DYYYHideAvatarVisualForSelector(context, NSSelectorFromString(@"avatarPicView"));
     }
+    DYYYApplyAvatarFollowPromptSettingsWithRetry(self);
+}
+
+- (void)viewController_willDisplay {
+    %orig;
+    DYYYApplyAvatarFollowPromptSettingsWithRetry(self);
+}
+
+- (void)viewController_viewDidAppear {
+    %orig;
+    DYYYApplyAvatarFollowPromptSettingsWithRetry(self);
+}
+
+- (void)setAppear:(BOOL)appear {
+    %orig(appear);
+    DYYYApplyAvatarFollowPromptSettingsWithRetry(self);
 }
 %end
 
@@ -7209,21 +7353,31 @@ static NSHashTable *processedParentViews = nil;
 %hook AWEPlayInteractionUserAvatarDecorationController
 - (void)layoutElementView {
     %orig;
-    DYYYApplyAvatarFollowPromptSettings(self);
+    DYYYApplyAvatarFollowPromptSettingsWithRetry(self);
 }
 
 - (void)viewController_willDisplay {
     %orig;
-    DYYYApplyAvatarFollowPromptSettings(self);
+    DYYYApplyAvatarFollowPromptSettingsWithRetry(self);
 }
 
 - (void)setDecorationStyle:(long long)style {
     %orig(style);
-    DYYYApplyAvatarFollowPromptSettings(self);
+    DYYYApplyAvatarFollowPromptSettingsWithRetry(self);
 }
 %end
 
 %hook AWEPlayInteractionViewController
+
+- (void)performCommentAction {
+    %orig;
+    DYYYApplyAvatarFollowPromptSettingsWithRetry(self);
+}
+
+- (void)setIsCommentVCShowing:(BOOL)showing {
+    %orig(showing);
+    DYYYApplyAvatarFollowPromptSettingsWithRetry(self);
+}
 
 - (void)onPlayer:(id)arg0 didDoubleClick:(id)arg1 {
     BOOL isPopupEnabled = DYYYGetBool(@"DYYYEnableDoubleTapMenu");

--- a/DYYY.xm
+++ b/DYYY.xm
@@ -829,13 +829,58 @@ static void DYYYHandleCurrentSpeedAwemeChanged(id aweme) {
 @property(nonatomic, weak) id playingPlayer;
 @end
 
+@interface MPNowPlayingInfoCenter : NSObject
+@property(nonatomic, copy) NSDictionary *nowPlayingInfo;
++ (instancetype)defaultCenter;
+@end
+
 static BOOL dyyyClearingFeedNowPlayingSystemInfo = NO;
+static BOOL dyyyFeedNowPlayingPictureInPictureActive = NO;
 static CFTimeInterval dyyyLastFeedNowPlayingSystemClearTime = 0.0;
+static CFTimeInterval dyyyFeedNowPlayingSystemBlockUntil = 0.0;
+static CFTimeInterval dyyyFeedNowPlayingPictureInPictureBlockUntil = 0.0;
+
+static void DYYYClearFeedNowPlayingSystemInfoThrottled(void);
+
+static BOOL DYYYIsAppActiveForFeedNowPlayingBlock(void) {
+    return [UIApplication sharedApplication].applicationState == UIApplicationStateActive;
+}
+
+static void DYYYExtendFeedNowPlayingSystemBlockWindow(void) {
+    dyyyFeedNowPlayingSystemBlockUntil = MAX(dyyyFeedNowPlayingSystemBlockUntil, CFAbsoluteTimeGetCurrent() + 0.75);
+}
+
+static void DYYYExtendFeedNowPlayingPictureInPictureBlockWindow(void) {
+    CFTimeInterval currentTime = CFAbsoluteTimeGetCurrent();
+    dyyyFeedNowPlayingPictureInPictureBlockUntil = MAX(dyyyFeedNowPlayingPictureInPictureBlockUntil, currentTime + 8.0);
+    dyyyFeedNowPlayingSystemBlockUntil = MAX(dyyyFeedNowPlayingSystemBlockUntil, currentTime + 1.5);
+}
+
+static void DYYYSetFeedNowPlayingPictureInPictureActive(BOOL active) {
+    dyyyFeedNowPlayingPictureInPictureActive = active;
+    if (active) {
+        DYYYExtendFeedNowPlayingPictureInPictureBlockWindow();
+        DYYYClearFeedNowPlayingSystemInfoThrottled();
+    } else {
+        dyyyFeedNowPlayingPictureInPictureBlockUntil = 0.0;
+    }
+}
+
+static BOOL DYYYIsFeedNowPlayingPictureInPictureBlockActive(void) {
+    return dyyyFeedNowPlayingPictureInPictureActive ||
+           CFAbsoluteTimeGetCurrent() <= dyyyFeedNowPlayingPictureInPictureBlockUntil;
+}
+
+static BOOL DYYYShouldBlockFeedNowPlayingScene(void) {
+    return DYYYIsAppActiveForFeedNowPlayingBlock() || DYYYIsFeedNowPlayingPictureInPictureBlockActive();
+}
 
 static void DYYYClearFeedNowPlayingSystemInfoThrottled(void) {
     if (!DYYYGetBool(@"DYYYDisableFeedNowPlayingInfo") || dyyyClearingFeedNowPlayingSystemInfo) {
         return;
     }
+
+    DYYYExtendFeedNowPlayingSystemBlockWindow();
 
     CFTimeInterval currentTime = CFAbsoluteTimeGetCurrent();
     if (currentTime - dyyyLastFeedNowPlayingSystemClearTime < 0.25) {
@@ -858,10 +903,47 @@ static void DYYYClearFeedNowPlayingSystemInfoThrottled(void) {
         if ([center respondsToSelector:@selector(setNowPlayingInfo:)]) {
             ((void (*)(id, SEL, id))objc_msgSend)(center, @selector(setNowPlayingInfo:), nil);
         }
+
+        SEL setPlaybackStateSelector = NSSelectorFromString(@"setPlaybackState:");
+        if ([center respondsToSelector:setPlaybackStateSelector]) {
+            ((void (*)(id, SEL, NSInteger))objc_msgSend)(center, setPlaybackStateSelector, 0);
+        }
     } @catch (__unused NSException *exception) {
     } @finally {
         dyyyClearingFeedNowPlayingSystemInfo = NO;
     }
+}
+
+static BOOL DYYYObjectIsKindOfClassNamed(id object, NSString *className) {
+    if (!object || className.length == 0) {
+        return NO;
+    }
+
+    Class targetClass = NSClassFromString(className);
+    return targetClass && [object isKindOfClass:targetClass];
+}
+
+static BOOL DYYYObjectBoolValueForSelector(id object, SEL selector) {
+    if (!object || ![object respondsToSelector:selector]) {
+        return NO;
+    }
+
+    return ((BOOL (*)(id, SEL))objc_msgSend)(object, selector);
+}
+
+static BOOL DYYYPlayerViewSupportsPictureInPicture(id playerView) {
+    return DYYYObjectBoolValueForSelector(playerView, NSSelectorFromString(@"isSupportPictureInPictureMode")) ||
+           DYYYObjectBoolValueForSelector(playerView, NSSelectorFromString(@"supportPictureInPictureMode"));
+}
+
+static BOOL DYYYFeedBackgroundPlayManagerIsUserAudioMode(id player) {
+    if (!DYYYObjectIsKindOfClassNamed(player, @"AWEFeedBackgroundPlayManager")) {
+        return NO;
+    }
+
+    return DYYYObjectBoolValueForSelector(player, @selector(backgroundPlayerIsOn)) ||
+           DYYYObjectBoolValueForSelector(player, @selector(isBackgroundPlayerOn)) ||
+           DYYYObjectBoolValueForSelector(player, @selector(enableListenFeed));
 }
 
 static BOOL DYYYShouldBlockFeedNowPlayingPlayer(id player) {
@@ -869,23 +951,77 @@ static BOOL DYYYShouldBlockFeedNowPlayingPlayer(id player) {
         return NO;
     }
 
-    Class feedBackgroundPlayClass = NSClassFromString(@"AWEAwemeBackgroundPlayModule");
-    return feedBackgroundPlayClass && [player isKindOfClass:feedBackgroundPlayClass];
+    if (DYYYObjectIsKindOfClassNamed(player, @"AWEAwemeBackgroundPlayModule")) {
+        return DYYYShouldBlockFeedNowPlayingScene();
+    }
+
+    if (DYYYObjectIsKindOfClassNamed(player, @"AWEFeedBackgroundPlayManager")) {
+        return DYYYShouldBlockFeedNowPlayingScene() && !DYYYFeedBackgroundPlayManagerIsUserAudioMode(player);
+    }
+
+    return NO;
+}
+
+static BOOL DYYYShouldBlockFeedNowPlayingSystemInfoWrite(void) {
+    return DYYYGetBool(@"DYYYDisableFeedNowPlayingInfo") &&
+           !dyyyClearingFeedNowPlayingSystemInfo &&
+           DYYYShouldBlockFeedNowPlayingScene() &&
+           (CFAbsoluteTimeGetCurrent() <= dyyyFeedNowPlayingSystemBlockUntil ||
+            DYYYIsFeedNowPlayingPictureInPictureBlockActive());
+}
+
+static void DYYYRegisterFeedNowPlayingPictureInPictureObservers(void) {
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+      NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
+      NSArray<NSString *> *startNotifications = @[
+          @"AVPictureInPictureControllerWillStartPictureInPictureNotification",
+          @"AVPictureInPictureControllerDidStartPictureInPictureNotification",
+          @"AVPictureInPictureControllerPictureInPictureWillStartNotification",
+          @"AVPictureInPictureControllerPictureInPictureDidStartNotification"
+      ];
+      NSArray<NSString *> *stopNotifications = @[
+          @"AVPictureInPictureControllerWillStopPictureInPictureNotification",
+          @"AVPictureInPictureControllerDidStopPictureInPictureNotification",
+          @"AVPictureInPictureControllerPictureInPictureWillStopNotification",
+          @"AVPictureInPictureControllerPictureInPictureDidStopNotification"
+      ];
+
+      for (NSString *name in startNotifications) {
+          [center addObserverForName:name
+                              object:nil
+                               queue:[NSOperationQueue mainQueue]
+                          usingBlock:^(__unused NSNotification *notification) {
+                            if (DYYYGetBool(@"DYYYDisableFeedNowPlayingInfo")) {
+                                DYYYSetFeedNowPlayingPictureInPictureActive(YES);
+                            }
+                          }];
+      }
+
+      for (NSString *name in stopNotifications) {
+          [center addObserverForName:name
+                              object:nil
+                               queue:[NSOperationQueue mainQueue]
+                          usingBlock:^(__unused NSNotification *notification) {
+                            DYYYSetFeedNowPlayingPictureInPictureActive(NO);
+                          }];
+      }
+    });
 }
 
 %hook AWEAwemeBackgroundPlayModule
 
 - (id)nowPlayingInfo {
-    if (DYYYGetBool(@"DYYYDisableFeedNowPlayingInfo")) {
+    if (DYYYShouldBlockFeedNowPlayingPlayer(self)) {
         DYYYClearFeedNowPlayingSystemInfoThrottled();
+        return nil;
     }
 
     return %orig;
 }
 
 - (void)refreshNowPlayingInfoIfNeeded {
-    if (DYYYGetBool(@"DYYYDisableFeedNowPlayingInfo")) {
-        %orig;
+    if (DYYYShouldBlockFeedNowPlayingPlayer(self)) {
         DYYYClearFeedNowPlayingSystemInfoThrottled();
         return;
     }
@@ -894,8 +1030,7 @@ static BOOL DYYYShouldBlockFeedNowPlayingPlayer(id player) {
 }
 
 - (void)updateNowPlayingInfoPlayback {
-    if (DYYYGetBool(@"DYYYDisableFeedNowPlayingInfo")) {
-        %orig;
+    if (DYYYShouldBlockFeedNowPlayingPlayer(self)) {
         DYYYClearFeedNowPlayingSystemInfoThrottled();
         return;
     }
@@ -905,15 +1040,75 @@ static BOOL DYYYShouldBlockFeedNowPlayingPlayer(id player) {
 
 %end
 
-// 再从播放中心入口兜底，保留听抖音和音乐服务的系统播放信息。
+%hook AWEFeedBackgroundPlayManager
+
+- (id)nowPlayingInfo {
+    if (DYYYShouldBlockFeedNowPlayingPlayer(self)) {
+        DYYYClearFeedNowPlayingSystemInfoThrottled();
+        return nil;
+    }
+
+    return %orig;
+}
+
+- (void)setNowPlayingInfo:(id)nowPlayingInfo {
+    if (DYYYShouldBlockFeedNowPlayingPlayer(self)) {
+        %orig(nil);
+        DYYYClearFeedNowPlayingSystemInfoThrottled();
+        return;
+    }
+
+    %orig;
+}
+
+- (void)resetNowPlayingInfo:(id)model {
+    if (DYYYShouldBlockFeedNowPlayingPlayer(self)) {
+        DYYYClearFeedNowPlayingSystemInfoThrottled();
+        return;
+    }
+
+    %orig;
+}
+
+- (void)refreshNowPlayingInfo {
+    if (DYYYShouldBlockFeedNowPlayingPlayer(self)) {
+        DYYYClearFeedNowPlayingSystemInfoThrottled();
+        return;
+    }
+
+    %orig;
+}
+
+- (void)refreshNowPlayingInfoIsForce:(BOOL)isForce {
+    if (DYYYShouldBlockFeedNowPlayingPlayer(self)) {
+        DYYYClearFeedNowPlayingSystemInfoThrottled();
+        return;
+    }
+
+    %orig;
+}
+
+- (void)updateNowPlayingInfoPlayback {
+    if (DYYYShouldBlockFeedNowPlayingPlayer(self)) {
+        DYYYClearFeedNowPlayingSystemInfoThrottled();
+        return;
+    }
+
+    %orig;
+}
+
+%end
+
+// 再从抖音播放中心入口兜底，阻断前台信息流视频上岛。
 %hook AWENowPlayingInfoCenter
 
 - (void)becomePlayingPlayer:(id)player {
-    %orig;
-
     if (DYYYShouldBlockFeedNowPlayingPlayer(player)) {
         DYYYClearFeedNowPlayingSystemInfoThrottled();
+        return;
     }
+
+    %orig;
 }
 
 - (void)setNowPlayingInfo:(id)nowPlayingInfo {
@@ -929,6 +1124,29 @@ static BOOL DYYYShouldBlockFeedNowPlayingPlayer(id player) {
 - (void)refreshNowPlayingInfo {
     if (DYYYShouldBlockFeedNowPlayingPlayer(self.playingPlayer)) {
         DYYYClearFeedNowPlayingSystemInfoThrottled();
+        return;
+    }
+
+    %orig;
+}
+
+%end
+
+// 耳机或系统媒体会话可能绕过抖音播放中心，最终都要写入 MPNowPlayingInfoCenter。
+%hook MPNowPlayingInfoCenter
+
+- (void)setNowPlayingInfo:(NSDictionary *)nowPlayingInfo {
+    if (DYYYShouldBlockFeedNowPlayingSystemInfoWrite()) {
+        %orig(nil);
+        return;
+    }
+
+    %orig;
+}
+
+- (void)setPlaybackState:(NSInteger)playbackState {
+    if (DYYYShouldBlockFeedNowPlayingSystemInfoWrite()) {
+        %orig(0);
         return;
     }
 
@@ -9679,11 +9897,33 @@ static Class TagViewClass = nil;
 
 %hook TTPlayerView
 
+- (void)checkPictureInPictureMode {
+    %orig;
+
+    if (DYYYGetBool(@"DYYYDisableFeedNowPlayingInfo") && DYYYPlayerViewSupportsPictureInPicture(self)) {
+        DYYYExtendFeedNowPlayingPictureInPictureBlockWindow();
+        DYYYClearFeedNowPlayingSystemInfoThrottled();
+    }
+}
+
 - (void)layoutSubviews {
     %orig;
     UIView *parent = self.superview;
     if (parent) {
         parent.backgroundColor = self.backgroundColor;
+    }
+}
+
+%end
+
+%hook TTPlayerView2
+
+- (void)checkPictureInPictureMode {
+    %orig;
+
+    if (DYYYGetBool(@"DYYYDisableFeedNowPlayingInfo") && DYYYPlayerViewSupportsPictureInPicture(self)) {
+        DYYYExtendFeedNowPlayingPictureInPictureBlockWindow();
+        DYYYClearFeedNowPlayingSystemInfoThrottled();
     }
 }
 
@@ -10251,6 +10491,8 @@ static void findTargetViewInView(UIView *view) {
     [[NSUserDefaults standardUserDefaults] registerDefaults:@{
         @"DYYYDisableFeedNowPlayingInfo" : @YES
     }];
+
+    DYYYRegisterFeedNowPlayingPictureInPictureObservers();
 
     DYYYMigrateCombinedHDRModeIfNeeded();
 

--- a/DYYY.xm
+++ b/DYYY.xm
@@ -224,6 +224,12 @@ static __weak AWEPlayInteractionViewController *dyyyActiveSpeedInteractionContro
 static __weak AWEAwemeModel *dyyyCurrentSpeedAweme = nil;
 static NSString *dyyyLastAutoRestoredSpeedAwemeIdentifier = nil;
 static BOOL dyyyLongPressFastSpeedActive = NO;
+static BOOL dyyyLongPressLockedSpeedActive = NO;
+
+static void DYYYClearLongPressSpeedState(void) {
+    dyyyLongPressFastSpeedActive = NO;
+    dyyyLongPressLockedSpeedActive = NO;
+}
 
 static CGFloat DYYYViewControllerVisibilityScore(UIViewController *viewController) {
     if (!viewController || !viewController.isViewLoaded) {
@@ -347,6 +353,12 @@ static void DYYYEnsureFloatSpeedButton(AWEPlayInteractionViewController *interac
     if (!currentController) {
         updateSpeedButtonVisibility();
         return;
+    }
+
+    if ((dyyyLongPressFastSpeedActive || dyyyLongPressLockedSpeedActive) &&
+        currentController.model &&
+        !DYYYAwemeModelsMatch(dyyyCurrentSpeedAweme, currentController.model)) {
+        DYYYClearLongPressSpeedState();
     }
 
     dyyyActiveSpeedInteractionController = currentController;
@@ -477,7 +489,7 @@ static double DYYYPreparedPlaybackSpeed(void) {
 }
 
 static void DYYYApplyPreparedPlaybackSpeedToPlayer(id playerViewController) {
-    if (!DYYYShouldHandleSpeedFeatures() || !playerViewController || dyyyLongPressFastSpeedActive) {
+    if (!DYYYShouldHandleSpeedFeatures() || !playerViewController || dyyyLongPressFastSpeedActive || dyyyLongPressLockedSpeedActive) {
         return;
     }
 
@@ -493,7 +505,7 @@ static void DYYYApplyPreparedPlaybackSpeedToPlayer(id playerViewController) {
 }
 
 static void DYYYBindAndApplyCurrentPlaybackSpeed(void) {
-    if (!DYYYShouldHandleSpeedFeatures() || dyyyLongPressFastSpeedActive) {
+    if (!DYYYShouldHandleSpeedFeatures() || dyyyLongPressFastSpeedActive || dyyyLongPressLockedSpeedActive) {
         return;
     }
 
@@ -504,6 +516,20 @@ static void DYYYBindAndApplyCurrentPlaybackSpeed(void) {
 
     DYYYEnsureFloatSpeedButton(currentController);
     DYYYApplyPlaybackSpeed(currentController, DYYYConfiguredPlaybackSpeed());
+}
+
+static void DYYYScheduleConfiguredPlaybackSpeedRestore(void) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+      DYYYBindAndApplyCurrentPlaybackSpeed();
+    });
+}
+
+static void DYYYEndLockedLongPressSpeedAndRestoreIfNeeded(void) {
+    if (!dyyyLongPressLockedSpeedActive) {
+        return;
+    }
+    dyyyLongPressLockedSpeedActive = NO;
+    DYYYScheduleConfiguredPlaybackSpeedRestore();
 }
 
 static void DYYYHandleCurrentSpeedAwemeChanged(id aweme) {
@@ -522,12 +548,11 @@ static void DYYYHandleCurrentSpeedAwemeChanged(id aweme) {
         return;
     }
 
+    DYYYClearLongPressSpeedState();
     DYYYRestoreFloatSpeedButtonForAwemeIfNeeded(dyyyCurrentSpeedAweme);
 
     DYYYBindAndApplyCurrentPlaybackSpeed();
-    dispatch_async(dispatch_get_main_queue(), ^{
-      DYYYBindAndApplyCurrentPlaybackSpeed();
-    });
+    DYYYScheduleConfiguredPlaybackSpeedRestore();
 }
 
 @interface AWEFeedProgressSlider (DYYYProgressLabel)
@@ -3445,6 +3470,10 @@ static BOOL isGestureActive = NO;
         return;
     }
 
+    if (speed <= 1.0 && dyyyLongPressLockedSpeedActive) {
+        DYYYEndLockedLongPressSpeedAndRestoreIfNeeded();
+    }
+
     %orig(speed);
 }
 
@@ -3459,6 +3488,7 @@ static BOOL isGestureActive = NO;
 
     if (isBeginning) {
         dyyyLongPressFastSpeedActive = YES;
+        dyyyLongPressLockedSpeedActive = NO;
     } else if (isEnding) {
         isGestureActive = NO;
         currentLongPressSpeed = 0;
@@ -3469,9 +3499,7 @@ static BOOL isGestureActive = NO;
     %orig;
 
     if (isEnding) {
-        dispatch_async(dispatch_get_main_queue(), ^{
-          DYYYBindAndApplyCurrentPlaybackSpeed();
-        });
+        DYYYScheduleConfiguredPlaybackSpeedRestore();
     }
 
     if (!enableSpeedGesture) {
@@ -3510,20 +3538,27 @@ static BOOL isGestureActive = NO;
 
 - (void)handleLongPressLockedSpeedBegan {
     dyyyLongPressFastSpeedActive = YES;
+    dyyyLongPressLockedSpeedActive = NO;
     %orig;
 }
 
 - (void)handleLongPressLockedDoubleSpeedChanged:(id)arg1 gesture:(UIGestureRecognizer *)gesture {
     dyyyLongPressFastSpeedActive = YES;
+    dyyyLongPressLockedSpeedActive = NO;
     %orig(arg1, gesture);
 }
 
 - (void)handleLongPressLockedDoubleSpeedEnded:(id)arg1 gesture:(UIGestureRecognizer *)gesture {
     %orig(arg1, gesture);
     dyyyLongPressFastSpeedActive = NO;
-    dispatch_async(dispatch_get_main_queue(), ^{
-      DYYYBindAndApplyCurrentPlaybackSpeed();
-    });
+    dyyyLongPressLockedSpeedActive = YES;
+}
+
+- (void)longPressSpeedControlDidChangeSpeed:(double)speed {
+    %orig(speed);
+    if (speed <= 1.0 && dyyyLongPressLockedSpeedActive) {
+        DYYYEndLockedLongPressSpeedAndRestoreIfNeeded();
+    }
 }
 %end
 
@@ -8543,6 +8578,7 @@ static Class tabBarButtonClass = nil;
 
     float newSpeed = [speeds[newIndex] floatValue];
     updateSpeedButtonUI();
+    DYYYClearLongPressSpeedState();
 
     [UIView animateWithDuration:0.1
         delay:0


### PR DESCRIPTION
## 改动摘要

本次合并包含五部分：完善 Deb 自动构建与 GitHub Release 更新日志的触发判定；协调并发打包时的 Release 发布顺序；修复长按倍速、锁定倍速与快捷倍速自动恢复之间的状态冲突；增强头像加号隐藏在头像特效和动态刷新场景下的兜底；继续收紧信息流视频向系统播放信息和灵动岛写入的路径。

## 自动构建与 Release 调整

- 为 `main` 分支推送增加路径过滤，仅插件源码、`DYYY.plist`、`control`、`Makefile`、资源和布局变化时进入构建判定。
- 将 `control` 版本号变化纳入自动发布范围，更新日志会读取前后版本并归入“版本与构建信息”。
- 新增 `build-relevance.sh`，统一判断单个提交或推送范围是否真正影响构建产物。
- 对 `Makefile` 进行归一化比较，忽略设备 IP、端口、本地安装脚本、注释和 `Makefile.local` 等不影响产物的变化。
- `Makefile` 中构建目标、源码列表、依赖和编译参数等有效变化仍会正常触发 Deb 构建与 Release。
- 工作流先在 Ubuntu 环境判断是否需要构建，仅必要时启动 macOS 打包任务。
- 更新日志复用同一构建相关性判定，确保触发范围与 Release 内容一致。

## Release 发布协调

- 新增 `release-coordinator.sh`，在发布前查询同一分支的 `build deb` 工作流运行状态。
- 如果存在更新的构建相关运行，当前运行只保留 Artifact，不再抢发 GitHub Release。
- 如果存在更早的打包任务仍在运行，当前任务会等待其结束并留出稳定窗口后再判断是否发布。
- 复用 `build-relevance.sh` 判断新运行是否真正影响构建，避免纯维护运行阻止有效版本发布。
- 将生成更新日志和发布 Release 移到发布协调之后，仅最终应发布的运行执行。
- 为工作流补充 `actions: read` 权限，用于读取 Actions 运行列表。

## 倍速控制修复

- 长按临时倍速生效期间暂停快捷倍速与默认倍速的自动重写，避免手势中的速度被配置值覆盖。
- 移除原先基于 `hasChangedSpeed` 的二次切换逻辑，避免长按 2 倍速与自定义长按倍速互相覆盖。
- 区分普通长按和锁定长按倍速状态，锁定倍速期间阻止自动恢复逻辑抢写播放速度。
- 长按或锁定倍速结束后回到主线程重新应用当前配置倍速，避免播放器停留在临时速度。
- 切换作品或点击快捷倍速按钮时清理长按倍速状态，防止旧作品的临时状态影响当前视频。

## 头像加号隐藏修复

- 补充头像特效、关注动画、静态关注动画、关注提示容器等多类头像加号视图识别。
- 支持在头像装饰控制器、头像主业务控制器、头像元素、关注提示控制器等路径中重新应用隐藏逻辑。
- 对关注动画播放、关注状态变化、评论区显示、视图进入窗口和父视图变化增加兜底处理。
- 对隐藏加号和移除加号分别处理：隐藏时只清理图标内容，移除时禁用对应容器交互并隐藏容器。
- 增加延迟重试，避免头像特效或关注动画异步重建后加号重新出现。

## 播放信息屏蔽修复

- 强化“屏蔽灵动岛抖音播放信息”开关的兜底逻辑，继续阻止信息流视频写入系统播放信息。
- 拦截 `AWEAwemeBackgroundPlayModule`、`AWEFeedBackgroundPlayManager`、`AWENowPlayingInfoCenter` 和 `MPNowPlayingInfoCenter` 等多条播放信息写入路径。
- 前台信息流和画中画场景下延长播放信息清理窗口，避免灵动岛、锁屏或系统播放控件残留。
- 监听画中画开始与结束事件，并在支持画中画的播放器检查路径中主动清空播放信息。
- 保留“听抖音”等用户主动音频模式，避免误伤正常后台音频和系统播放信息能力。

## 验证

- 工作流 YAML、`build-relevance.sh`、`generate-release-notes.sh` 和 `release-coordinator.sh` 语法检查通过。
- 版本号变化会被识别为构建相关，仅修改设备 IP 的 Makefile 变更会被忽略，修改构建目标的 Makefile 变更会被识别为构建相关。
- `cfd60a4` 推送到 `VexCove:main` 后已自动纳入此 PR，并已同步补充标题、摘要和详细改动信息。
- `cfd60a4` 为 workflow-only 改动，推送后未触发 fork 仓库 Deb 构建，符合当前路径过滤规则。