### PR TITLE
完善自动构建触发与更新日志判定

### DIFF
--- a/.github/scripts/build-relevance.sh
+++ b/.github/scripts/build-relevance.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+zero_sha="0000000000000000000000000000000000000000"
+
+is_direct_build_path() {
+    local path=$1
+
+    case "$path" in
+        DYYY.plist|control|Resources/*|layout/*)
+            return 0
+            ;;
+    esac
+
+    if [[ "$path" != */* ]]; then
+        case "$path" in
+            *.h|*.m|*.mm|*.x|*.xm|*.c|*.cc|*.cpp|*.s|*.S)
+                return 0
+                ;;
+        esac
+    fi
+
+    return 1
+}
+
+normalize_makefile_revision() {
+    local revision=$1
+    local makefile_content
+
+    if ! makefile_content=$(git show "${revision}:Makefile" 2>/dev/null); then
+        return 0
+    fi
+
+    printf '%s\n' "$makefile_content" |
+        awk '
+            BEGIN {
+                skip_device_block = 0
+                skip_after_package = 0
+            }
+
+            skip_device_block {
+                if ($0 ~ /^[[:space:]]*THEOS_DEVICE_PORT[[:space:]]*[:+?]?=/) {
+                    skip_device_block = 0
+                }
+                next
+            }
+
+            /^[[:space:]]*ifeq[[:space:]]*\(\$\(shell whoami\),huami\)/ {
+                skip_device_block = 1
+                next
+            }
+
+            skip_after_package {
+                line = $0
+                gsub(/^[[:space:]]+|[[:space:]\\]+$/, "", line)
+                if (line == "fi") {
+                    skip_after_package = 0
+                }
+                next
+            }
+
+            /^after-package::[[:space:]]*$/ {
+                skip_after_package = 1
+                next
+            }
+
+            /^[[:space:]]*THEOS_DEVICE_(IP|PORT)[[:space:]]*[:+?]?=/ {
+                next
+            }
+
+            {
+                line = $0
+                sub(/[[:space:]]*#.*/, "", line)
+                gsub(/[[:space:]]+/, " ", line)
+                sub(/^ /, "", line)
+                sub(/ $/, "", line)
+
+                if (line == "" || line == "-include Makefile.local") {
+                    next
+                }
+
+                print line
+            }
+        '
+}
+
+makefile_affects_build() {
+    local before=$1
+    local after=$2
+    local before_file
+    local after_file
+    local result
+
+    before_file=$(mktemp)
+    after_file=$(mktemp)
+
+    normalize_makefile_revision "$before" > "$before_file"
+    normalize_makefile_revision "$after" > "$after_file"
+
+    if cmp -s "$before_file" "$after_file"; then
+        result=1
+    else
+        result=0
+    fi
+
+    rm -f "$before_file" "$after_file"
+    return "$result"
+}
+
+commit_touches_path() {
+    local hash=$1
+    local expected_path=$2
+
+    git diff-tree --root --no-commit-id --name-only -r "$hash" |
+        grep -Fxq "$expected_path"
+}
+
+commit_touches_direct_build_path() {
+    local hash=$1
+    local path
+
+    while IFS= read -r path; do
+        if is_direct_build_path "$path"; then
+            return 0
+        fi
+    done < <(git diff-tree --root --no-commit-id --name-only -r "$hash")
+
+    return 1
+}
+
+commit_affects_build() {
+    local hash=$1
+    local parent
+
+    if commit_touches_direct_build_path "$hash"; then
+        return 0
+    fi
+
+    if ! commit_touches_path "$hash" "Makefile"; then
+        return 1
+    fi
+
+    parent=$(git rev-parse "${hash}^" 2>/dev/null || git hash-object -t tree /dev/null)
+    makefile_affects_build "$parent" "$hash"
+}
+
+range_affects_build() {
+    local before=$1
+    local after=$2
+    local path
+    local makefile_changed=false
+
+    if [[ -z "$before" || "$before" == "$zero_sha" ]] ||
+       ! git cat-file -e "${before}^{commit}" 2>/dev/null; then
+        before=$(git hash-object -t tree /dev/null)
+    fi
+
+    while IFS= read -r path; do
+        if is_direct_build_path "$path"; then
+            return 0
+        fi
+
+        if [[ "$path" == "Makefile" ]]; then
+            makefile_changed=true
+        fi
+    done < <(git diff --name-only "$before" "$after")
+
+    if [[ "$makefile_changed" == true ]]; then
+        makefile_affects_build "$before" "$after"
+        return
+    fi
+
+    return 1
+}
+
+main() {
+    local command=${1:-}
+
+    case "$command" in
+        commit)
+            commit_affects_build "$2"
+            ;;
+        range)
+            range_affects_build "$2" "$3"
+            ;;
+        makefile)
+            makefile_affects_build "$2" "$3"
+            ;;
+        *)
+            echo "Usage: $0 {commit <sha>|range <before> <after>|makefile <before> <after>}" >&2
+            exit 2
+            ;;
+    esac
+}
+
+if [[ "${BASH_SOURCE[0]:-$0}" == "$0" ]]; then
+    main "$@"
+fi

