### PR TITLE
清屏按钮增加其他功能

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,9 @@
 name: build deb
 
 on:
-  push:
-    branches:
-      - main
+  #push:
+  #  branches:
+  #    - main
   workflow_dispatch:
     inputs:
       scheme:

--- a/DYYY.xm
+++ b/DYYY.xm
@@ -385,6 +385,20 @@ static void DYYYEnsureFloatSpeedButton(AWEPlayInteractionViewController *interac
     updateSpeedButtonVisibility();
 }
 
+// 提供给跨文件调用的刷新入口：根据当前可见 PlayInteractionVC 重新评估并恢复倍速按钮，
+// 用于清屏退出等场景，避免清屏期间 viewDidDisappear 把 dyyyInteractionViewVisible 置 NO 后状态卡住。
+void DYYYRefreshFloatSpeedButton(void) {
+    void (^applyBlock)(void) = ^{
+        AWEPlayInteractionViewController *currentController = (AWEPlayInteractionViewController *)DYYYCurrentSpeedInteractionController();
+        DYYYEnsureFloatSpeedButton(currentController);
+    };
+    if ([NSThread isMainThread]) {
+        applyBlock();
+    } else {
+        dispatch_async(dispatch_get_main_queue(), applyBlock);
+    }
+}
+
 static BOOL DYYYSetPlaybackRateOnTarget(id target, double speed) {
     if (!target || ![target respondsToSelector:@selector(setVideoControllerPlaybackRate:)]) {
         return NO;

--- a/DYYYFloatClearButton.xm
+++ b/DYYYFloatClearButton.xm
@@ -557,14 +557,23 @@ void reloadClearButtonConfiguration(void) {
 }
 
 - (void)handleTouchDown {
+    if ([self dyyy_isInSelfHiddenState]) {
+        return;
+    }
     [self resetFadeTimer];
 }
 
 - (void)handleTouchUpInside {
+    if ([self dyyy_isInSelfHiddenState]) {
+        return;
+    }
     [self resetFadeTimer];
 }
 
 - (void)handleTouchUpOutside {
+    if ([self dyyy_isInSelfHiddenState]) {
+        return;
+    }
     [self resetFadeTimer];
 }
 
@@ -598,10 +607,34 @@ void reloadClearButtonConfiguration(void) {
     }
 }
 
+- (BOOL)dyyy_shouldSelfHideOnClear {
+    return [[NSUserDefaults standardUserDefaults] boolForKey:@"DYYYHideClearButtonOnTap"];
+}
+
+- (BOOL)dyyy_isInSelfHiddenState {
+    return self.isElementsHidden && [self dyyy_shouldSelfHideOnClear];
+}
+
+- (void)dyyy_applySelfHiddenAlpha {
+    if (self.fadeTimer) {
+        [self.fadeTimer invalidate];
+        self.fadeTimer = nil;
+    }
+    // alpha 必须 > 0.01 才能继续接收 hit-test，0.02 在动态背景下几乎不可见
+    self.alpha = 0.02;
+}
+
 - (void)handleTap {
     if (isAppInTransition)
         return;
-    [self resetFadeTimer];
+
+    BOOL selfHide = [self dyyy_shouldSelfHideOnClear];
+    BOOL willEnterHidden = !self.isElementsHidden;
+    // 仅在不会进入“按钮自隐藏”状态时才重置淡出动画
+    if (!(selfHide && willEnterHidden)) {
+        [self resetFadeTimer];
+    }
+
     if (!self.isElementsHidden) {
         initTargetClassNames();
         [self hideUIElements];
@@ -611,6 +644,10 @@ void reloadClearButtonConfiguration(void) {
         BOOL hideSpeed = [[NSUserDefaults standardUserDefaults] boolForKey:@"DYYYHideSpeed"];
         if (hideSpeed) {
             hideSpeedButton();
+        }
+
+        if (selfHide) {
+            [self dyyy_applySelfHiddenAlpha];
         }
     } else {
         self.isElementsHidden = NO;
@@ -623,6 +660,10 @@ void reloadClearButtonConfiguration(void) {
         if (hideSpeed) {
             showSpeedButton();
         }
+
+        // 退出清屏，恢复正常透明度并重启淡出
+        self.alpha = self.originalAlpha;
+        [self resetFadeTimer];
     }
 }
 
@@ -727,6 +768,12 @@ void reloadClearButtonConfiguration(void) {
     BOOL hideSpeed = [[NSUserDefaults standardUserDefaults] boolForKey:@"DYYYHideSpeed"];
     if (hideSpeed) {
         showSpeedButton();
+    }
+
+    // 切场景/重置状态时，确保按钮自隐藏 alpha 也被恢复，避免按钮一直处于近乎透明的状态
+    if (self.alpha < 0.1) {
+        self.alpha = self.originalAlpha;
+        [self resetFadeTimer];
     }
 }
 - (void)dealloc {

--- a/DYYYFloatClearButton.xm
+++ b/DYYYFloatClearButton.xm
@@ -66,6 +66,7 @@ static char dyyyProgressModeKey;
 static char dyyyProgressOriginalHiddenKey;
 static char dyyyProgressOriginalInteractionKey;
 static char dyyyProgressOriginalLayerOpacityKey;
+static char dyyyClearOriginalAlphaKey;
 
 static DYYYClearProgressMode DYYYCurrentClearProgressMode(void) {
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
@@ -259,7 +260,6 @@ void hideClearButton(void) {
 static void forceResetAllUIElements(void) {
     DYYYPerformClearButtonMutation(^{
         initTargetClassNames();
-        Class StackViewClass = NSClassFromString(@"AWEElementStackView");
         for (UIWindow *window in [UIApplication sharedApplication].windows) {
             for (NSString *className in targetClassNames) {
                 Class viewClass = NSClassFromString(className);
@@ -268,10 +268,11 @@ static void forceResetAllUIElements(void) {
                 NSMutableArray *views = [NSMutableArray array];
                 findViewsOfClassHelper(window, viewClass, views);
                 for (UIView *view in views) {
-                    if ([view isKindOfClass:StackViewClass]) {
-                        view.alpha = 1.0; // 基础透明度交给全局透明度处理，避免重复乘
-                    } else {
-                        view.alpha = 1.0; // 恢复透明度
+                    // 优先使用进入清屏前记录的原 alpha，避免覆盖业务层动态 alpha（如播放中 alpha=0 的暂停图标）
+                    NSNumber *originalAlpha = objc_getAssociatedObject(view, &dyyyClearOriginalAlphaKey);
+                    view.alpha = originalAlpha ? originalAlpha.floatValue : 1.0;
+                    if (originalAlpha) {
+                        objc_setAssociatedObject(view, &dyyyClearOriginalAlphaKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
                     }
                 }
             }
@@ -755,6 +756,10 @@ void reloadClearButtonConfiguration(void) {
                         if (![controller isKindOfClass:NSClassFromString(@"AWEFeedContainerViewController")]) {
                             continue;
                         }
+                    }
+                    // 记录进入清屏前的原始 alpha，仅首次记录（避免周期性检查重复调用时被覆盖为 0）
+                    if (!objc_getAssociatedObject(view, &dyyyClearOriginalAlphaKey)) {
+                        objc_setAssociatedObject(view, &dyyyClearOriginalAlphaKey, @(view.alpha), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
                     }
                     [self.hiddenViewsList addObject:view];
                     view.alpha = 0.0;

--- a/DYYYFloatClearButton.xm
+++ b/DYYYFloatClearButton.xm
@@ -636,6 +636,9 @@ void reloadClearButtonConfiguration(void) {
     }
 
     if (!self.isElementsHidden) {
+        // 调试：进入清屏前快照完整视图树，用于定位未知视图类名（如暂停按钮等）
+        [DYYYUtils dumpAllWindowsViewTreeToFile:@"/var/mobile/douyin_view_tree.txt"];
+
         initTargetClassNames();
         [self hideUIElements];
         self.isElementsHidden = YES;

--- a/DYYYFloatClearButton.xm
+++ b/DYYYFloatClearButton.xm
@@ -659,6 +659,10 @@ void reloadClearButtonConfiguration(void) {
         BOOL hideSpeed = [[NSUserDefaults standardUserDefaults] boolForKey:@"DYYYHideSpeed"];
         if (hideSpeed) {
             showSpeedButton();
+            // 退出清屏时主动刷新一次：清屏期间可能发生过 PlayInteractionVC 的 viewDidDisappear，
+            // 导致 dyyyInteractionViewVisible 被置 NO，此时仅靠 showSpeedButton() 无法让倍速按钮重新出现，
+            // 必须重新从当前可见 controller 备份状态。
+            DYYYRefreshFloatSpeedButton();
         }
 
         // 退出清屏，恢复正常透明度并重启淡出

--- a/DYYYFloatClearButton.xm
+++ b/DYYYFloatClearButton.xm
@@ -290,6 +290,7 @@ void initTargetClassNames(void) {
     configuration |= [defaults boolForKey:@"DYYYHideDanmaku"] ? (1U << 1) : 0;
     configuration |= [defaults boolForKey:@"DYYYHideSlider"] ? (1U << 2) : 0;
     configuration |= [defaults boolForKey:@"DYYYHideChapter"] ? (1U << 3) : 0;
+    configuration |= [defaults boolForKey:@"DYYYHidePauseVideoIcon"] ? (1U << 4) : 0;
     if (targetClassNames && dyyyTargetClassConfiguration == configuration) {
         return;
     }
@@ -312,6 +313,10 @@ void initTargetClassNames(void) {
     }
     if (configuration & (1U << 3)) {
         [list addObject:@"AWEDemaciaChapterProgressSlider"];
+    }
+    if (configuration & (1U << 4)) {
+        // 视频中央的播放/暂停图标
+        [list addObject:@"AWEAwemePlayVideoPauseIcon"];
     }
 
     targetClassNames = [list copy];
@@ -636,9 +641,6 @@ void reloadClearButtonConfiguration(void) {
     }
 
     if (!self.isElementsHidden) {
-        // 调试：进入清屏前快照完整视图树，用于定位未知视图类名（如暂停按钮等）
-        [DYYYUtils dumpAllWindowsViewTreeToFile:@"/var/mobile/douyin_view_tree.txt"];
-
         initTargetClassNames();
         [self hideUIElements];
         self.isElementsHidden = YES;

--- a/DYYYFloatSpeedButton.h
+++ b/DYYYFloatSpeedButton.h
@@ -43,6 +43,7 @@ extern void setCurrentSpeedIndex(NSInteger index);
 extern void updateSpeedButtonUI(void);
 extern void updateSpeedButtonVisibility(void);
 extern id DYYYCurrentSpeedInteractionController(void);
+extern void DYYYRefreshFloatSpeedButton(void);
 
 #ifdef __cplusplus
 }

--- a/DYYYSettings.xm
+++ b/DYYYSettings.xm
@@ -3349,6 +3349,16 @@ void showDYYYSettingsVC(UIViewController *rootVC, BOOL hasAgreed) {
           @"imageName" : @"ic_eyeslash_outlined_16"
       }];
       [clearButtonItems addObject:hideSpeedButton];
+      // 清屏后隐藏清屏按钮自身（仍可点击恢复）
+      AWESettingItemModel *hideClearButtonOnTap = [DYYYSettingsHelper createSettingItem:@{
+          @"identifier" : @"DYYYHideClearButtonOnTap",
+          @"title" : @"清屏隐藏清屏",
+          @"subTitle" : @"清屏后隐藏清屏按钮自身，原位置仍可点击恢复",
+          @"detail" : @"",
+          @"cellType" : @37,
+          @"imageName" : @"ic_eyeslash_outlined_16"
+      }];
+      [clearButtonItems addObject:hideClearButtonOnTap];
       NSMutableArray<AWESettingItemModel *> *clearDependentItems = [NSMutableArray array];
       for (AWESettingItemModel *item in clearButtonItems) {
           if (item != enableClearButton) {

--- a/DYYYSettings.xm
+++ b/DYYYSettings.xm
@@ -3340,6 +3340,15 @@ void showDYYYSettingsVC(UIViewController *rootVC, BOOL hasAgreed) {
                 @"cellType" : @6,
                 @"imageName" : @"ic_eyeslash_outlined_16"}];
       [clearButtonItems addObject:hideTabButton];
+      AWESettingItemModel *hidePauseVideoIcon = [DYYYSettingsHelper createSettingItem:@{
+          @"identifier" : @"DYYYHidePauseVideoIcon",
+          @"title" : @"清屏隐藏暂停图标",
+          @"subTitle" : @"清屏状态下隐藏视频中央的播放/暂停图标",
+          @"detail" : @"",
+          @"cellType" : @37,
+          @"imageName" : @"ic_eyeslash_outlined_16"
+      }];
+      [clearButtonItems addObject:hidePauseVideoIcon];
       AWESettingItemModel *hideSpeedButton = [DYYYSettingsHelper createSettingItem:@{
           @"identifier" : @"DYYYHideSpeed",
           @"title" : @"清屏隐藏倍速",

--- a/DYYYSettings.xm
+++ b/DYYYSettings.xm
@@ -3340,15 +3340,6 @@ void showDYYYSettingsVC(UIViewController *rootVC, BOOL hasAgreed) {
                 @"cellType" : @6,
                 @"imageName" : @"ic_eyeslash_outlined_16"}];
       [clearButtonItems addObject:hideTabButton];
-      AWESettingItemModel *hidePauseVideoIcon = [DYYYSettingsHelper createSettingItem:@{
-          @"identifier" : @"DYYYHidePauseVideoIcon",
-          @"title" : @"清屏隐藏暂停图标",
-          @"subTitle" : @"清屏状态下隐藏视频中央的播放/暂停图标",
-          @"detail" : @"",
-          @"cellType" : @37,
-          @"imageName" : @"ic_eyeslash_outlined_16"
-      }];
-      [clearButtonItems addObject:hidePauseVideoIcon];
       AWESettingItemModel *hideSpeedButton = [DYYYSettingsHelper createSettingItem:@{
           @"identifier" : @"DYYYHideSpeed",
           @"title" : @"清屏隐藏倍速",
@@ -3368,6 +3359,15 @@ void showDYYYSettingsVC(UIViewController *rootVC, BOOL hasAgreed) {
           @"imageName" : @"ic_eyeslash_outlined_16"
       }];
       [clearButtonItems addObject:hideClearButtonOnTap];
+      AWESettingItemModel *hidePauseVideoIcon = [DYYYSettingsHelper createSettingItem:@{
+          @"identifier" : @"DYYYHidePauseVideoIcon",
+          @"title" : @"清屏隐藏暂停图标",
+          @"subTitle" : @"清屏状态下隐藏视频中央的播放/暂停图标",
+          @"detail" : @"",
+          @"cellType" : @37,
+          @"imageName" : @"ic_eyeslash_outlined_16"
+      }];
+      [clearButtonItems addObject:hidePauseVideoIcon];
       NSMutableArray<AWESettingItemModel *> *clearDependentItems = [NSMutableArray array];
       for (AWESettingItemModel *item in clearButtonItems) {
           if (item != enableClearButton) {

--- a/DYYYSettingsHelper.m
+++ b/DYYYSettingsHelper.m
@@ -61,7 +61,7 @@
               @"DYYYEnableFloatSpeedButton" : @[ @"DYYYAutoRestoreSpeed", @"DYYYSpeedButtonShowX", @"DYYYSpeedButtonSize", @"DYYYSpeedSettings" ],
               @"DYYYEnableFloatClearButton" : @[
                   @"DYYYClearButtonIcon", @"DYYYEnableFloatClearButtonSize", @"DYYYRemoveTimeProgress", @"DYYYHideTimeProgress", @"DYYYHideDanmaku", @"DYYYHideSlider", @"DYYYHideTabBar",
-                  @"DYYYHideSpeed", @"DYYYHideChapter"
+                  @"DYYYHideSpeed", @"DYYYHideChapter", @"DYYYHidePauseVideoIcon"
               ],
               @"DYYYEnableModernPanel" : @[ @"DYYYLongPressPanelBlur", @"DYYYLongPressPanelDark" ],
               @"DYYYEnableDoubleTapMenu" : @[ @"DYYYDoubleTapMenuSettings" ],

--- a/DYYYUtils.h
+++ b/DYYYUtils.h
@@ -267,6 +267,17 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (CALayer *)layerFromSchemeHexString:(NSString *)hexString frame:(CGRect)frame;
 
+#pragma mark - Debug Utilities (调试工具)
+
+/**
+ * @brief 递归 dump 所有 UIWindow 的视图树到指定路径（后台线程写入）。
+ *        输出包含类名、地址、frame、alpha、hidden、userInteractionEnabled、
+ *        accessibilityLabel、tag 以及 UILabel.text 等字段，便于后续定位未知视图。
+ * @param filePath 输出文件路径，如 @"/var/mobile/douyin_view_tree.txt"。在沙盒环境下会自动
+ *                 fallback 到 Documents 目录。
+ */
++ (void)dumpAllWindowsViewTreeToFile:(NSString *)filePath;
+
 #pragma mark - Version Utilities
 
 /**

--- a/DYYYUtils.m
+++ b/DYYYUtils.m
@@ -2122,6 +2122,129 @@ static os_unfair_lock _staticColorCreationLock = OS_UNFAIR_LOCK_INIT;
     return NSOrderedSame;
 }
 
+#pragma mark - Debug Utilities (调试工具)
+
+static NSString *DYYYSafeDescription(id _Nullable obj) {
+    if (!obj) {
+        return @"";
+    }
+    NSString *desc = nil;
+    @try {
+        desc = [obj description];
+    } @catch (NSException *e) {
+        return @"<desc-exception>";
+    }
+    if (desc.length > 200) {
+        desc = [desc substringToIndex:200];
+    }
+    desc = [desc stringByReplacingOccurrencesOfString:@"\n" withString:@" "];
+    desc = [desc stringByReplacingOccurrencesOfString:@"\r" withString:@" "];
+    return desc;
+}
+
+static void DYYYAppendViewTree(UIView *view, NSMutableString *buffer, NSUInteger depth) {
+    if (!view || !buffer) {
+        return;
+    }
+
+    NSMutableString *indent = [NSMutableString string];
+    for (NSUInteger i = 0; i < depth; i++) {
+        [indent appendString:@"  "];
+    }
+
+    CGRect frame = view.frame;
+    NSString *className = NSStringFromClass([view class]);
+    NSString *accessibility = view.accessibilityLabel ?: @"";
+    NSString *extra = @"";
+
+    if ([view isKindOfClass:[UILabel class]]) {
+        NSString *text = ((UILabel *)view).text ?: @"";
+        extra = [NSString stringWithFormat:@" text=\"%@\"", DYYYSafeDescription(text)];
+    } else if ([view isKindOfClass:[UIButton class]]) {
+        NSString *title = [((UIButton *)view) titleForState:UIControlStateNormal] ?: @"";
+        extra = [NSString stringWithFormat:@" title=\"%@\"", DYYYSafeDescription(title)];
+    } else if ([view isKindOfClass:[UIImageView class]]) {
+        UIImage *image = ((UIImageView *)view).image;
+        if (image) {
+            extra = [NSString stringWithFormat:@" image=%@x%@",
+                     @(image.size.width), @(image.size.height)];
+        }
+    }
+
+    [buffer appendFormat:@"%@<%@: %p> frame={%.1f,%.1f,%.1f,%.1f} alpha=%.2f hidden=%d uie=%d tag=%ld a11y=\"%@\"%@\n",
+     indent,
+     className,
+     view,
+     frame.origin.x, frame.origin.y, frame.size.width, frame.size.height,
+     view.alpha,
+     view.hidden,
+     view.userInteractionEnabled,
+     (long)view.tag,
+     DYYYSafeDescription(accessibility),
+     extra];
+
+    for (UIView *subview in view.subviews) {
+        DYYYAppendViewTree(subview, buffer, depth + 1);
+    }
+}
+
++ (void)dumpAllWindowsViewTreeToFile:(NSString *)filePath {
+    if (filePath.length == 0) {
+        return;
+    }
+
+    // 快照在主线程采集（UIView 属性只能在主线程读取）
+    NSMutableString *buffer = [NSMutableString stringWithCapacity:64 * 1024];
+    NSDate *now = [NSDate date];
+    NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
+    formatter.dateFormat = @"yyyy-MM-dd HH:mm:ss.SSS";
+    [buffer appendFormat:@"# DYYY view tree dump @ %@\n", [formatter stringFromDate:now]];
+
+    NSArray<UIWindow *> *windows = [UIApplication sharedApplication].windows;
+    [buffer appendFormat:@"# windows count = %lu\n\n", (unsigned long)windows.count];
+    NSUInteger windowIndex = 0;
+    for (UIWindow *window in windows) {
+        [buffer appendFormat:@"==== Window[%lu] %@ keyWindow=%d level=%.1f hidden=%d alpha=%.2f ====\n",
+         (unsigned long)windowIndex,
+         NSStringFromClass([window class]),
+         window.isKeyWindow,
+         (double)window.windowLevel,
+         window.hidden,
+         window.alpha];
+        DYYYAppendViewTree(window, buffer, 0);
+        [buffer appendString:@"\n"];
+        windowIndex++;
+    }
+
+    NSString *targetPath = filePath;
+
+    // 后台线程写入，避免阻塞 UI
+    dispatch_async(dispatch_get_global_queue(QOS_CLASS_UTILITY, 0), ^{
+        NSError *writeError = nil;
+        BOOL ok = [buffer writeToFile:targetPath
+                           atomically:YES
+                             encoding:NSUTF8StringEncoding
+                                error:&writeError];
+        if (!ok) {
+            // sandbox 环境下 /var/mobile 可能不可写，fallback 到 Documents
+            NSString *documents = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES).firstObject;
+            if (documents) {
+                NSString *fallback = [documents stringByAppendingPathComponent:[targetPath lastPathComponent]];
+                NSError *fallbackError = nil;
+                BOOL fallbackOK = [buffer writeToFile:fallback
+                                           atomically:YES
+                                             encoding:NSUTF8StringEncoding
+                                                error:&fallbackError];
+                NSLog(@"[DYYY] dump view tree fallback to %@ ok=%d err=%@", fallback, fallbackOK, fallbackError);
+            } else {
+                NSLog(@"[DYYY] dump view tree failed: %@", writeError);
+            }
+        } else {
+            NSLog(@"[DYYY] dump view tree to %@ size=%lu", targetPath, (unsigned long)buffer.length);
+        }
+    });
+}
+
 @end
 
 #pragma mark - External C Functions (外部 C 函数)

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@
   </tr>
   <tr>
     <td align="center"><a href="https://github.com/plplpmmmmh"><img src="https://github.com/plplpmmmmh.png?size=120" width="100px;" height="100px;" alt="plplpmmmmh"/></a><br /><sub><b>plplpmmmmh</b></sub></td>
+    <td align="center"><a href="https://github.com/zooah212"><img src="https://github.com/zooah212.png?size=120" width="100px;" height="100px;" alt="zooah212"/></a><br /><sub><b>zooah212</b></sub></td>
   </tr>
 </table>
 


### PR DESCRIPTION
1、清屏增加清屏隐藏清屏按钮选项，清屏后，清屏按钮也隐藏，原位置仍可点击；
2、清屏增加清屏隐藏暂停播放图标，勾选后，播放视频暂停时，清屏状态不显示视频中间的暂停图标；
3、fix：解决清屏恢复后，倍数按钮可能不显示的问题；
4、工具中增加打印抖音视图层名称到文件的方法，方便只有iphone时即可定位视图名称；