### PR TITLE
完善 Release、播放体验与头像入口隐藏表现

### DIFF
--- a/.github/scripts/extract-release-dylib.sh
+++ b/.github/scripts/extract-release-dylib.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+shopt -s nullglob
+
+package_id=${PACKAGE_ID:-$(awk -F': ' '$1 == "Package" { print $2; exit }' control)}
+package_version=${PACKAGE_VERSION:-$(awk -F': ' '$1 == "Version" { print $2; exit }' control)}
+source_deb_glob=${SOURCE_DEB_GLOB:-packages/*arm64e*.deb}
+fallback_deb_glob=${FALLBACK_DEB_GLOB:-packages/*roothide*.deb}
+output_dir=${OUTPUT_DIR:-packages}
+tweak_dylib_name=${TWEAK_DYLIB_NAME:-DYYY.dylib}
+required_arch=${REQUIRED_ARCH:-arm64e}
+
+if [[ -z "$package_id" || -z "$package_version" ]]; then
+    echo "Unable to read package id or version from control" >&2
+    exit 1
+fi
+
+matching_debs=()
+while IFS= read -r deb; do
+    matching_debs+=("$deb")
+done < <(compgen -G "$source_deb_glob" | sort)
+
+if [[ "${#matching_debs[@]}" -eq 0 && -n "$fallback_deb_glob" ]]; then
+    while IFS= read -r deb; do
+        matching_debs+=("$deb")
+    done < <(compgen -G "$fallback_deb_glob" | sort)
+fi
+
+if [[ "${#matching_debs[@]}" -ne 1 ]]; then
+    echo "Expected exactly one arm64e Deb package, found ${#matching_debs[@]}:" >&2
+    printf '  %s\n' "${matching_debs[@]}" >&2
+    exit 1
+fi
+
+source_deb=${matching_debs[0]}
+case "$source_deb" in
+    /*) source_deb_path=$source_deb ;;
+    *) source_deb_path=$PWD/$source_deb ;;
+esac
+
+work_dir=$(mktemp -d)
+extract_dir="$work_dir/data"
+trap 'rm -rf "$work_dir"' EXIT
+
+mkdir -p "$extract_dir"
+(
+    cd "$work_dir"
+    ar -x "$source_deb_path"
+)
+
+data_archives=("$work_dir"/data.tar.*)
+if [[ "${#data_archives[@]}" -ne 1 ]]; then
+    echo "Expected exactly one data.tar archive in ${source_deb}, found ${#data_archives[@]}" >&2
+    exit 1
+fi
+
+tar -xf "${data_archives[0]}" -C "$extract_dir"
+
+dylib_paths=()
+while IFS= read -r dylib_path; do
+    dylib_paths+=("$dylib_path")
+done < <(find "$extract_dir" -type f -name "$tweak_dylib_name" | sort)
+
+if [[ "${#dylib_paths[@]}" -eq 0 ]]; then
+    while IFS= read -r dylib_path; do
+        dylib_paths+=("$dylib_path")
+    done < <(find "$extract_dir" -type f -name '*.dylib' | sort)
+fi
+
+if [[ "${#dylib_paths[@]}" -ne 1 ]]; then
+    echo "Expected exactly one dylib in ${source_deb}, found ${#dylib_paths[@]}:" >&2
+    printf '  %s\n' "${dylib_paths[@]}" >&2
+    exit 1
+fi
+
+mkdir -p "$output_dir"
+output_file="${output_dir}/${package_id}_${package_version}.dylib"
+cp "${dylib_paths[0]}" "$output_file"
+
+if command -v lipo >/dev/null 2>&1; then
+    lipo_info=$(lipo -info "$output_file")
+    echo "$lipo_info"
+
+    if [[ -n "$required_arch" ]] &&
+       ! grep -Eq "(^|[^[:alnum:]_])${required_arch}([^[:alnum:]_]|$)" <<< "$lipo_info"; then
+        echo "Extracted dylib does not contain required architecture: ${required_arch}" >&2
+        exit 1
+    fi
+fi
+
+printf 'Release asset: %s\n' "$output_file"

--- a/.github/scripts/generate-release-notes.sh
+++ b/.github/scripts/generate-release-notes.sh
@@ -120,7 +120,7 @@ cat >> "$notes_file" <<'EOF'
 
 ---
 
-本 Release 包含 Rootful、Rootless 和 Roothide 三个 Deb 安装包。
+本 Release 包含 Rootful、Rootless 和 Roothide 三个 Deb 安装包，并提供从 arm64e Deb 中提取的 dylib 文件。
 EOF
 
 cat "$notes_file"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -167,11 +167,18 @@ jobs:
 
           printf 'Release asset: %s\n' "${deb_files[@]}"
 
-      - name: Upload specific Deb packages
+      - name: Extract arm64e dylib
+        env:
+          PACKAGE_VERSION: ${{ steps.release.outputs.version }}
+        run: .github/scripts/extract-release-dylib.sh
+
+      - name: Upload release package artifacts
         uses: actions/upload-artifact@v7
         with:
           name: DYYY-${{ steps.release.outputs.timestamp }}
-          path: ${{ github.workspace }}/packages/*.deb
+          path: |
+            ${{ github.workspace }}/packages/*.deb
+            ${{ github.workspace }}/packages/*.dylib
 
       - name: Coordinate Release publication
         id: release_gate
@@ -191,7 +198,7 @@ jobs:
           RELEASE_TAG: ${{ steps.release.outputs.tag }}
           RELEASE_TITLE: ${{ steps.release.outputs.title }}
         run: |
-          gh release create "$RELEASE_TAG" packages/*.deb \
+          gh release create "$RELEASE_TAG" packages/*.deb packages/*.dylib \
             --target "$GITHUB_SHA" \
             --title "$RELEASE_TITLE" \
             --notes-file release-notes.md \

--- a/AwemeHeaders.h
+++ b/AwemeHeaders.h
@@ -1376,10 +1376,19 @@ typedef NS_ENUM(NSUInteger, DYEdgeMode) {
 @property(retain, nonatomic) UIView *followAnimationView;
 @property(retain, nonatomic) UIView *unfollowAnimationView;
 @property(retain, nonatomic) UIView *staticFollowAnimationView;
+@property(retain, nonatomic) UIView *sendMessageView;
+@property(retain, nonatomic) UIView *sendMessageGuideView;
+@property(nonatomic, weak) UIImageView *avatarSendMessageImageView;
+@property(retain, nonatomic) UIView *enterStoreView;
+@property(retain, nonatomic) UIView *enterStoreGuideView;
+@property(nonatomic, weak) UIImageView *avatarEnterStoreImageView;
+@property(retain, nonatomic) UIView *linkIconContainerView;
+@property(retain, nonatomic) UIImageView *userAvatarLinkIcon;
 - (void)updateRightContainerElement;
 - (void)p_resetFollowAnimation;
 - (void)playFollowAnimation:(id)completion;
 - (void)playUnFollowAnimation;
+- (void)changeSendMessageViewWithFlag:(BOOL)flag;
 @end
 
 @interface AWEPlayInteractionStaticFollowAnimationView : UIView
@@ -1442,8 +1451,12 @@ typedef NS_ENUM(NSUInteger, DYEdgeMode) {
 @property(retain, nonatomic) UIView *unfollowAnimationView;
 @property(retain, nonatomic) AWEPlayInteractionStaticFollowAnimationView *staticFollowAnimationView;
 - (void)onFollowViewClicked:(id)gesture;
+- (void)onUnFollowViewClicked:(id)arg1;
+- (void)followPromptViewClicked:(id)arg1;
 - (void)layoutElementView;
 - (void)showFollowAddView:(BOOL)show;
+- (BOOL)shouldShowFollowAddWithModel:(id)arg1;
+- (BOOL)shouldShowSpecialFollowWithModel:(id)arg1;
 - (void)viewController_willDisplay;
 - (void)viewController_viewDidAppear;
 - (void)updateFollowStatus;
@@ -1480,6 +1493,71 @@ typedef NS_ENUM(NSUInteger, DYEdgeMode) {
 - (void)layoutElementView;
 - (void)viewController_willDisplay;
 - (void)setDecorationStyle:(long long)style;
+@end
+
+@interface AWEPlayInteractionUserAvatarSendMessageController : NSObject
+- (id)userAvatarView;
+- (void)controllerViewDidLayout;
+- (void)controllerStartConfigAvatarView:(id)view;
+- (void)controllerWillDisplay;
+- (void)controllerPlay;
+- (void)controllerReset;
+- (void)updateSendMessageView:(BOOL)show;
+- (void)p_updateSendMessageView:(BOOL)show;
+- (void)p_showSendMessageView:(id)view shouldShowSendMessageView:(BOOL)show animated:(BOOL)animated completion:(id)completion;
+- (BOOL)shouldShowSendMessageView;
+- (BOOL)shouldShowSendMessageGuideAnimation;
+- (void)playSendMessageGuideAnimationIfNeeded;
+- (void)onSendMessageViewClicked:(id)arg1;
+@end
+
+@interface AWEPlayInteractionUserAvatarSendMsgController : NSObject
+@property(retain, nonatomic) AWEPlayInteractionUserAvatarContext *userAvatarContext;
+@property(retain, nonatomic) UIView *sendMessageView;
+@property(retain, nonatomic) UIView *sendMessageGuideView;
+@property(retain, nonatomic) UIImageView *avatarSendMessageImageView;
+- (void)layoutElementView;
+- (void)viewController_willDisplay;
+- (void)viewController_viewDidDisappear;
+- (void)play;
+- (void)reset;
+- (void)changeSendMessageViewWithFlag:(BOOL)flag;
+- (void)showSendMessageView:(id)view show:(BOOL)show animated:(BOOL)animated completion:(id)completion;
+- (void)showSendMessageViewWithAnimation:(BOOL)animated;
+- (BOOL)shouldShowSendMessageView:(id)arg1;
+- (BOOL)shouldShowSendMessageGuideAnimation;
+- (void)updateSendMsgWithFollowShow:(BOOL)show animation:(BOOL)animated;
+- (void)handleAvatarFollowStatusChange:(id)arg1;
+- (void)playSendMessageGuideAnimationIfNeeded;
+- (void)onSendMessageViewClicked:(id)arg1;
+@end
+
+@interface AWEPlayInteractionUserAvatarEnterStoreController : NSObject
+@property(retain, nonatomic) AWEPlayInteractionUserAvatarContext *userAvatarContext;
+@property(retain, nonatomic) UIView *enterStoreView;
+@property(retain, nonatomic) UIView *enterStoreGuideView;
+- (void)layoutElementView;
+- (void)viewController_willDisplay;
+- (void)viewController_viewDidAppear;
+- (void)play;
+- (void)reset;
+- (void)showEnterStore;
+- (void)hideEnterStore;
+- (BOOL)shouldShowEnterStoreView;
+- (BOOL)shouldShowEnterStoreGuideAnimation;
+- (void)playEnterStoreGuideAnimationIfNeeded;
+- (void)handleAvatarFollowStatusChange:(id)arg1;
+- (void)onEnterStoreViewClicked:(id)arg1;
+@end
+
+@interface AWEPlayInteractionUserAvatarAdLinkController : NSObject
+@property(retain, nonatomic) AWEPlayInteractionUserAvatarContext *userAvatarContext;
+@property(retain, nonatomic) UIView *linkIconContainerView;
+@property(retain, nonatomic) UIImageView *userAvatarLinkIcon;
+- (void)layoutElementView;
+- (void)reset;
+- (void)updateCommerceHotSplashLinkIconImageIfNeeded:(id)arg1;
+- (void)onLinkIconContainerViewClicked:(id)arg1;
 @end
 
 @interface AWECodeGenCommonAnchorBasicInfoModel : UIViewController

--- a/DYYY.xm
+++ b/DYYY.xm
@@ -4289,7 +4289,12 @@ static BOOL DYYYHideAvatarFollowIconInView(UIView *view) {
 
 static BOOL DYYYIsAvatarFollowContainerView(UIView *view) {
     NSString *className = NSStringFromClass(view.class);
-    return [className containsString:@"Follow"] || [className containsString:@"follow"] || [className containsString:@"Prompt"] || [className containsString:@"Add"];
+    return [className containsString:@"Follow"] || [className containsString:@"follow"] ||
+           [className containsString:@"Prompt"] || [className containsString:@"Add"] ||
+           [className containsString:@"SendMessage"] || [className containsString:@"sendMessage"] ||
+           [className containsString:@"SendMsg"] || [className containsString:@"sendMsg"] ||
+           [className containsString:@"EnterStore"] || [className containsString:@"enterStore"] ||
+           [className containsString:@"LinkIcon"] || [className containsString:@"linkIcon"];
 }
 
 static BOOL DYYYIsSmallAvatarFollowBadgeView(UIView *view) {
@@ -4312,6 +4317,82 @@ static UIView *DYYYAvatarFollowRemovalTargetForView(UIView *view, UIView *rootVi
     return target;
 }
 
+static BOOL DYYYHideAvatarAuxiliaryActionVisualsInView(UIView *view) {
+    if (!view) {
+        return NO;
+    }
+
+    NSString *className = NSStringFromClass(view.class);
+    BOOL isActionVisual = [view isKindOfClass:[UIImageView class]] ||
+                          [className containsString:@"GuideAnimation"] ||
+                          [className containsString:@"SendMessageImage"] ||
+                          [className containsString:@"SendMsgImage"] ||
+                          [className containsString:@"EnterStoreImage"] ||
+                          [className containsString:@"LinkIcon"];
+    if (isActionVisual) {
+        view.hidden = YES;
+        return YES;
+    }
+
+    BOOL foundVisual = NO;
+    for (UIView *subview in [view.subviews copy]) {
+        foundVisual = DYYYHideAvatarAuxiliaryActionVisualsInView(subview) || foundVisual;
+    }
+    return foundVisual;
+}
+
+static NSArray<NSArray<NSString *> *> *DYYYAvatarAuxiliaryActionSelectorGroups(void) {
+    return @[
+        @[ @"sendMessageView", @"avatarSendMessageImageView", @"sendMessageGuideView" ],
+        @[ @"enterStoreView", @"avatarEnterStoreImageView", @"enterStoreGuideView" ],
+        @[ @"linkIconContainerView", @"userAvatarLinkIcon" ],
+    ];
+}
+
+static BOOL DYYYApplyAvatarAuxiliaryActionSettingsForOwner(id owner) {
+    BOOL hidePlus = DYYYGetBool(@"DYYYHideLOTAnimationView");
+    BOOL removePlus = DYYYGetBool(@"DYYYHideFollowPromptView");
+    if (!hidePlus && !removePlus) {
+        return NO;
+    }
+
+    BOOL handled = NO;
+    for (NSArray<NSString *> *selectorGroup in DYYYAvatarAuxiliaryActionSelectorGroups()) {
+        UIView *containerView = DYYYAvatarViewForSelector(owner, NSSelectorFromString(selectorGroup.firstObject));
+        NSMutableArray<UIView *> *visualViews = [NSMutableArray array];
+        for (NSUInteger index = 1; index < selectorGroup.count; index++) {
+            UIView *visualView = DYYYAvatarViewForSelector(owner, NSSelectorFromString(selectorGroup[index]));
+            if (visualView) {
+                [visualViews addObject:visualView];
+            }
+        }
+
+        if (removePlus) {
+            UIView *fallbackVisual = visualViews.firstObject;
+            UIView *removalTarget = containerView ?: DYYYAvatarFollowRemovalTargetForView(fallbackVisual, nil);
+            DYYYRemoveAvatarView(removalTarget);
+            for (UIView *visualView in visualViews) {
+                DYYYRemoveAvatarView(visualView);
+            }
+            handled = (removalTarget || visualViews.count > 0) || handled;
+            continue;
+        }
+
+        for (UIView *visualView in visualViews) {
+            visualView.hidden = YES;
+            handled = YES;
+        }
+        if (containerView) {
+            BOOL foundVisual = DYYYHideAvatarAuxiliaryActionVisualsInView(containerView);
+            if (!foundVisual && visualViews.count == 0) {
+                DYYYHideAvatarFollowLayerContents(containerView);
+            }
+            handled = YES;
+        }
+    }
+    return handled;
+}
+
 static BOOL DYYYApplyAvatarFollowSettingsInView(UIView *view, UIView *rootView) {
     if (!view) {
         return NO;
@@ -4324,10 +4405,15 @@ static BOOL DYYYApplyAvatarFollowSettingsInView(UIView *view, UIView *rootView) 
     }
 
     NSString *className = NSStringFromClass(view.class);
+    BOOL isAvatarView = [className isEqualToString:@"AWEPlayInteractionUserAvatarView"];
     BOOL isStaticFollowView = [className isEqualToString:@"AWEPlayInteractionStaticFollowAnimationView"];
     BOOL isLegacyFollowAnimation = [className isEqualToString:@"LOTAnimationView"] && DYYYIsLegacyAvatarFollowAnimationView(view);
     BOOL isLegacyPromptContainer = [className isEqualToString:@"AWEPlayInteractionFollowPromptView"];
     BOOL handled = NO;
+
+    if (isAvatarView) {
+        handled = DYYYApplyAvatarAuxiliaryActionSettingsForOwner(view) || handled;
+    }
 
     if (isStaticFollowView || isLegacyFollowAnimation) {
         if (removePlus) {
@@ -4391,10 +4477,16 @@ static void DYYYApplyAvatarFollowPromptSettings(id owner) {
         DYYYApplyAvatarFollowSettingsInView(followPromptView, followPromptView);
     }
 
+    DYYYApplyAvatarAuxiliaryActionSettingsForOwner(owner);
+
     if ([owner isKindOfClass:[UIView class]]) {
         DYYYApplyAvatarFollowSettingsInView((UIView *)owner, (UIView *)owner);
     } else if ([owner isKindOfClass:[UIViewController class]]) {
         DYYYApplyAvatarFollowSettingsInView(((UIViewController *)owner).view, ((UIViewController *)owner).view);
+    }
+    UIView *userAvatarView = DYYYAvatarViewForSelector(owner, NSSelectorFromString(@"userAvatarView"));
+    if (userAvatarView) {
+        DYYYApplyAvatarFollowSettingsInView(userAvatarView, userAvatarView);
     }
     DYYYApplyAvatarFollowSettingsForContext(DYYYAvatarObjectForSelector(owner, NSSelectorFromString(@"userAvatarContext")));
 }
@@ -7325,10 +7417,19 @@ static NSHashTable *processedParentViews = nil;
     %orig;
     DYYYApplyAvatarFollowPromptSettingsWithRetry(self);
 }
+
+- (void)changeSendMessageViewWithFlag:(BOOL)flag {
+    %orig(flag);
+    DYYYApplyAvatarFollowPromptSettingsWithRetry(self);
+}
 %end
 
 %hook AWEPlayInteractionUserAvatarFollowPromptController
 - (void)onFollowViewClicked:(UITapGestureRecognizer *)gesture {
+    if (DYYYGetBool(@"DYYYHideFollowPromptView")) {
+        return;
+    }
+
     if (DYYYGetBool(@"DYYYFollowTips")) {
         AWEPlayInteractionUserAvatarContext *context = nil;
         if ([self respondsToSelector:@selector(userAvatarContext)]) {
@@ -7379,9 +7480,37 @@ static NSHashTable *processedParentViews = nil;
     }
 }
 
+- (void)onUnFollowViewClicked:(id)arg1 {
+    if (DYYYGetBool(@"DYYYHideFollowPromptView")) {
+        return;
+    }
+    %orig(arg1);
+}
+
+- (void)followPromptViewClicked:(id)arg1 {
+    if (DYYYGetBool(@"DYYYHideFollowPromptView")) {
+        return;
+    }
+    %orig(arg1);
+}
+
 - (void)layoutElementView {
     %orig;
     DYYYApplyAvatarFollowPromptSettingsWithRetry(self);
+}
+
+- (BOOL)shouldShowFollowAddWithModel:(id)arg1 {
+    if (DYYYGetBool(@"DYYYHideFollowPromptView")) {
+        return NO;
+    }
+    return %orig(arg1);
+}
+
+- (BOOL)shouldShowSpecialFollowWithModel:(id)arg1 {
+    if (DYYYGetBool(@"DYYYHideFollowPromptView")) {
+        return NO;
+    }
+    return %orig(arg1);
 }
 
 - (void)showFollowAddView:(BOOL)show {
@@ -7498,6 +7627,251 @@ static NSHashTable *processedParentViews = nil;
 - (void)setDecorationStyle:(long long)style {
     %orig(style);
     DYYYApplyAvatarFollowPromptSettingsWithRetry(self);
+}
+%end
+
+%hook AWEPlayInteractionUserAvatarSendMessageController
+- (void)controllerViewDidLayout {
+    %orig;
+    DYYYApplyAvatarFollowPromptSettingsWithRetry(self);
+}
+
+- (void)controllerStartConfigAvatarView:(id)view {
+    %orig(view);
+    DYYYApplyAvatarFollowPromptSettingsWithRetry(self);
+    DYYYApplyAvatarFollowPromptSettingsWithRetry(view);
+}
+
+- (void)controllerWillDisplay {
+    %orig;
+    DYYYApplyAvatarFollowPromptSettingsWithRetry(self);
+}
+
+- (void)controllerPlay {
+    %orig;
+    DYYYApplyAvatarFollowPromptSettingsWithRetry(self);
+}
+
+- (void)controllerReset {
+    %orig;
+    DYYYApplyAvatarFollowPromptSettingsWithRetry(self);
+}
+
+- (void)updateSendMessageView:(BOOL)show {
+    %orig(show);
+    DYYYApplyAvatarFollowPromptSettingsWithRetry(self);
+}
+
+- (void)p_updateSendMessageView:(BOOL)show {
+    %orig(show);
+    DYYYApplyAvatarFollowPromptSettingsWithRetry(self);
+}
+
+- (void)p_showSendMessageView:(id)view shouldShowSendMessageView:(BOOL)show animated:(BOOL)animated completion:(id)completion {
+    %orig(view, show, animated, completion);
+    DYYYApplyAvatarFollowPromptSettingsWithRetry(self);
+    DYYYApplyAvatarFollowPromptSettingsWithRetry(view);
+}
+
+- (BOOL)shouldShowSendMessageView {
+    if (DYYYGetBool(@"DYYYHideFollowPromptView")) {
+        return NO;
+    }
+    return %orig;
+}
+
+- (BOOL)shouldShowSendMessageGuideAnimation {
+    if (DYYYAvatarFollowOptionsEnabled()) {
+        return NO;
+    }
+    return %orig;
+}
+
+- (void)playSendMessageGuideAnimationIfNeeded {
+    %orig;
+    DYYYApplyAvatarFollowPromptSettingsWithRetry(self);
+}
+
+- (void)onSendMessageViewClicked:(id)arg1 {
+    if (DYYYGetBool(@"DYYYHideFollowPromptView")) {
+        return;
+    }
+    %orig(arg1);
+}
+%end
+
+%hook AWEPlayInteractionUserAvatarSendMsgController
+- (void)layoutElementView {
+    %orig;
+    DYYYApplyAvatarFollowPromptSettingsWithRetry(self);
+}
+
+- (void)viewController_willDisplay {
+    %orig;
+    DYYYApplyAvatarFollowPromptSettingsWithRetry(self);
+}
+
+- (void)viewController_viewDidDisappear {
+    %orig;
+    DYYYApplyAvatarFollowPromptSettingsWithRetry(self);
+}
+
+- (void)play {
+    %orig;
+    DYYYApplyAvatarFollowPromptSettingsWithRetry(self);
+}
+
+- (void)reset {
+    %orig;
+    DYYYApplyAvatarFollowPromptSettingsWithRetry(self);
+}
+
+- (void)changeSendMessageViewWithFlag:(BOOL)flag {
+    %orig(flag);
+    DYYYApplyAvatarFollowPromptSettingsWithRetry(self);
+}
+
+- (void)showSendMessageView:(id)view show:(BOOL)show animated:(BOOL)animated completion:(id)completion {
+    %orig(view, show, animated, completion);
+    DYYYApplyAvatarFollowPromptSettingsWithRetry(self);
+    DYYYApplyAvatarFollowPromptSettingsWithRetry(view);
+}
+
+- (void)showSendMessageViewWithAnimation:(BOOL)animated {
+    %orig(animated);
+    DYYYApplyAvatarFollowPromptSettingsWithRetry(self);
+}
+
+- (BOOL)shouldShowSendMessageView:(id)arg1 {
+    if (DYYYGetBool(@"DYYYHideFollowPromptView")) {
+        return NO;
+    }
+    return %orig(arg1);
+}
+
+- (BOOL)shouldShowSendMessageGuideAnimation {
+    if (DYYYAvatarFollowOptionsEnabled()) {
+        return NO;
+    }
+    return %orig;
+}
+
+- (void)updateSendMsgWithFollowShow:(BOOL)show animation:(BOOL)animated {
+    %orig(show, animated);
+    DYYYApplyAvatarFollowPromptSettingsWithRetry(self);
+}
+
+- (void)handleAvatarFollowStatusChange:(id)arg1 {
+    %orig(arg1);
+    DYYYApplyAvatarFollowPromptSettingsWithRetry(self);
+}
+
+- (void)playSendMessageGuideAnimationIfNeeded {
+    %orig;
+    DYYYApplyAvatarFollowPromptSettingsWithRetry(self);
+}
+
+- (void)onSendMessageViewClicked:(id)arg1 {
+    if (DYYYGetBool(@"DYYYHideFollowPromptView")) {
+        return;
+    }
+    %orig(arg1);
+}
+%end
+
+%hook AWEPlayInteractionUserAvatarEnterStoreController
+- (void)layoutElementView {
+    %orig;
+    DYYYApplyAvatarFollowPromptSettingsWithRetry(self);
+}
+
+- (void)viewController_willDisplay {
+    %orig;
+    DYYYApplyAvatarFollowPromptSettingsWithRetry(self);
+}
+
+- (void)viewController_viewDidAppear {
+    %orig;
+    DYYYApplyAvatarFollowPromptSettingsWithRetry(self);
+}
+
+- (void)play {
+    %orig;
+    DYYYApplyAvatarFollowPromptSettingsWithRetry(self);
+}
+
+- (void)reset {
+    %orig;
+    DYYYApplyAvatarFollowPromptSettingsWithRetry(self);
+}
+
+- (void)showEnterStore {
+    %orig;
+    DYYYApplyAvatarFollowPromptSettingsWithRetry(self);
+}
+
+- (void)hideEnterStore {
+    %orig;
+    DYYYApplyAvatarFollowPromptSettingsWithRetry(self);
+}
+
+- (BOOL)shouldShowEnterStoreView {
+    if (DYYYGetBool(@"DYYYHideFollowPromptView")) {
+        return NO;
+    }
+    return %orig;
+}
+
+- (BOOL)shouldShowEnterStoreGuideAnimation {
+    if (DYYYAvatarFollowOptionsEnabled()) {
+        return NO;
+    }
+    return %orig;
+}
+
+- (void)playEnterStoreGuideAnimationIfNeeded {
+    if (DYYYAvatarFollowOptionsEnabled()) {
+        DYYYApplyAvatarFollowPromptSettingsWithRetry(self);
+        return;
+    }
+    %orig;
+    DYYYApplyAvatarFollowPromptSettingsWithRetry(self);
+}
+
+- (void)handleAvatarFollowStatusChange:(id)arg1 {
+    %orig(arg1);
+    DYYYApplyAvatarFollowPromptSettingsWithRetry(self);
+}
+
+- (void)onEnterStoreViewClicked:(id)arg1 {
+    if (DYYYGetBool(@"DYYYHideFollowPromptView")) {
+        return;
+    }
+    %orig(arg1);
+}
+%end
+
+%hook AWEPlayInteractionUserAvatarAdLinkController
+- (void)layoutElementView {
+    %orig;
+    DYYYApplyAvatarFollowPromptSettingsWithRetry(self);
+}
+
+- (void)reset {
+    %orig;
+    DYYYApplyAvatarFollowPromptSettingsWithRetry(self);
+}
+
+- (void)updateCommerceHotSplashLinkIconImageIfNeeded:(id)arg1 {
+    %orig(arg1);
+    DYYYApplyAvatarFollowPromptSettingsWithRetry(self);
+}
+
+- (void)onLinkIconContainerViewClicked:(id)arg1 {
+    if (DYYYGetBool(@"DYYYHideFollowPromptView")) {
+        return;
+    }
+    %orig(arg1);
 }
 %end
 

--- a/DYYY.xm
+++ b/DYYY.xm
@@ -4237,9 +4237,68 @@ static void DYYYRemoveAvatarViewForSelector(id object, SEL selector) {
 }
 
 static void DYYYHideAvatarFollowLayerContents(UIView *view) {
+    view.backgroundColor = UIColor.clearColor;
+    view.opaque = NO;
     view.layer.contents = nil;
+    view.layer.opaque = NO;
+    view.layer.backgroundColor = UIColor.clearColor.CGColor;
+    view.layer.borderWidth = 0.0;
+    view.layer.borderColor = UIColor.clearColor.CGColor;
+    view.layer.shadowOpacity = 0.0;
+    view.layer.shadowColor = UIColor.clearColor.CGColor;
     for (CALayer *sublayer in view.layer.sublayers) {
         sublayer.hidden = YES;
+    }
+}
+
+static void DYYYClearAvatarActionLayerChrome(CALayer *layer) {
+    if (!layer) {
+        return;
+    }
+
+    layer.contents = nil;
+    layer.opaque = NO;
+    layer.backgroundColor = UIColor.clearColor.CGColor;
+    layer.borderWidth = 0.0;
+    layer.borderColor = UIColor.clearColor.CGColor;
+    layer.shadowOpacity = 0.0;
+    layer.shadowColor = UIColor.clearColor.CGColor;
+    if ([layer isKindOfClass:[CAShapeLayer class]]) {
+        CAShapeLayer *shapeLayer = (CAShapeLayer *)layer;
+        shapeLayer.fillColor = UIColor.clearColor.CGColor;
+        shapeLayer.strokeColor = UIColor.clearColor.CGColor;
+    }
+
+    for (CALayer *sublayer in [layer.sublayers copy]) {
+        DYYYClearAvatarActionLayerChrome(sublayer);
+    }
+}
+
+static void DYYYClearAvatarActionSubviewChrome(UIView *view) {
+    if (!view) {
+        return;
+    }
+
+    view.backgroundColor = UIColor.clearColor;
+    view.opaque = NO;
+    DYYYClearAvatarActionLayerChrome(view.layer);
+
+    for (UIView *subview in [view.subviews copy]) {
+        DYYYClearAvatarActionSubviewChrome(subview);
+    }
+}
+
+static void DYYYClearAvatarActionViewChrome(UIView *view) {
+    if (!view) {
+        return;
+    }
+
+    view.backgroundColor = UIColor.clearColor;
+    view.opaque = NO;
+    DYYYClearAvatarActionLayerChrome(view.layer);
+
+    for (UIView *subview in [view.subviews copy]) {
+        DYYYClearAvatarActionSubviewChrome(subview);
     }
 }
 
@@ -4383,6 +4442,7 @@ static BOOL DYYYApplyAvatarAuxiliaryActionSettingsForOwner(id owner) {
             handled = YES;
         }
         if (containerView) {
+            DYYYClearAvatarActionViewChrome(containerView);
             BOOL foundVisual = DYYYHideAvatarAuxiliaryActionVisualsInView(containerView);
             if (!foundVisual && visualViews.count == 0) {
                 DYYYHideAvatarFollowLayerContents(containerView);
@@ -4465,8 +4525,11 @@ static void DYYYApplyAvatarFollowPromptSettings(id owner) {
         DYYYRemoveAvatarView(followAddView);
     } else {
         BOOL foundIcon = DYYYHideAvatarFollowIconInView(followAddView);
-        if (hidePlus && followAddView && !foundIcon) {
-            DYYYHideAvatarFollowLayerContents(followAddView);
+        if (hidePlus && followAddView) {
+            DYYYClearAvatarActionViewChrome(followAddView);
+            if (!foundIcon) {
+                DYYYHideAvatarFollowLayerContents(followAddView);
+            }
         }
     }
 

--- a/DYYY.xm
+++ b/DYYY.xm
@@ -279,6 +279,27 @@ static NSString *DYYYSpeedAwemeIdentifier(AWEAwemeModel *aweme) {
     return [NSString stringWithFormat:@"%p", aweme];
 }
 
+static AWEAwemeModel *DYYYSpeedAwemeFromObject(id object) {
+    Class awemeClass = NSClassFromString(@"AWEAwemeModel");
+    if (!object || !awemeClass) {
+        return nil;
+    }
+    if ([object isKindOfClass:awemeClass]) {
+        return (AWEAwemeModel *)object;
+    }
+
+    for (NSString *key in @[ @"model", @"awemeModel", @"currentAweme" ]) {
+        @try {
+            id value = [object valueForKey:key];
+            if ([value isKindOfClass:awemeClass]) {
+                return (AWEAwemeModel *)value;
+            }
+        } @catch (NSException *exception) {
+        }
+    }
+    return nil;
+}
+
 static double DYYYDefaultPlaybackSpeed(void) {
     double defaultSpeed = [[NSUserDefaults standardUserDefaults] doubleForKey:@"DYYYDefaultSpeed"];
     if (isfinite(defaultSpeed) && defaultSpeed > 0.0) {
@@ -486,9 +507,20 @@ static double DYYYConfiguredPlaybackSpeed(void) {
     return 1.0;
 }
 
-static double DYYYPreparedPlaybackSpeed(void) {
+static BOOL DYYYShouldPrepareDefaultPlaybackSpeedForPlayer(id playerViewController) {
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-    if ([defaults boolForKey:@"DYYYEnableFloatSpeedButton"] && [defaults boolForKey:@"DYYYAutoRestoreSpeed"]) {
+    if (![defaults boolForKey:@"DYYYEnableFloatSpeedButton"] || ![defaults boolForKey:@"DYYYAutoRestoreSpeed"]) {
+        return NO;
+    }
+
+    AWEAwemeModel *targetAweme = DYYYSpeedAwemeFromObject(playerViewController) ?: dyyyCurrentSpeedAweme;
+    NSString *awemeIdentifier = DYYYSpeedAwemeIdentifier(targetAweme);
+    return awemeIdentifier.length > 0 && ![awemeIdentifier isEqualToString:dyyyLastAutoRestoredSpeedAwemeIdentifier];
+}
+
+static double DYYYPreparedPlaybackSpeedForPlayer(id playerViewController) {
+    // Auto-restore belongs to aweme transitions; current-video refreshes should keep the selected quick speed.
+    if (DYYYShouldPrepareDefaultPlaybackSpeedForPlayer(playerViewController)) {
         return DYYYDefaultPlaybackSpeed();
     }
     return DYYYConfiguredPlaybackSpeed();
@@ -499,7 +531,7 @@ static void DYYYApplyPreparedPlaybackSpeedToPlayer(id playerViewController) {
         return;
     }
 
-    double speed = DYYYPreparedPlaybackSpeed();
+    double speed = DYYYPreparedPlaybackSpeedForPlayer(playerViewController);
     void (^applyBlock)(void) = ^{
       DYYYSetPlaybackRateOnTarget(playerViewController, speed);
     };

--- a/DYYY.xm
+++ b/DYYY.xm
@@ -835,52 +835,12 @@ static void DYYYHandleCurrentSpeedAwemeChanged(id aweme) {
 @end
 
 static BOOL dyyyClearingFeedNowPlayingSystemInfo = NO;
-static BOOL dyyyFeedNowPlayingPictureInPictureActive = NO;
 static CFTimeInterval dyyyLastFeedNowPlayingSystemClearTime = 0.0;
-static CFTimeInterval dyyyFeedNowPlayingSystemBlockUntil = 0.0;
-static CFTimeInterval dyyyFeedNowPlayingPictureInPictureBlockUntil = 0.0;
-
-static void DYYYClearFeedNowPlayingSystemInfoThrottled(void);
-
-static BOOL DYYYIsAppActiveForFeedNowPlayingBlock(void) {
-    return [UIApplication sharedApplication].applicationState == UIApplicationStateActive;
-}
-
-static void DYYYExtendFeedNowPlayingSystemBlockWindow(void) {
-    dyyyFeedNowPlayingSystemBlockUntil = MAX(dyyyFeedNowPlayingSystemBlockUntil, CFAbsoluteTimeGetCurrent() + 0.75);
-}
-
-static void DYYYExtendFeedNowPlayingPictureInPictureBlockWindow(void) {
-    CFTimeInterval currentTime = CFAbsoluteTimeGetCurrent();
-    dyyyFeedNowPlayingPictureInPictureBlockUntil = MAX(dyyyFeedNowPlayingPictureInPictureBlockUntil, currentTime + 8.0);
-    dyyyFeedNowPlayingSystemBlockUntil = MAX(dyyyFeedNowPlayingSystemBlockUntil, currentTime + 1.5);
-}
-
-static void DYYYSetFeedNowPlayingPictureInPictureActive(BOOL active) {
-    dyyyFeedNowPlayingPictureInPictureActive = active;
-    if (active) {
-        DYYYExtendFeedNowPlayingPictureInPictureBlockWindow();
-        DYYYClearFeedNowPlayingSystemInfoThrottled();
-    } else {
-        dyyyFeedNowPlayingPictureInPictureBlockUntil = 0.0;
-    }
-}
-
-static BOOL DYYYIsFeedNowPlayingPictureInPictureBlockActive(void) {
-    return dyyyFeedNowPlayingPictureInPictureActive ||
-           CFAbsoluteTimeGetCurrent() <= dyyyFeedNowPlayingPictureInPictureBlockUntil;
-}
-
-static BOOL DYYYShouldBlockFeedNowPlayingScene(void) {
-    return DYYYIsAppActiveForFeedNowPlayingBlock() || DYYYIsFeedNowPlayingPictureInPictureBlockActive();
-}
 
 static void DYYYClearFeedNowPlayingSystemInfoThrottled(void) {
     if (!DYYYGetBool(@"DYYYDisableFeedNowPlayingInfo") || dyyyClearingFeedNowPlayingSystemInfo) {
         return;
     }
-
-    DYYYExtendFeedNowPlayingSystemBlockWindow();
 
     CFTimeInterval currentTime = CFAbsoluteTimeGetCurrent();
     if (currentTime - dyyyLastFeedNowPlayingSystemClearTime < 0.25) {
@@ -914,105 +874,14 @@ static void DYYYClearFeedNowPlayingSystemInfoThrottled(void) {
     }
 }
 
-static BOOL DYYYObjectIsKindOfClassNamed(id object, NSString *className) {
-    if (!object || className.length == 0) {
-        return NO;
-    }
-
-    Class targetClass = NSClassFromString(className);
-    return targetClass && [object isKindOfClass:targetClass];
-}
-
-static BOOL DYYYObjectBoolValueForSelector(id object, SEL selector) {
-    if (!object || ![object respondsToSelector:selector]) {
-        return NO;
-    }
-
-    return ((BOOL (*)(id, SEL))objc_msgSend)(object, selector);
-}
-
-static BOOL DYYYPlayerViewSupportsPictureInPicture(id playerView) {
-    return DYYYObjectBoolValueForSelector(playerView, NSSelectorFromString(@"isSupportPictureInPictureMode")) ||
-           DYYYObjectBoolValueForSelector(playerView, NSSelectorFromString(@"supportPictureInPictureMode"));
-}
-
-static BOOL DYYYFeedBackgroundPlayManagerIsUserAudioMode(id player) {
-    if (!DYYYObjectIsKindOfClassNamed(player, @"AWEFeedBackgroundPlayManager")) {
-        return NO;
-    }
-
-    return DYYYObjectBoolValueForSelector(player, @selector(backgroundPlayerIsOn)) ||
-           DYYYObjectBoolValueForSelector(player, @selector(isBackgroundPlayerOn)) ||
-           DYYYObjectBoolValueForSelector(player, @selector(enableListenFeed));
-}
-
-static BOOL DYYYShouldBlockFeedNowPlayingPlayer(id player) {
-    if (!DYYYGetBool(@"DYYYDisableFeedNowPlayingInfo") || !player) {
-        return NO;
-    }
-
-    if (DYYYObjectIsKindOfClassNamed(player, @"AWEAwemeBackgroundPlayModule")) {
-        return DYYYShouldBlockFeedNowPlayingScene();
-    }
-
-    if (DYYYObjectIsKindOfClassNamed(player, @"AWEFeedBackgroundPlayManager")) {
-        return DYYYShouldBlockFeedNowPlayingScene() && !DYYYFeedBackgroundPlayManagerIsUserAudioMode(player);
-    }
-
-    return NO;
-}
-
 static BOOL DYYYShouldBlockFeedNowPlayingSystemInfoWrite(void) {
-    return DYYYGetBool(@"DYYYDisableFeedNowPlayingInfo") &&
-           !dyyyClearingFeedNowPlayingSystemInfo &&
-           DYYYShouldBlockFeedNowPlayingScene() &&
-           (CFAbsoluteTimeGetCurrent() <= dyyyFeedNowPlayingSystemBlockUntil ||
-            DYYYIsFeedNowPlayingPictureInPictureBlockActive());
-}
-
-static void DYYYRegisterFeedNowPlayingPictureInPictureObservers(void) {
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-      NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
-      NSArray<NSString *> *startNotifications = @[
-          @"AVPictureInPictureControllerWillStartPictureInPictureNotification",
-          @"AVPictureInPictureControllerDidStartPictureInPictureNotification",
-          @"AVPictureInPictureControllerPictureInPictureWillStartNotification",
-          @"AVPictureInPictureControllerPictureInPictureDidStartNotification"
-      ];
-      NSArray<NSString *> *stopNotifications = @[
-          @"AVPictureInPictureControllerWillStopPictureInPictureNotification",
-          @"AVPictureInPictureControllerDidStopPictureInPictureNotification",
-          @"AVPictureInPictureControllerPictureInPictureWillStopNotification",
-          @"AVPictureInPictureControllerPictureInPictureDidStopNotification"
-      ];
-
-      for (NSString *name in startNotifications) {
-          [center addObserverForName:name
-                              object:nil
-                               queue:[NSOperationQueue mainQueue]
-                          usingBlock:^(__unused NSNotification *notification) {
-                            if (DYYYGetBool(@"DYYYDisableFeedNowPlayingInfo")) {
-                                DYYYSetFeedNowPlayingPictureInPictureActive(YES);
-                            }
-                          }];
-      }
-
-      for (NSString *name in stopNotifications) {
-          [center addObserverForName:name
-                              object:nil
-                               queue:[NSOperationQueue mainQueue]
-                          usingBlock:^(__unused NSNotification *notification) {
-                            DYYYSetFeedNowPlayingPictureInPictureActive(NO);
-                          }];
-      }
-    });
+    return DYYYGetBool(@"DYYYDisableFeedNowPlayingInfo") && !dyyyClearingFeedNowPlayingSystemInfo;
 }
 
 %hook AWEAwemeBackgroundPlayModule
 
 - (id)nowPlayingInfo {
-    if (DYYYShouldBlockFeedNowPlayingPlayer(self)) {
+    if (DYYYGetBool(@"DYYYDisableFeedNowPlayingInfo")) {
         DYYYClearFeedNowPlayingSystemInfoThrottled();
         return nil;
     }
@@ -1021,7 +890,7 @@ static void DYYYRegisterFeedNowPlayingPictureInPictureObservers(void) {
 }
 
 - (void)refreshNowPlayingInfoIfNeeded {
-    if (DYYYShouldBlockFeedNowPlayingPlayer(self)) {
+    if (DYYYGetBool(@"DYYYDisableFeedNowPlayingInfo")) {
         DYYYClearFeedNowPlayingSystemInfoThrottled();
         return;
     }
@@ -1030,7 +899,7 @@ static void DYYYRegisterFeedNowPlayingPictureInPictureObservers(void) {
 }
 
 - (void)updateNowPlayingInfoPlayback {
-    if (DYYYShouldBlockFeedNowPlayingPlayer(self)) {
+    if (DYYYGetBool(@"DYYYDisableFeedNowPlayingInfo")) {
         DYYYClearFeedNowPlayingSystemInfoThrottled();
         return;
     }
@@ -1043,7 +912,7 @@ static void DYYYRegisterFeedNowPlayingPictureInPictureObservers(void) {
 %hook AWEFeedBackgroundPlayManager
 
 - (id)nowPlayingInfo {
-    if (DYYYShouldBlockFeedNowPlayingPlayer(self)) {
+    if (DYYYGetBool(@"DYYYDisableFeedNowPlayingInfo")) {
         DYYYClearFeedNowPlayingSystemInfoThrottled();
         return nil;
     }
@@ -1052,8 +921,7 @@ static void DYYYRegisterFeedNowPlayingPictureInPictureObservers(void) {
 }
 
 - (void)setNowPlayingInfo:(id)nowPlayingInfo {
-    if (DYYYShouldBlockFeedNowPlayingPlayer(self)) {
-        %orig(nil);
+    if (DYYYGetBool(@"DYYYDisableFeedNowPlayingInfo")) {
         DYYYClearFeedNowPlayingSystemInfoThrottled();
         return;
     }
@@ -1062,7 +930,7 @@ static void DYYYRegisterFeedNowPlayingPictureInPictureObservers(void) {
 }
 
 - (void)resetNowPlayingInfo:(id)model {
-    if (DYYYShouldBlockFeedNowPlayingPlayer(self)) {
+    if (DYYYGetBool(@"DYYYDisableFeedNowPlayingInfo")) {
         DYYYClearFeedNowPlayingSystemInfoThrottled();
         return;
     }
@@ -1071,7 +939,7 @@ static void DYYYRegisterFeedNowPlayingPictureInPictureObservers(void) {
 }
 
 - (void)refreshNowPlayingInfo {
-    if (DYYYShouldBlockFeedNowPlayingPlayer(self)) {
+    if (DYYYGetBool(@"DYYYDisableFeedNowPlayingInfo")) {
         DYYYClearFeedNowPlayingSystemInfoThrottled();
         return;
     }
@@ -1080,7 +948,7 @@ static void DYYYRegisterFeedNowPlayingPictureInPictureObservers(void) {
 }
 
 - (void)refreshNowPlayingInfoIsForce:(BOOL)isForce {
-    if (DYYYShouldBlockFeedNowPlayingPlayer(self)) {
+    if (DYYYGetBool(@"DYYYDisableFeedNowPlayingInfo")) {
         DYYYClearFeedNowPlayingSystemInfoThrottled();
         return;
     }
@@ -1089,7 +957,7 @@ static void DYYYRegisterFeedNowPlayingPictureInPictureObservers(void) {
 }
 
 - (void)updateNowPlayingInfoPlayback {
-    if (DYYYShouldBlockFeedNowPlayingPlayer(self)) {
+    if (DYYYGetBool(@"DYYYDisableFeedNowPlayingInfo")) {
         DYYYClearFeedNowPlayingSystemInfoThrottled();
         return;
     }
@@ -1099,11 +967,11 @@ static void DYYYRegisterFeedNowPlayingPictureInPictureObservers(void) {
 
 %end
 
-// 再从抖音播放中心入口兜底，阻断前台信息流视频上岛。
+// 采用 HideNowPlayingInfo 的强屏蔽思路：播放中心写入时直接清空系统 Now Playing，不再走原实现。
 %hook AWENowPlayingInfoCenter
 
 - (void)becomePlayingPlayer:(id)player {
-    if (DYYYShouldBlockFeedNowPlayingPlayer(player)) {
+    if (DYYYGetBool(@"DYYYDisableFeedNowPlayingInfo")) {
         DYYYClearFeedNowPlayingSystemInfoThrottled();
         return;
     }
@@ -1112,8 +980,7 @@ static void DYYYRegisterFeedNowPlayingPictureInPictureObservers(void) {
 }
 
 - (void)setNowPlayingInfo:(id)nowPlayingInfo {
-    if (DYYYShouldBlockFeedNowPlayingPlayer(self.playingPlayer)) {
-        %orig(nil);
+    if (DYYYGetBool(@"DYYYDisableFeedNowPlayingInfo")) {
         DYYYClearFeedNowPlayingSystemInfoThrottled();
         return;
     }
@@ -1122,7 +989,7 @@ static void DYYYRegisterFeedNowPlayingPictureInPictureObservers(void) {
 }
 
 - (void)refreshNowPlayingInfo {
-    if (DYYYShouldBlockFeedNowPlayingPlayer(self.playingPlayer)) {
+    if (DYYYGetBool(@"DYYYDisableFeedNowPlayingInfo")) {
         DYYYClearFeedNowPlayingSystemInfoThrottled();
         return;
     }
@@ -9897,33 +9764,11 @@ static Class TagViewClass = nil;
 
 %hook TTPlayerView
 
-- (void)checkPictureInPictureMode {
-    %orig;
-
-    if (DYYYGetBool(@"DYYYDisableFeedNowPlayingInfo") && DYYYPlayerViewSupportsPictureInPicture(self)) {
-        DYYYExtendFeedNowPlayingPictureInPictureBlockWindow();
-        DYYYClearFeedNowPlayingSystemInfoThrottled();
-    }
-}
-
 - (void)layoutSubviews {
     %orig;
     UIView *parent = self.superview;
     if (parent) {
         parent.backgroundColor = self.backgroundColor;
-    }
-}
-
-%end
-
-%hook TTPlayerView2
-
-- (void)checkPictureInPictureMode {
-    %orig;
-
-    if (DYYYGetBool(@"DYYYDisableFeedNowPlayingInfo") && DYYYPlayerViewSupportsPictureInPicture(self)) {
-        DYYYExtendFeedNowPlayingPictureInPictureBlockWindow();
-        DYYYClearFeedNowPlayingSystemInfoThrottled();
     }
 }
 
@@ -10491,8 +10336,6 @@ static void findTargetViewInView(UIView *view) {
     [[NSUserDefaults standardUserDefaults] registerDefaults:@{
         @"DYYYDisableFeedNowPlayingInfo" : @YES
     }];
-
-    DYYYRegisterFeedNowPlayingPictureInPictureObservers();
 
     DYYYMigrateCombinedHDRModeIfNeeded();
 

--- a/DYYY.xm
+++ b/DYYY.xm
@@ -318,7 +318,7 @@ static NSArray<AWEPlayInteractionViewController *> *DYYYSpeedInteractionControll
     return controllers;
 }
 
-static AWEPlayInteractionViewController *DYYYResolveCurrentSpeedInteractionController(AWEPlayInteractionViewController *preferredController) {
+static AWEPlayInteractionViewController *DYYYResolveSpeedInteractionController(AWEPlayInteractionViewController *preferredController, AWEAwemeModel *targetAweme, BOOL allowVisibleFallback) {
     AWEPlayInteractionViewController *bestModelMatch = nil;
     AWEPlayInteractionViewController *bestVisibleController = nil;
     CGFloat bestModelMatchScore = -1.0;
@@ -334,13 +334,17 @@ static AWEPlayInteractionViewController *DYYYResolveCurrentSpeedInteractionContr
             bestVisibleScore = visibilityScore;
             bestVisibleController = controller;
         }
-        if (DYYYAwemeModelsMatch(controller.model, dyyyCurrentSpeedAweme) && visibilityScore > bestModelMatchScore) {
+        if (targetAweme && DYYYAwemeModelsMatch(controller.model, targetAweme) && visibilityScore > bestModelMatchScore) {
             bestModelMatchScore = visibilityScore;
             bestModelMatch = controller;
         }
     }
 
-    return bestModelMatch ?: bestVisibleController;
+    return bestModelMatch ?: (allowVisibleFallback ? bestVisibleController : nil);
+}
+
+static AWEPlayInteractionViewController *DYYYResolveCurrentSpeedInteractionController(AWEPlayInteractionViewController *preferredController) {
+    return DYYYResolveSpeedInteractionController(preferredController, dyyyCurrentSpeedAweme, YES);
 }
 
 id DYYYCurrentSpeedInteractionController(void) {
@@ -349,7 +353,9 @@ id DYYYCurrentSpeedInteractionController(void) {
 
 static void DYYYEnsureFloatSpeedButton(AWEPlayInteractionViewController *interactionController) {
     [FloatingSpeedButton reloadConfiguration];
-    AWEPlayInteractionViewController *currentController = DYYYResolveCurrentSpeedInteractionController(interactionController);
+    AWEAwemeModel *targetAweme = dyyyCurrentSpeedAweme;
+    BOOL allowVisibleFallback = !targetAweme || (interactionController && DYYYAwemeModelsMatch(interactionController.model, targetAweme));
+    AWEPlayInteractionViewController *currentController = DYYYResolveSpeedInteractionController(interactionController, targetAweme, allowVisibleFallback);
     if (!currentController) {
         updateSpeedButtonVisibility();
         return;
@@ -509,7 +515,8 @@ static void DYYYBindAndApplyCurrentPlaybackSpeed(void) {
         return;
     }
 
-    AWEPlayInteractionViewController *currentController = DYYYResolveCurrentSpeedInteractionController(nil);
+    AWEAwemeModel *targetAweme = dyyyCurrentSpeedAweme;
+    AWEPlayInteractionViewController *currentController = DYYYResolveSpeedInteractionController(nil, targetAweme, targetAweme == nil);
     if (!currentController) {
         return;
     }
@@ -518,10 +525,20 @@ static void DYYYBindAndApplyCurrentPlaybackSpeed(void) {
     DYYYApplyPlaybackSpeed(currentController, DYYYConfiguredPlaybackSpeed());
 }
 
-static void DYYYScheduleConfiguredPlaybackSpeedRestore(void) {
-    dispatch_async(dispatch_get_main_queue(), ^{
+static void DYYYScheduleConfiguredPlaybackSpeedRestoreAfterDelay(NSTimeInterval delay) {
+    dispatch_block_t restoreBlock = ^{
       DYYYBindAndApplyCurrentPlaybackSpeed();
-    });
+    };
+    if (delay <= 0.0) {
+        dispatch_async(dispatch_get_main_queue(), restoreBlock);
+    } else {
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delay * NSEC_PER_SEC)), dispatch_get_main_queue(), restoreBlock);
+    }
+}
+
+static void DYYYScheduleConfiguredPlaybackSpeedRestore(void) {
+    DYYYScheduleConfiguredPlaybackSpeedRestoreAfterDelay(0.0);
+    DYYYScheduleConfiguredPlaybackSpeedRestoreAfterDelay(0.2);
 }
 
 static void DYYYEndLockedLongPressSpeedAndRestoreIfNeeded(void) {

--- a/DYYY.xm
+++ b/DYYY.xm
@@ -279,6 +279,14 @@ static NSString *DYYYSpeedAwemeIdentifier(AWEAwemeModel *aweme) {
     return [NSString stringWithFormat:@"%p", aweme];
 }
 
+static double DYYYDefaultPlaybackSpeed(void) {
+    double defaultSpeed = [[NSUserDefaults standardUserDefaults] doubleForKey:@"DYYYDefaultSpeed"];
+    if (isfinite(defaultSpeed) && defaultSpeed > 0.0) {
+        return defaultSpeed;
+    }
+    return 1.0;
+}
+
 static void DYYYRestoreFloatSpeedButtonForAwemeIfNeeded(AWEAwemeModel *aweme) {
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
     BOOL shouldAutoRestore = [defaults boolForKey:@"DYYYEnableFloatSpeedButton"] && [defaults boolForKey:@"DYYYAutoRestoreSpeed"];
@@ -293,7 +301,9 @@ static void DYYYRestoreFloatSpeedButtonForAwemeIfNeeded(AWEAwemeModel *aweme) {
     }
 
     dyyyLastAutoRestoredSpeedAwemeIdentifier = [awemeIdentifier copy];
-    setCurrentSpeedIndex(0);
+    if (!setCurrentSpeedValue((float)DYYYDefaultPlaybackSpeed())) {
+        setCurrentSpeedIndex(0);
+    }
     updateSpeedButtonUI();
 }
 
@@ -471,10 +481,7 @@ static double DYYYConfiguredPlaybackSpeed(void) {
     }
 
     if ([defaults boolForKey:@"DYYYUserAgreementAccepted"]) {
-        double defaultSpeed = [defaults doubleForKey:@"DYYYDefaultSpeed"];
-        if (isfinite(defaultSpeed) && defaultSpeed > 0.0) {
-            return defaultSpeed;
-        }
+        return DYYYDefaultPlaybackSpeed();
     }
     return 1.0;
 }
@@ -482,14 +489,7 @@ static double DYYYConfiguredPlaybackSpeed(void) {
 static double DYYYPreparedPlaybackSpeed(void) {
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
     if ([defaults boolForKey:@"DYYYEnableFloatSpeedButton"] && [defaults boolForKey:@"DYYYAutoRestoreSpeed"]) {
-        NSArray *speeds = getSpeedOptions();
-        if (speeds.count > 0) {
-            double defaultSpeed = [speeds.firstObject doubleValue];
-            if (isfinite(defaultSpeed) && defaultSpeed > 0.0) {
-                return defaultSpeed;
-            }
-        }
-        return 1.0;
+        return DYYYDefaultPlaybackSpeed();
     }
     return DYYYConfiguredPlaybackSpeed();
 }

--- a/DYYYFloatSpeedButton.h
+++ b/DYYYFloatSpeedButton.h
@@ -40,6 +40,7 @@ extern NSArray *findViewControllersInHierarchy(UIViewController *rootViewControl
 extern float getCurrentSpeed(void);
 extern NSInteger getCurrentSpeedIndex(void);
 extern void setCurrentSpeedIndex(NSInteger index);
+extern BOOL setCurrentSpeedValue(float speed);
 extern void updateSpeedButtonUI(void);
 extern void updateSpeedButtonVisibility(void);
 extern id DYYYCurrentSpeedInteractionController(void);

--- a/DYYYFloatSpeedButton.m
+++ b/DYYYFloatSpeedButton.m
@@ -72,6 +72,26 @@ static NSString *DYYYFormatSpeedOption(double speed) {
     return speedString;
 }
 
+static BOOL DYYYSpeedValuesMatch(double lhs, double rhs) {
+    return fabs(lhs - rhs) <= 0.001;
+}
+
+static NSArray<NSString *> *DYYYAdjustedSpeedOptionsForMissingDefaultSpeed(NSArray<NSString *> *currentSpeeds, double defaultSpeed) {
+    if (DYYYSpeedValuesMatch(defaultSpeed, 1.25)) {
+        return @[ @"1.25", @"2.0" ];
+    }
+    if (DYYYSpeedValuesMatch(defaultSpeed, 1.5)) {
+        return @[ @"1.5", @"2.0" ];
+    }
+    if (DYYYSpeedValuesMatch(defaultSpeed, 2.0)) {
+        return @[ @"1.0", @"1.25", @"1.5", @"2.0" ];
+    }
+
+    NSMutableArray<NSString *> *adjustedSpeeds = [currentSpeeds mutableCopy];
+    [adjustedSpeeds addObject:DYYYFormatSpeedOption(defaultSpeed)];
+    return adjustedSpeeds;
+}
+
 NSArray *getSpeedOptions() {
     NSString *speedConfig = [[NSUserDefaults standardUserDefaults] stringForKey:@"DYYYSpeedSettings"] ?: @"1.0,1.25,1.5,2.0";
     NSMutableArray<NSString *> *validSpeeds = [NSMutableArray array];
@@ -92,7 +112,7 @@ NSArray *getSpeedOptions() {
         double speed = 0.0;
         if ([scanner scanDouble:&speed] && scanner.isAtEnd && isfinite(speed) && speed > 0.0) {
             [validSpeeds addObject:trimmedValue];
-            if (shouldIncludeDefaultSpeed && fabs(speed - configuredDefaultSpeed) <= 0.001) {
+            if (shouldIncludeDefaultSpeed && DYYYSpeedValuesMatch(speed, configuredDefaultSpeed)) {
                 containsDefaultSpeed = YES;
             }
         }
@@ -102,7 +122,7 @@ NSArray *getSpeedOptions() {
         [validSpeeds addObjectsFromArray:fallbackSpeeds];
         if (shouldIncludeDefaultSpeed) {
             for (NSString *speedString in fallbackSpeeds) {
-                if (fabs([speedString doubleValue] - configuredDefaultSpeed) <= 0.001) {
+                if (DYYYSpeedValuesMatch([speedString doubleValue], configuredDefaultSpeed)) {
                     containsDefaultSpeed = YES;
                     break;
                 }
@@ -111,7 +131,7 @@ NSArray *getSpeedOptions() {
     }
 
     if (shouldIncludeDefaultSpeed && !containsDefaultSpeed) {
-        [validSpeeds addObject:DYYYFormatSpeedOption(configuredDefaultSpeed)];
+        return DYYYAdjustedSpeedOptionsForMissingDefaultSpeed(validSpeeds, configuredDefaultSpeed);
     }
 
     return validSpeeds;
@@ -159,7 +179,7 @@ BOOL setCurrentSpeedValue(float speed) {
 
     NSArray *speeds = getSpeedOptions();
     for (NSInteger index = 0; index < speeds.count; index++) {
-        if (fabs([speeds[index] floatValue] - speed) <= 0.001f) {
+        if (DYYYSpeedValuesMatch([speeds[index] floatValue], speed)) {
             setCurrentSpeedIndex(index);
             return YES;
         }

--- a/DYYYFloatSpeedButton.m
+++ b/DYYYFloatSpeedButton.m
@@ -61,10 +61,26 @@ static BOOL DYYYShouldHideSpeedButton(void) {
     return NO;
 }
 
+static NSString *DYYYFormatSpeedOption(double speed) {
+    NSString *speedString = [NSString stringWithFormat:@"%.2f", speed];
+    while ([speedString containsString:@"."] && [speedString hasSuffix:@"0"]) {
+        speedString = [speedString substringToIndex:speedString.length - 1];
+    }
+    if ([speedString hasSuffix:@"."]) {
+        speedString = [speedString substringToIndex:speedString.length - 1];
+    }
+    return speedString;
+}
+
 NSArray *getSpeedOptions() {
     NSString *speedConfig = [[NSUserDefaults standardUserDefaults] stringForKey:@"DYYYSpeedSettings"] ?: @"1.0,1.25,1.5,2.0";
     NSMutableArray<NSString *> *validSpeeds = [NSMutableArray array];
     NSCharacterSet *whitespace = [NSCharacterSet whitespaceAndNewlineCharacterSet];
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    double configuredDefaultSpeed = [defaults objectForKey:@"DYYYDefaultSpeed"] ? [defaults doubleForKey:@"DYYYDefaultSpeed"] : 1.0;
+    BOOL shouldIncludeDefaultSpeed = [defaults boolForKey:@"DYYYEnableFloatSpeedButton"] && [defaults boolForKey:@"DYYYAutoRestoreSpeed"] && isfinite(configuredDefaultSpeed) && configuredDefaultSpeed > 0.0;
+    BOOL containsDefaultSpeed = NO;
+    NSArray<NSString *> *fallbackSpeeds = @[ @"1.0", @"1.25", @"1.5", @"2.0" ];
 
     for (NSString *component in [speedConfig componentsSeparatedByString:@","]) {
         NSString *trimmedValue = [component stringByTrimmingCharactersInSet:whitespace];
@@ -76,10 +92,29 @@ NSArray *getSpeedOptions() {
         double speed = 0.0;
         if ([scanner scanDouble:&speed] && scanner.isAtEnd && isfinite(speed) && speed > 0.0) {
             [validSpeeds addObject:trimmedValue];
+            if (shouldIncludeDefaultSpeed && fabs(speed - configuredDefaultSpeed) <= 0.001) {
+                containsDefaultSpeed = YES;
+            }
         }
     }
 
-    return validSpeeds.count > 0 ? validSpeeds : @[ @"1.0", @"1.25", @"1.5", @"2.0" ];
+    if (validSpeeds.count == 0) {
+        [validSpeeds addObjectsFromArray:fallbackSpeeds];
+        if (shouldIncludeDefaultSpeed) {
+            for (NSString *speedString in fallbackSpeeds) {
+                if (fabs([speedString doubleValue] - configuredDefaultSpeed) <= 0.001) {
+                    containsDefaultSpeed = YES;
+                    break;
+                }
+            }
+        }
+    }
+
+    if (shouldIncludeDefaultSpeed && !containsDefaultSpeed) {
+        [validSpeeds addObject:DYYYFormatSpeedOption(configuredDefaultSpeed)];
+    }
+
+    return validSpeeds;
 }
 
 NSInteger getCurrentSpeedIndex() {
@@ -115,6 +150,21 @@ void setCurrentSpeedIndex(NSInteger index) {
     }
 
     [[NSUserDefaults standardUserDefaults] setInteger:index forKey:@"DYYYCurrentSpeedIndex"];
+}
+
+BOOL setCurrentSpeedValue(float speed) {
+    if (!isfinite(speed) || speed <= 0.0f) {
+        return NO;
+    }
+
+    NSArray *speeds = getSpeedOptions();
+    for (NSInteger index = 0; index < speeds.count; index++) {
+        if (fabs([speeds[index] floatValue] - speed) <= 0.001f) {
+            setCurrentSpeedIndex(index);
+            return YES;
+        }
+    }
+    return NO;
 }
 
 void updateSpeedButtonUI() {


### PR DESCRIPTION
## 概述

- Release 自动发布新增 arm64e dylib 提取脚本：从 arm64e/roothide deb 中提取 DYYY.dylib、按包名与版本命名，并在可用时校验 dylib 架构。
- build workflow 同步上传 deb 与 dylib 到 Actions artifact 和 GitHub Release，Release notes 也补充 arm64e dylib 说明。
- 信息流播放信息屏蔽改为更直接的强拦截：在抖音背景播放模块、播放中心和系统 MPNowPlayingInfoCenter 写入时直接清空或阻断，减少灵动岛/锁屏播放信息残留。
- 修复默认倍速切换视频时的控制器定位问题，按当前 aweme 匹配交互控制器，避免速度应用到预加载或错误的可见控制器。
- 联动默认倍速与快捷倍速自动恢复：自动恢复优先使用配置的默认倍速，并把该默认倍速补入快捷倍速选项，保证按钮显示与实际播放速度一致。
- 优化默认倍速缺失时的快捷倍速候选规则：默认倍速为 1.25、1.5、2.0 等常见值时使用更稳定的候选列表，避免自动追加导致循环顺序不符合预期。
- 修复长按面板关闭后的倍速重置问题：自动恢复只在 aweme 切换时回到默认倍速，当前视频刷新或长按倍速结束后保留用户已选的快捷倍速。
- 完善头像下加号替代入口隐藏：将隐藏头像加号/关注提示的处理范围扩展到私信、进店、广告链接等头像下方动态入口。
- 为头像视图、关注提示、私信、进店和广告链接控制器补充布局、展示、播放、重置和状态变化后的重试应用逻辑，避免入口在刷新后重新出现。
- 当完整隐藏关注提示时，同步阻断相关入口的展示判断和点击事件；仅隐藏加号动画时则优先隐藏图标、引导动画等视觉层。
- 清理头像下隐藏入口圆形底板：隐藏头像加号或替代入口时，同步清理残留背景色、边框、阴影和 layer 内容，避免图标已隐藏但仍留下空白圆形容器。
- 递归处理入口容器的 UIView、CALayer 与 CAShapeLayer，覆盖子视图、子图层、fill/stroke 等形态，让私信、进店、广告链接和关注加号的隐藏结果更一致。

## 验证

- git diff --check origin/main..HEAD
- make clean
- make package FINALPACKAGE=1 INSTALL=0
- xcodebuild -project DYYY.xcodeproj -target DYYYDylib -configuration Debug -sdk iphoneos build CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO
- xcodebuild -project DYYY.xcodeproj -target DYYY -configuration Debug -sdk iphoneos build CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO EXCLUDED_SOURCE_FILE_NAMES=Aweme.app
- lipo -info DYYY.dylib：arm64 arm64e
- rg -a 检查产物包含 AWEPlayInteractionUserAvatarSendMessageController、AWEPlayInteractionUserAvatarSendMsgController、AWEPlayInteractionUserAvatarEnterStoreController、AWEPlayInteractionUserAvatarAdLinkController、DYYYHideFollowPromptView、DYYYHideLOTAnimationView

## 备注

- 新增的 3b25d97 与 b48c67a 已随 VexCove:main 自动进入本 PR，本文已同步补充对应摘要与验证信息。
- b48c67a 只改动 DYYY.xm，重点是清理隐藏入口后残留的容器视觉层，不改变设置项语义。