--- a/.github/scripts/generate-release-notes.sh
+++ b/.github/scripts/generate-release-notes.sh
@@ -11,13 +11,14 @@ zero_sha="0000000000000000000000000000000000000000"
 features_file=$(mktemp)
 improvements_file=$(mktemp)
 fixes_file=$(mktemp)
-trap 'rm -f "$features_file" "$improvements_file" "$fixes_file"' EXIT
+package_file=$(mktemp)
+trap 'rm -f "$features_file" "$improvements_file" "$fixes_file" "$package_file"' EXIT
 
 is_plugin_file() {
     local path=$1
 
     case "$path" in
-        DYYY.plist|Resources/*|layout/*)
+        DYYY.plist|control|Resources/*|layout/*)
             return 0
             ;;
     esac
@@ -31,6 +32,13 @@ is_plugin_file() {
     fi
 
     return 1
+}
+
+commit_touches_control() {
+    local hash=$1
+
+    git diff-tree --root --no-commit-id --name-only -r "$hash" |
+        grep -Fxq 'control'
 }
 
 commit_touches_plugin() {
@@ -74,6 +82,28 @@ while IFS=$'\t' read -r hash subject; do
     short_hash=${hash:0:8}
     entry="- **${subject}** ([\`${short_hash}\`](${server_url}/${repository}/commit/${hash}))"
 
+    if commit_touches_control "$hash"; then
+        previous_version=$(
+            git show "${hash}^:control" 2>/dev/null |
+                awk -F': ' '$1 == "Version" { print $2; exit }' || true
+        )
+        current_version=$(
+            git show "${hash}:control" 2>/dev/null |
+                awk -F': ' '$1 == "Version" { print $2; exit }' || true
+        )
+
+        if [[ -n "$current_version" && "$previous_version" != "$current_version" ]]; then
+            if [[ -n "$previous_version" ]]; then
+                entry="- **版本更新：\`${previous_version}\` → \`${current_version}\`** ([\`${short_hash}\`](${server_url}/${repository}/commit/${hash}))"
+            else
+                entry="- **版本设置为 \`${current_version}\`** ([\`${short_hash}\`](${server_url}/${repository}/commit/${hash}))"
+            fi
+        fi
+
+        printf '%s\n' "$entry" >> "$package_file"
+        continue
+    fi
+
     case "$subject" in
         新增*|增加*|添加*|支持*|引入*|实现*|feat:*|feat\(*|Feature*|Add*)
             printf '%s\n' "$entry" >> "$features_file"
@@ -90,7 +120,7 @@ done < <(git log --reverse --format=$'%H\t%s' "$commit_range")
 cat > "$notes_file" <<EOF
 # 更新日志
 
-本次构建包含 ${relevant_count} 项插件功能变更，以下为详细更新内容：
+本次构建包含 ${relevant_count} 项插件或版本变更，以下为详细更新内容：
 EOF
 
 append_section() {
@@ -106,9 +136,10 @@ append_section() {
 append_section "新增功能" "$features_file"
 append_section "体验优化与调整" "$improvements_file"
 append_section "问题修复" "$fixes_file"
+append_section "版本与打包信息" "$package_file"
 
 if (( relevant_count == 0 )); then
-    printf '\n本次手动构建未检测到新的插件功能变更。\n' >> "$notes_file"
+    printf '\n本次手动构建未检测到新的插件功能或版本变更。\n' >> "$notes_file"
 fi
 
 cat >> "$notes_file" <<'EOF'

--- a/.github/scripts/generate-release-notes.sh
+++ b/.github/scripts/generate-release-notes.sh
@@ -2,11 +2,13 @@
 
 set -euo pipefail
 
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+source "${script_dir}/build-relevance.sh"
+
 notes_file="${1:-release-notes.md}"
 head_sha="${GITHUB_SHA:-HEAD}"
 repository="${GITHUB_REPOSITORY:-$(git config --get remote.origin.url | sed -E 's#(git@github.com:|https://github.com/)##; s#\.git$##')}"
 server_url="${GITHUB_SERVER_URL:-https://github.com}"
-zero_sha="0000000000000000000000000000000000000000"
 
 features_file=$(mktemp)
 improvements_file=$(mktemp)
@@ -14,44 +16,10 @@ fixes_file=$(mktemp)
 package_file=$(mktemp)
 trap 'rm -f "$features_file" "$improvements_file" "$fixes_file" "$package_file"' EXIT
 
-is_plugin_file() {
-    local path=$1
-
-    case "$path" in
-        DYYY.plist|control|Resources/*|layout/*)
-            return 0
-            ;;
-    esac
-
-    if [[ "$path" != */* ]]; then
-        case "$path" in
-            *.h|*.m|*.mm|*.x|*.xm|*.c|*.cc|*.cpp|*.s|*.S)
-                return 0
-                ;;
-        esac
-    fi
-
-    return 1
-}
-
 commit_touches_control() {
     local hash=$1
 
-    git diff-tree --root --no-commit-id --name-only -r "$hash" |
-        grep -Fxq 'control'
-}
-
-commit_touches_plugin() {
-    local hash=$1
-    local path
-
-    while IFS= read -r path; do
-        if is_plugin_file "$path"; then
-            return 0
-        fi
-    done < <(git diff-tree --root --no-commit-id --name-only -r "$hash")
-
-    return 1
+    commit_touches_path "$hash" "control"
 }
 
 if [[ -n "${PUSH_BEFORE:-}" && "$PUSH_BEFORE" != "$zero_sha" ]] &&
@@ -74,7 +42,7 @@ while IFS=$'\t' read -r hash subject; do
     [[ -n "$hash" ]] || continue
 
     parent_count=$(git rev-list --parents -n 1 "$hash" | awk '{ print NF - 1 }')
-    if (( parent_count > 1 )) || ! commit_touches_plugin "$hash"; then
+    if (( parent_count > 1 )) || ! commit_affects_build "$hash"; then
         continue
     fi
 
@@ -104,6 +72,12 @@ while IFS=$'\t' read -r hash subject; do
         continue
     fi
 
+    if commit_touches_path "$hash" "Makefile" &&
+       ! commit_touches_direct_build_path "$hash"; then
+        printf '%s\n' "$entry" >> "$package_file"
+        continue
+    fi
+
     case "$subject" in
         新增*|增加*|添加*|支持*|引入*|实现*|feat:*|feat\(*|Feature*|Add*)
             printf '%s\n' "$entry" >> "$features_file"
@@ -120,7 +94,7 @@ done < <(git log --reverse --format=$'%H\t%s' "$commit_range")
 cat > "$notes_file" <<EOF
 # 更新日志
 
-本次构建包含 ${relevant_count} 项插件或版本变更，以下为详细更新内容：
+本次构建包含 ${relevant_count} 项插件、版本或构建配置变更，以下为详细更新内容：
 EOF
 
 append_section() {
@@ -136,10 +110,10 @@ append_section() {
 append_section "新增功能" "$features_file"
 append_section "体验优化与调整" "$improvements_file"
 append_section "问题修复" "$fixes_file"
-append_section "版本与打包信息" "$package_file"
+append_section "版本与构建信息" "$package_file"
 
 if (( relevant_count == 0 )); then
-    printf '\n本次手动构建未检测到新的插件功能或版本变更。\n' >> "$notes_file"
+    printf '\n本次手动构建未检测到新的插件、版本或构建配置变更。\n' >> "$notes_file"
 fi
 
 cat >> "$notes_file" <<'EOF'

--- a/.github/scripts/generate-release-notes.sh
+++ b/.github/scripts/generate-release-notes.sh
@@ -13,6 +13,39 @@ improvements_file=$(mktemp)
 fixes_file=$(mktemp)
 trap 'rm -f "$features_file" "$improvements_file" "$fixes_file"' EXIT
 
+is_plugin_file() {
+    local path=$1
+
+    case "$path" in
+        DYYY.plist|Resources/*|layout/*)
+            return 0
+            ;;
+    esac
+
+    if [[ "$path" != */* ]]; then
+        case "$path" in
+            *.h|*.m|*.mm|*.x|*.xm|*.c|*.cc|*.cpp|*.s|*.S)
+                return 0
+                ;;
+        esac
+    fi
+
+    return 1
+}
+
+commit_touches_plugin() {
+    local hash=$1
+    local path
+
+    while IFS= read -r path; do
+        if is_plugin_file "$path"; then
+            return 0
+        fi
+    done < <(git diff-tree --root --no-commit-id --name-only -r "$hash")
+
+    return 1
+}
+
 if [[ -n "${PUSH_BEFORE:-}" && "$PUSH_BEFORE" != "$zero_sha" ]] &&
    git cat-file -e "${PUSH_BEFORE}^{commit}" 2>/dev/null; then
     commit_range="${PUSH_BEFORE}..${head_sha}"
@@ -27,19 +60,25 @@ else
     fi
 fi
 
-commit_count=$(git rev-list --count "$commit_range")
+relevant_count=0
 
 while IFS=$'\t' read -r hash subject; do
     [[ -n "$hash" ]] || continue
 
+    parent_count=$(git rev-list --parents -n 1 "$hash" | awk '{ print NF - 1 }')
+    if (( parent_count > 1 )) || ! commit_touches_plugin "$hash"; then
+        continue
+    fi
+
+    relevant_count=$((relevant_count + 1))
     short_hash=${hash:0:8}
     entry="- **${subject}** ([\`${short_hash}\`](${server_url}/${repository}/commit/${hash}))"
 
     case "$subject" in
-        新增*|增加*|添加*|支持*|引入*|实现*)
+        新增*|增加*|添加*|支持*|引入*|实现*|feat:*|feat\(*|Feature*|Add*)
             printf '%s\n' "$entry" >> "$features_file"
             ;;
-        修复*|解决*|恢复*|纠正*)
+        修复*|解决*|恢复*|纠正*|fix:*|fix\(*|Fix*|Bugfix*)
             printf '%s\n' "$entry" >> "$fixes_file"
             ;;
         *)
@@ -51,7 +90,7 @@ done < <(git log --reverse --format=$'%H\t%s' "$commit_range")
 cat > "$notes_file" <<EOF
 # 更新日志
 
-本次构建包含本次推送中的 ${commit_count} 项变更，以下为详细更新内容：
+本次构建包含 ${relevant_count} 项插件功能变更，以下为详细更新内容：
 EOF
 
 append_section() {
@@ -67,6 +106,10 @@ append_section() {
 append_section "新增功能" "$features_file"
 append_section "体验优化与调整" "$improvements_file"
 append_section "问题修复" "$fixes_file"
+
+if (( relevant_count == 0 )); then
+    printf '\n本次手动构建未检测到新的插件功能变更。\n' >> "$notes_file"
+fi
 
 cat >> "$notes_file" <<'EOF'
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,7 @@ on:
       - '*.s'
       - '*.S'
       - 'DYYY.plist'
+      - 'control'
       - 'Resources/**'
       - 'layout/**'
   workflow_dispatch:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,7 @@ on:
       - '*.S'
       - 'DYYY.plist'
       - 'control'
+      - 'Makefile'
       - 'Resources/**'
       - 'layout/**'
   workflow_dispatch:
@@ -36,7 +37,33 @@ permissions:
   contents: write
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      should_build: ${{ steps.relevance.outputs.should_build }}
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Detect build-relevant changes
+        id: relevance
+        env:
+          PUSH_BEFORE: ${{ github.event.before }}
+        run: |
+          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]] ||
+             .github/scripts/build-relevance.sh range "$PUSH_BEFORE" "$GITHUB_SHA"; then
+            echo "should_build=true" >> "$GITHUB_OUTPUT"
+            echo "Build-relevant plugin, package, or Makefile changes detected."
+          else
+            echo "should_build=false" >> "$GITHUB_OUTPUT"
+            echo "Only non-build Makefile settings changed; skipping Deb build and Release."
+          fi
+
   build:
+    needs: changes
+    if: needs.changes.outputs.should_build == 'true'
     runs-on: macos-latest
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,20 @@ on:
   push:
     branches:
       - main
+    paths:
+      - '*.h'
+      - '*.m'
+      - '*.mm'
+      - '*.x'
+      - '*.xm'
+      - '*.c'
+      - '*.cc'
+      - '*.cpp'
+      - '*.s'
+      - '*.S'
+      - 'DYYY.plist'
+      - 'Resources/**'
+      - 'layout/**'
   workflow_dispatch:
     inputs:
       scheme:


### PR DESCRIPTION
## 改动摘要

完善 Deb 自动构建与 GitHub Release 更新日志的判定逻辑，仅在插件功能、版本号或实际影响构建产物的配置变化时触发发布，并避免维护性提交污染 Release 内容。

## 具体调整

- 为 `main` 分支推送增加路径过滤，仅插件源码、`DYYY.plist`、`control`、`Makefile`、资源和布局变化时进入构建判定。
- 将 `control` 版本号变化纳入发布范围，更新日志会读取前后版本并归入“版本与构建信息”。
- 新增 `build-relevance.sh`，统一判断单个提交或推送范围是否真正影响构建。
- 对 `Makefile` 进行归一化比较，忽略设备 IP、端口、本地安装脚本、注释和 `Makefile.local` 等不影响产物的变化。
- `Makefile` 中构建目标、源码列表、依赖、编译参数等有效变化仍会正常触发 Deb 构建与 Release。
- 工作流先在 Ubuntu 环境判断是否需要构建，仅必要时启动 macOS 打包任务。
- 更新日志复用同一构建相关性判定，确保触发范围与 Release 内容一致。

## 验证

- 工作流 YAML、`build-relevance.sh` 和 `generate-release-notes.sh` 语法检查通过。
- 版本号变化会被识别为构建相关，并生成版本升级记录。
- 仅修改设备 IP 的 Makefile 变更会被忽略。
- 修改 iOS 构建目标的 Makefile 变更会被识别为构建相关。
- 此 PR 使用隔离分支提交，未包含后续长按倍速修复。