### PR TITLE
补充设置搜索、HDR 屏蔽与交互隐藏修复

### DIFF
--- a/.github/scripts/generate-release-notes.sh
+++ b/.github/scripts/generate-release-notes.sh
@@ -18,7 +18,9 @@ docs_file=$(mktemp)
 style_file=$(mktemp)
 chore_file=$(mktemp)
 revert_file=$(mktemp)
-trap 'rm -f "$feat_file" "$fix_file" "$perf_file" "$refactor_file" "$docs_file" "$style_file" "$chore_file" "$revert_file"' EXIT
+records_file=$(mktemp)
+skip_file=$(mktemp)
+trap 'rm -f "$feat_file" "$fix_file" "$perf_file" "$refactor_file" "$docs_file" "$style_file" "$chore_file" "$revert_file" "$records_file" "$skip_file"' EXIT
 
 trim_text() {
     local value=$1
@@ -98,7 +100,7 @@ canonical_commit_type() {
         新增*|增加*|添加*|支持*|引入*|实现*)
             printf 'feat'
             ;;
-        修复*|解决*|恢复*|纠正*)
+        修复*|解决*|恢复*|纠正*|*修复*)
             printf 'fix'
             ;;
         性能*|提速*|加速*|*性能*优化*|*速度*优化*|*加载*优化*)
@@ -246,7 +248,7 @@ summarize_commit_title() {
             printf '新增%s' "${content:-插件功能}"
             ;;
         fix)
-            content=$(printf '%s' "$content" | sed -E 's/^(修复|解决|恢复|纠正|修改|调整)[[:space:]:：]*//; s/的问题$//')
+            content=$(printf '%s' "$content" | sed -E 's/^(兜底修复|修复|解决|恢复|纠正|修改|调整)[[:space:]:：]*//; s/的问题$//')
             content=$(printf '%s' "$content" | sed -E 's/不生效/生效异常/g; s/失效/异常/g; s/无法/不能/g')
             content=$(trim_text "$content")
             printf '修正%s' "${content:-已知问题}"
@@ -297,6 +299,123 @@ section_file_for_type() {
     esac
 }
 
+reverted_commit_hash() {
+    local hash=$1
+    local target_hash
+    local resolved_hash
+
+    target_hash=$(
+        git show -s --format=%B "$hash" |
+            sed -nE 's/^This reverts commit ([0-9a-fA-F]{7,40})\.$/\1/p' |
+            head -n 1
+    )
+
+    if [[ -z "$target_hash" ]]; then
+        return
+    fi
+
+    resolved_hash=$(git rev-parse --verify "${target_hash}^{commit}" 2>/dev/null || true)
+    printf '%s' "${resolved_hash:-$target_hash}"
+}
+
+reverted_subject_from_title() {
+    local subject=$1
+    local revert_regex='^Revert[[:space:]]+"(.*)"$'
+
+    if [[ "$subject" =~ $revert_regex ]]; then
+        printf '%s' "${BASH_REMATCH[1]}"
+        return
+    fi
+
+    case "$subject" in
+        回滚*|撤销*|取消*)
+            printf '%s' "$subject" | sed -E 's/^(回滚|撤销|取消)[[:space:]:：]*//'
+            ;;
+    esac
+}
+
+normalize_revert_match_text() {
+    local value=$1
+
+    value=$(strip_commit_type_prefix "$value")
+    value=$(printf '%s' "$value" |
+        sed -E 's/^(新增|增加|添加|支持|引入|实现|修复|解决|恢复|纠正|修改|调整|优化|完善|重构|简化|清理|整理)[[:space:]:：]*//')
+    value=$(printf '%s' "$value" |
+        sed -E 's/(的问题|问题|逻辑|优化|功能|选项|状态)$//')
+    value=$(printf '%s' "$value" |
+        tr -d '[:space:]' |
+        sed -E 's/[[:punct:]，。；：“”"'\''（）()、]//g')
+
+    printf '%s' "$value"
+}
+
+record_contains_hash() {
+    local target_hash=$1
+
+    awk -F $'\t' -v target="$target_hash" '
+        $1 == target || index($1, target) == 1 || index(target, $1) == 1 {
+            found = 1
+        }
+        END {
+            exit found ? 0 : 1
+        }
+    ' "$records_file"
+}
+
+mark_skip_pair() {
+    local revert_hash=$1
+    local target_hash=$2
+
+    printf '%s\n%s\n' "$revert_hash" "$target_hash" >> "$skip_file"
+}
+
+detect_same_range_reverts() {
+    local hash
+    local subject
+    local commit_type
+    local target_hash
+    local target_subject
+    local target_key
+    local candidate_hash
+    local candidate_subject
+    local candidate_type
+    local candidate_key
+
+    while IFS=$'\t' read -r hash subject commit_type; do
+        [[ -n "$hash" ]] || continue
+        [[ "$commit_type" == "revert" ]] || continue
+
+        target_hash=$(reverted_commit_hash "$hash")
+        if [[ -n "$target_hash" ]] && record_contains_hash "$target_hash"; then
+            mark_skip_pair "$hash" "$target_hash"
+            continue
+        fi
+
+        target_subject=$(reverted_subject_from_title "$subject")
+        target_key=$(normalize_revert_match_text "$target_subject")
+        if [[ -z "$target_key" || "${#target_key}" -lt 6 ]]; then
+            continue
+        fi
+
+        while IFS=$'\t' read -r candidate_hash candidate_subject candidate_type; do
+            [[ -n "$candidate_hash" ]] || continue
+            [[ "$candidate_hash" == "$hash" ]] && continue
+
+            candidate_key=$(normalize_revert_match_text "$candidate_subject")
+            if [[ -n "$candidate_key" && "$candidate_key" == "$target_key" ]]; then
+                mark_skip_pair "$hash" "$candidate_hash"
+                break
+            fi
+        done < "$records_file"
+    done < "$records_file"
+}
+
+commit_is_skipped() {
+    local hash=$1
+
+    grep -Fxq "$hash" "$skip_file"
+}
+
 commit_touches_control() {
     local hash=$1
 
@@ -317,8 +436,6 @@ else
     fi
 fi
 
-relevant_count=0
-
 while IFS=$'\t' read -r hash subject; do
     [[ -n "$hash" ]] || continue
 
@@ -327,13 +444,26 @@ while IFS=$'\t' read -r hash subject; do
         continue
     fi
 
+    commit_type=$(canonical_commit_type "$subject")
+    printf '%s\t%s\t%s\n' "$hash" "$subject" "$commit_type" >> "$records_file"
+done < <(git log --reverse --format=$'%H\t%s' "$commit_range")
+
+detect_same_range_reverts
+
+relevant_count=0
+
+while IFS=$'\t' read -r hash subject commit_type; do
+    [[ -n "$hash" ]] || continue
+    if commit_is_skipped "$hash"; then
+        continue
+    fi
+
     relevant_count=$((relevant_count + 1))
     short_hash=${hash:0:8}
-    commit_type=$(canonical_commit_type "$subject")
     summary_title=$(summarize_commit_title "$hash" "$subject" "$commit_type")
     entry="- \`${commit_type}\` **${summary_title}** ([\`${short_hash}\`](${server_url}/${repository}/commit/${hash}))"
     printf '%s\n' "$entry" >> "$(section_file_for_type "$commit_type")"
-done < <(git log --reverse --format=$'%H\t%s' "$commit_range")
+done < "$records_file"
 
 cat > "$notes_file" <<EOF
 # 更新日志

--- a/DYYY.xm
+++ b/DYYY.xm
@@ -10,6 +10,7 @@
 #import <UIKit/UIKit.h>
 #import <dlfcn.h>
 #import <float.h>
+#import <limits.h>
 #import <math.h>
 #import <objc/message.h>
 #import <objc/runtime.h>
@@ -4726,6 +4727,120 @@ static BOOL DYYYShouldEnableSaveAvatar(void) {
     return DYYYGetBool(@"DYYYEnableSaveAvatar");
 }
 
+typedef BOOL (*DYYYSaveAvatarShouldShowItemIMP)(id, SEL);
+
+static NSMutableDictionary<NSString *, NSValue *> *DYYYSaveAvatarOriginalShouldShowItemIMPs(void) {
+    static NSMutableDictionary<NSString *, NSValue *> *imps = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+      imps = [NSMutableDictionary dictionary];
+    });
+    return imps;
+}
+
+static BOOL DYYYSaveAvatarShouldShowItemHook(id self, SEL _cmd) {
+    if (DYYYShouldEnableSaveAvatar()) {
+        return YES;
+    }
+
+    NSString *className = NSStringFromClass([self class]);
+    DYYYSaveAvatarShouldShowItemIMP originalIMP = (DYYYSaveAvatarShouldShowItemIMP)[DYYYSaveAvatarOriginalShouldShowItemIMPs()[className] pointerValue];
+    if (originalIMP) {
+        return originalIMP(self, _cmd);
+    }
+    return NO;
+}
+
+static BOOL DYYYSaveAvatarManagerClassIsCandidate(Class cls) {
+    NSString *className = NSStringFromClass(cls);
+    return [className containsString:@"ProfileAvatar"] && [className containsString:@"FunctionManager"] && class_getInstanceMethod(cls, @selector(shouldShowSaveAvatarItem));
+}
+
+static void DYYYRegisterSaveAvatarManagerClass(Class cls) {
+    if (!cls || !DYYYSaveAvatarManagerClassIsCandidate(cls)) {
+        return;
+    }
+
+    NSString *className = NSStringFromClass(cls);
+    if (DYYYSaveAvatarOriginalShouldShowItemIMPs()[className]) {
+        return;
+    }
+
+    DYYYSaveAvatarShouldShowItemIMP originalIMP = NULL;
+    MSHookMessageEx(cls, @selector(shouldShowSaveAvatarItem), (IMP)DYYYSaveAvatarShouldShowItemHook, (IMP *)&originalIMP);
+    if (originalIMP) {
+        DYYYSaveAvatarOriginalShouldShowItemIMPs()[className] = [NSValue valueWithPointer:originalIMP];
+    }
+}
+
+static void DYYYRegisterSaveAvatarManagerHooks(void) {
+    NSArray<NSString *> *candidateClassNames = @[
+        @"AWEProfileAvatarFunctionManager",
+        @"AFDProfileAvatarFunctionManager"
+    ];
+
+    for (NSString *className in candidateClassNames) {
+        DYYYRegisterSaveAvatarManagerClass(objc_getClass(className.UTF8String));
+    }
+
+    unsigned int classCount = 0;
+    Class *classes = objc_copyClassList(&classCount);
+    for (unsigned int index = 0; index < classCount; index++) {
+        DYYYRegisterSaveAvatarManagerClass(classes[index]);
+    }
+    free(classes);
+}
+
+static id DYYYProfileAvatarObjectForSelector(id object, SEL selector) {
+    if (!object || ![object respondsToSelector:selector]) {
+        return nil;
+    }
+    return ((id (*)(id, SEL))objc_msgSend)(object, selector);
+}
+
+static long long DYYYProfileAvatarIntegerForSelector(id object, SEL selector, long long fallbackValue) {
+    if (!object || ![object respondsToSelector:selector]) {
+        return fallbackValue;
+    }
+    return ((long long (*)(id, SEL))objc_msgSend)(object, selector);
+}
+
+static id DYYYProfileAvatarSaveModelForPreviewController(id controller) {
+    id functionManager = DYYYProfileAvatarObjectForSelector(controller, @selector(functionManager));
+    return DYYYProfileAvatarObjectForSelector(functionManager, @selector(saveAvatarModel));
+}
+
+static BOOL DYYYProfileAvatarFunctionTypeIsSaveAvatar(id controller, long long functionType) {
+    id saveAvatarModel = DYYYProfileAvatarSaveModelForPreviewController(controller);
+    if (!saveAvatarModel) {
+        return NO;
+    }
+    return DYYYProfileAvatarIntegerForSelector(saveAvatarModel, @selector(type), LLONG_MIN) == functionType;
+}
+
+static void DYYYEnsureSaveAvatarModelInPreviewController(id controller) {
+    if (!DYYYShouldEnableSaveAvatar() || ![controller respondsToSelector:@selector(setFunctionModels:)]) {
+        return;
+    }
+
+    id saveAvatarModel = DYYYProfileAvatarSaveModelForPreviewController(controller);
+    if (!saveAvatarModel) {
+        return;
+    }
+
+    id functionModels = DYYYProfileAvatarObjectForSelector(controller, @selector(functionModels));
+    if ([functionModels isKindOfClass:[NSArray class]] && [(NSArray *)functionModels containsObject:saveAvatarModel]) {
+        return;
+    }
+
+    NSMutableArray *updatedModels = [NSMutableArray array];
+    if ([functionModels isKindOfClass:[NSArray class]]) {
+        [updatedModels addObjectsFromArray:(NSArray *)functionModels];
+    }
+    [updatedModels addObject:saveAvatarModel];
+    ((void (*)(id, SEL, id))objc_msgSend)(controller, @selector(setFunctionModels:), [updatedModels copy]);
+}
+
 %hook AWEUserProfileABTestServiceObjc
 
 + (BOOL)profileAvatarLongPressEnable {
@@ -4749,24 +4864,20 @@ static BOOL DYYYShouldEnableSaveAvatar(void) {
 
 %end
 
-%hook AWEProfileAvatarFunctionManager
+%hook AWEProfileAvatarViewController
 
-- (BOOL)shouldShowSaveAvatarItem {
-    if (DYYYShouldEnableSaveAvatar()) {
+- (BOOL)p_shouldShowFunctionWithType:(long long)functionType {
+    if (DYYYShouldEnableSaveAvatar() && DYYYProfileAvatarFunctionTypeIsSaveAvatar(self, functionType)) {
         return YES;
     }
     return %orig;
 }
 
-%end
-
-%hook AFDProfileAvatarFunctionManager
-- (BOOL)shouldShowSaveAvatarItem {
-    if (DYYYShouldEnableSaveAvatar()) {
-        return YES;
-    }
-    return %orig;
+- (void)showMoreOptionsPopover {
+    DYYYEnsureSaveAvatarModelInPreviewController(self);
+    %orig;
 }
+
 %end
 
 %hook AWECommentMediaDownloadConfigLivePhoto
@@ -6360,32 +6471,127 @@ static void DYYYApplyAvatarFollowPromptSettingsWithRetry(id owner) {
 %end
 
 
-// 隐藏暂停关键词
+// 隐藏暂停相关
+static BOOL DYYYShouldHidePauseRelatedContent(void) {
+    return DYYYGetBool(@"DYYYHidePauseVideoRelatedWord");
+}
+
+static void DYYYHidePauseRelatedView(id object) {
+    if (![object isKindOfClass:[UIView class]]) {
+        return;
+    }
+
+    UIView *view = (UIView *)object;
+    view.hidden = YES;
+    view.alpha = 0.0;
+    view.userInteractionEnabled = NO;
+    if (view.superview) {
+        [view removeFromSuperview];
+    }
+}
+
+static void DYYYDisablePauseRelatedTap(id object) {
+    SEL blockSetter = @selector(setDidTapRelatedWordBlock:);
+    if ([object respondsToSelector:blockSetter]) {
+        ((void (*)(id, SEL, id))objc_msgSend)(object, blockSetter, nil);
+    }
+
+    SEL searchBlockSetter = @selector(setSearchBtnClickedBlock:);
+    if ([object respondsToSelector:searchBlockSetter]) {
+        ((void (*)(id, SEL, id))objc_msgSend)(object, searchBlockSetter, nil);
+    }
+
+    SEL scanBlockSetter = @selector(setScanBtnClickedBlock:);
+    if ([object respondsToSelector:scanBlockSetter]) {
+        ((void (*)(id, SEL, id))objc_msgSend)(object, scanBlockSetter, nil);
+    }
+}
+
+static void DYYYSetPauseRelatedObjectIfPossible(id object, SEL selector, id value) {
+    if ([object respondsToSelector:selector]) {
+        ((void (*)(id, SEL, id))objc_msgSend)(object, selector, value);
+    }
+}
+
+static void DYYYSetPauseRelatedBoolIfPossible(id object, SEL selector, BOOL value) {
+    if ([object respondsToSelector:selector]) {
+        ((void (*)(id, SEL, BOOL))objc_msgSend)(object, selector, value);
+    }
+}
+
+static id DYYYGetPauseRelatedObjectIfPossible(id object, SEL selector) {
+    if ([object respondsToSelector:selector]) {
+        return ((id (*)(id, SEL))objc_msgSend)(object, selector);
+    }
+    return nil;
+}
+
+static void DYYYClearPauseRelatedModelDepth(id object, NSInteger depth) {
+    if (!object || depth > 3) {
+        return;
+    }
+
+    DYYYDisablePauseRelatedTap(object);
+
+    id pauseModalInfo = DYYYGetPauseRelatedObjectIfPossible(object, @selector(pauseModalInfo));
+    if (pauseModalInfo && pauseModalInfo != object) {
+        DYYYClearPauseRelatedModelDepth(pauseModalInfo, depth + 1);
+    }
+
+    id pauseSearchInfoModel = DYYYGetPauseRelatedObjectIfPossible(object, @selector(pauseSearchInfoModel));
+    if (pauseSearchInfoModel && pauseSearchInfoModel != object) {
+        DYYYClearPauseRelatedModelDepth(pauseSearchInfoModel, depth + 1);
+    }
+
+    DYYYSetPauseRelatedObjectIfPossible(object, @selector(setPauseModalInfo:), nil);
+    DYYYSetPauseRelatedObjectIfPossible(object, @selector(setPauseSearchInfoModel:), nil);
+    DYYYSetPauseRelatedObjectIfPossible(object, @selector(setRelatedWords:), nil);
+    DYYYSetPauseRelatedObjectIfPossible(object, @selector(setRelatedWordArray:), nil);
+    DYYYSetPauseRelatedObjectIfPossible(object, @selector(setRelatedWordsCollectionView:), nil);
+    DYYYSetPauseRelatedBoolIfPossible(object, @selector(setIsTopRightPauseSearchEntranceShow:), NO);
+}
+
+static void DYYYClearPauseRelatedModel(id object) {
+    DYYYClearPauseRelatedModelDepth(object, 0);
+}
+
+static void DYYYHidePauseRelatedControllerView(id controller) {
+    if (![controller respondsToSelector:@selector(view)]) {
+        return;
+    }
+
+    UIView *view = ((UIView *(*)(id, SEL))objc_msgSend)(controller, @selector(view));
+    DYYYHidePauseRelatedView(view);
+}
+
 %hook AWEFeedPauseRelatedWordComponent
 
 - (id)updateViewWithModel:(id)arg0 {
-    if (DYYYGetBool(@"DYYYHidePauseVideoRelatedWord")) {
+    if (DYYYShouldHidePauseRelatedContent()) {
+        DYYYClearPauseRelatedModel(arg0);
+        DYYYHidePauseRelatedView(self.relatedView);
         return nil;
     }
     return %orig;
 }
 
 - (id)pauseContentWithModel:(id)arg0 {
-    if (DYYYGetBool(@"DYYYHidePauseVideoRelatedWord")) {
+    if (DYYYShouldHidePauseRelatedContent()) {
+        DYYYClearPauseRelatedModel(arg0);
         return nil;
     }
     return %orig;
 }
 
 - (id)recommendsWords {
-    if (DYYYGetBool(@"DYYYHidePauseVideoRelatedWord")) {
+    if (DYYYShouldHidePauseRelatedContent()) {
         return nil;
     }
     return %orig;
 }
 
 - (void)showRelatedRecommendPanelControllerWithSelectedText:(id)arg0 {
-    if (DYYYGetBool(@"DYYYHidePauseVideoRelatedWord")) {
+    if (DYYYShouldHidePauseRelatedContent()) {
         return;
     }
     %orig;
@@ -6393,11 +6599,434 @@ static void DYYYApplyAvatarFollowPromptSettingsWithRetry(id owner) {
 
 - (void)setupUI {
     %orig;
-    if (DYYYGetBool(@"DYYYHidePauseVideoRelatedWord")) {
-        if (self.relatedView) {
-            self.relatedView.hidden = YES;
-        }
+    if (DYYYShouldHidePauseRelatedContent()) {
+        DYYYHidePauseRelatedView(self.relatedView);
+        DYYYDisablePauseRelatedTap(self.relatedView);
     }
+}
+
+%end
+
+%hook AWEFeedPauseVideoRelatedWordView
+
+- (id)initWithFrame:(CGRect)frame wordsStyle:(unsigned long long)wordsStyle {
+    id view = %orig;
+    if (DYYYShouldHidePauseRelatedContent()) {
+        DYYYDisablePauseRelatedTap(view);
+        DYYYHidePauseRelatedView(view);
+    }
+    return view;
+}
+
+- (void)setupUI {
+    %orig;
+    if (DYYYShouldHidePauseRelatedContent()) {
+        DYYYDisablePauseRelatedTap(self);
+        DYYYHidePauseRelatedView(self);
+    }
+}
+
+- (void)updateRecommendWords:(id)arg0 {
+    if (DYYYShouldHidePauseRelatedContent()) {
+        DYYYClearPauseRelatedModel(arg0);
+        DYYYDisablePauseRelatedTap(self);
+        DYYYHidePauseRelatedView(self);
+        return;
+    }
+    %orig;
+}
+
+- (void)showDefaultView {
+    if (DYYYShouldHidePauseRelatedContent()) {
+        DYYYHidePauseRelatedView(self);
+        return;
+    }
+    %orig;
+}
+
+- (void)didTapRelatedWork {
+    if (DYYYShouldHidePauseRelatedContent()) {
+        return;
+    }
+    %orig;
+}
+
+- (void)collectionView:(id)arg0 didSelectItemAtIndexPath:(id)arg1 {
+    if (DYYYShouldHidePauseRelatedContent()) {
+        return;
+    }
+    %orig;
+}
+
+- (long long)collectionView:(id)arg0 numberOfItemsInSection:(long long)arg1 {
+    if (DYYYShouldHidePauseRelatedContent()) {
+        return 0;
+    }
+    return %orig;
+}
+
+- (long long)numberOfSectionsInCollectionView:(id)arg0 {
+    if (DYYYShouldHidePauseRelatedContent()) {
+        return 0;
+    }
+    return %orig;
+}
+
+%end
+
+%hook AWEPlayInteractionFeedPauseModalElement
+
+- (id)activateInfoWithContext:(id)arg0 {
+    if (DYYYShouldHidePauseRelatedContent()) {
+        DYYYClearPauseRelatedModel(arg0);
+        return nil;
+    }
+    return %orig;
+}
+
+- (BOOL)shouldActiveWithContext:(id)arg0 {
+    if (DYYYShouldHidePauseRelatedContent()) {
+        DYYYClearPauseRelatedModel(arg0);
+        return NO;
+    }
+    return %orig;
+}
+
+- (BOOL)shouldShowPauseModalWithModel:(id)arg0 {
+    if (DYYYShouldHidePauseRelatedContent()) {
+        DYYYClearPauseRelatedModel(arg0);
+        return NO;
+    }
+    return %orig;
+}
+
+%end
+
+%hook AWEFeedPauseModalManager
+
+- (void)createPauseModalViewWithModel:(id)arg0 {
+    if (DYYYShouldHidePauseRelatedContent()) {
+        DYYYClearPauseRelatedModel(arg0);
+        return;
+    }
+    %orig;
+}
+
+- (void)showBottomTabIfNeedWithModel:(id)arg0 {
+    if (DYYYShouldHidePauseRelatedContent()) {
+        DYYYClearPauseRelatedModel(arg0);
+        return;
+    }
+    %orig;
+}
+
+- (void)showPauseModalWithModel:(id)arg0 cellViewController:(id)arg1 {
+    if (DYYYShouldHidePauseRelatedContent()) {
+        DYYYClearPauseRelatedModel(arg0);
+        return;
+    }
+    %orig;
+}
+
+- (BOOL)shouldShowPauseModalIntro:(id)arg0 {
+    if (DYYYShouldHidePauseRelatedContent()) {
+        DYYYClearPauseRelatedModel(arg0);
+        return NO;
+    }
+    return %orig;
+}
+
+%end
+
+%hook AWEFeedPauseModalBaseComponent
+
+- (id)updateViewWithModel:(id)arg0 {
+    if (DYYYShouldHidePauseRelatedContent()) {
+        DYYYClearPauseRelatedModel(arg0);
+        id componentContainerView = nil;
+        id component = (id)self;
+        if ([component respondsToSelector:@selector(componentContainerView)]) {
+            componentContainerView = ((id (*)(id, SEL))objc_msgSend)(component, @selector(componentContainerView));
+        }
+        DYYYHidePauseRelatedView(componentContainerView);
+        return nil;
+    }
+    return %orig;
+}
+
+- (id)pauseContentWithModel:(id)arg0 {
+    if (DYYYShouldHidePauseRelatedContent()) {
+        DYYYClearPauseRelatedModel(arg0);
+        return nil;
+    }
+    return %orig;
+}
+
+%end
+
+%hook AWEFeedPauseModalController
+
+- (void)viewDidLoad {
+    %orig;
+    if (DYYYShouldHidePauseRelatedContent()) {
+        DYYYHidePauseRelatedControllerView(self);
+    }
+}
+
+- (void)viewWillAppear:(BOOL)animated {
+    %orig;
+    if (DYYYShouldHidePauseRelatedContent()) {
+        DYYYHidePauseRelatedControllerView(self);
+    }
+}
+
+- (void)showPauseSearchPopoverIfNeeded {
+    if (DYYYShouldHidePauseRelatedContent()) {
+        DYYYHidePauseRelatedControllerView(self);
+        return;
+    }
+    %orig;
+}
+
+%end
+
+%hook AWEFeedPauseToRelatePanelController
+
+- (void)viewDidLoad {
+    %orig;
+    if (DYYYShouldHidePauseRelatedContent()) {
+        DYYYHidePauseRelatedControllerView(self);
+    }
+}
+
+- (void)viewWillAppear:(BOOL)animated {
+    %orig;
+    if (DYYYShouldHidePauseRelatedContent()) {
+        DYYYHidePauseRelatedControllerView(self);
+    }
+}
+
+- (void)showSheet {
+    if (DYYYShouldHidePauseRelatedContent()) {
+        DYYYHidePauseRelatedControllerView(self);
+        return;
+    }
+    %orig;
+}
+
+- (void)showSheet:(BOOL)arg0 {
+    if (DYYYShouldHidePauseRelatedContent()) {
+        DYYYHidePauseRelatedControllerView(self);
+        return;
+    }
+    %orig;
+}
+
+- (void)showUnModalViewController {
+    if (DYYYShouldHidePauseRelatedContent()) {
+        DYYYHidePauseRelatedControllerView(self);
+        return;
+    }
+    %orig;
+}
+
+%end
+
+%hook AWEFeedSearchLongBarEntranceController
+
++ (BOOL)searchLongBarCouldShowForGlobal:(BOOL)arg0 {
+    if (DYYYShouldHidePauseRelatedContent()) {
+        return NO;
+    }
+    return %orig;
+}
+
+- (void)addLongBarView {
+    if (DYYYShouldHidePauseRelatedContent()) {
+        return;
+    }
+    %orig;
+}
+
+- (void)searchLongBarEntranceViewTapped:(id)arg0 {
+    if (DYYYShouldHidePauseRelatedContent()) {
+        return;
+    }
+    %orig;
+}
+
+- (BOOL)isSearchLongBarEntranceSwitchOn {
+    if (DYYYShouldHidePauseRelatedContent()) {
+        return NO;
+    }
+    return %orig;
+}
+
+- (BOOL)canShowLongBarEntrance {
+    if (DYYYShouldHidePauseRelatedContent()) {
+        return NO;
+    }
+    return %orig;
+}
+
+- (BOOL)canShowLongBarEntranceForHit {
+    if (DYYYShouldHidePauseRelatedContent()) {
+        return NO;
+    }
+    return %orig;
+}
+
+- (BOOL)canShowLongBarEntranceForGHit {
+    if (DYYYShouldHidePauseRelatedContent()) {
+        return NO;
+    }
+    return %orig;
+}
+
+- (BOOL)searchLongBarEntranceHitEnable {
+    if (DYYYShouldHidePauseRelatedContent()) {
+        return NO;
+    }
+    return %orig;
+}
+
+%end
+
+%hook AWEFeedSearchLongBarEntranceView
+
+- (id)initWithFrame:(CGRect)frame enableSkyLight:(BOOL)enableSkyLight config:(id)config {
+    id view = %orig;
+    if (DYYYShouldHidePauseRelatedContent()) {
+        DYYYDisablePauseRelatedTap(view);
+        DYYYHidePauseRelatedView(view);
+    }
+    return view;
+}
+
+- (void)addSubiews {
+    %orig;
+    if (DYYYShouldHidePauseRelatedContent()) {
+        DYYYDisablePauseRelatedTap(self);
+        DYYYHidePauseRelatedView(self);
+    }
+}
+
+- (void)updateSuggestWords:(id)arg0 {
+    if (DYYYShouldHidePauseRelatedContent()) {
+        DYYYClearPauseRelatedModel(arg0);
+        DYYYDisablePauseRelatedTap(self);
+        DYYYHidePauseRelatedView(self);
+        return;
+    }
+    %orig;
+}
+
+- (void)scanBtnClicked {
+    if (DYYYShouldHidePauseRelatedContent()) {
+        return;
+    }
+    %orig;
+}
+
+- (void)searchBtnClicked {
+    if (DYYYShouldHidePauseRelatedContent()) {
+        return;
+    }
+    %orig;
+}
+
+%end
+
+%hook AWEFeedSearchRecommendedVideosView
+
+- (id)initWithFrame:(CGRect)frame {
+    id view = %orig;
+    if (DYYYShouldHidePauseRelatedContent()) {
+        DYYYHidePauseRelatedView(view);
+    }
+    return view;
+}
+
+- (void)layoutSubviews {
+    %orig;
+    if (DYYYShouldHidePauseRelatedContent()) {
+        DYYYHidePauseRelatedView(self);
+    }
+}
+
+- (BOOL)gestureRecognizerShouldBegin:(id)arg0 {
+    if (DYYYShouldHidePauseRelatedContent()) {
+        return NO;
+    }
+    return %orig;
+}
+
+- (void)_updateWithModel:(id)arg0 {
+    if (DYYYShouldHidePauseRelatedContent()) {
+        DYYYClearPauseRelatedModel(arg0);
+        DYYYHidePauseRelatedView(self);
+        return;
+    }
+    %orig;
+}
+
+- (void)collectionView:(id)arg0 didSelectItemAtIndexPath:(id)arg1 {
+    if (DYYYShouldHidePauseRelatedContent()) {
+        return;
+    }
+    %orig;
+}
+
+- (long long)collectionView:(id)arg0 numberOfItemsInSection:(long long)arg1 {
+    if (DYYYShouldHidePauseRelatedContent()) {
+        return 0;
+    }
+    return %orig;
+}
+
+%end
+
+%hook AWECodeGenPauseModalInfoModel
+
+- (id)pauseSearchInfoModel {
+    if (DYYYShouldHidePauseRelatedContent()) {
+        return nil;
+    }
+    return %orig;
+}
+
+- (void)setPauseSearchInfoModel:(id)arg0 {
+    if (DYYYShouldHidePauseRelatedContent()) {
+        DYYYClearPauseRelatedModel(arg0);
+        %orig(nil);
+        return;
+    }
+    %orig;
+}
+
+- (BOOL)hasPauseSearchInfo {
+    if (DYYYShouldHidePauseRelatedContent()) {
+        return NO;
+    }
+    return %orig;
+}
+
+%end
+
+%hook AWECodeGenPauseSearchModel
+
+- (id)pauseSearchKeyWord {
+    if (DYYYShouldHidePauseRelatedContent()) {
+        return nil;
+    }
+    return %orig;
+}
+
+- (id)pauseSearchConfig {
+    if (DYYYShouldHidePauseRelatedContent()) {
+        return nil;
+    }
+    return %orig;
 }
 
 %end
@@ -8143,6 +8772,29 @@ static NSHashTable *processedParentViews = nil;
 		return;
 	}
 	%orig;
+}
+
+- (id)pauseModalInfo {
+    if (DYYYShouldHidePauseRelatedContent()) {
+        return nil;
+    }
+    return %orig;
+}
+
+- (void)setPauseModalInfo:(id)arg0 {
+    if (DYYYShouldHidePauseRelatedContent()) {
+        DYYYClearPauseRelatedModel(arg0);
+        %orig(nil);
+        return;
+    }
+    %orig;
+}
+
+- (BOOL)hasPauseModalInfo {
+    if (DYYYShouldHidePauseRelatedContent()) {
+        return NO;
+    }
+    return %orig;
 }
 
 %end
@@ -11970,6 +12622,7 @@ static void findTargetViewInView(UIView *view) {
     }];
 
     DYYYMigrateCombinedHDRModeIfNeeded();
+    DYYYRegisterSaveAvatarManagerHooks();
 
     Class interactionBaseLabelClass = objc_getClass("AWECommentSwiftBizUI.CommentInteractionBaseLabel");
     if (interactionBaseLabelClass) {

--- a/DYYY.xm
+++ b/DYYY.xm
@@ -4722,10 +4722,47 @@ static BOOL isGestureActive = NO;
 %end
 
 // 强制启用保存他人头像
+static BOOL DYYYShouldEnableSaveAvatar(void) {
+    return DYYYGetBool(@"DYYYEnableSaveAvatar");
+}
+
+%hook AWEUserProfileABTestServiceObjc
+
++ (BOOL)profileAvatarLongPressEnable {
+    if (DYYYShouldEnableSaveAvatar()) {
+        return YES;
+    }
+    return %orig;
+}
+
+%end
+
+%hook AWEProfileAvatarCollectionViewCellV2
+
+- (void)refreshLongPressState:(BOOL)enabled {
+    if (DYYYShouldEnableSaveAvatar()) {
+        %orig(YES);
+        return;
+    }
+    %orig(enabled);
+}
+
+%end
+
+%hook AWEProfileAvatarFunctionManager
+
+- (BOOL)shouldShowSaveAvatarItem {
+    if (DYYYShouldEnableSaveAvatar()) {
+        return YES;
+    }
+    return %orig;
+}
+
+%end
+
 %hook AFDProfileAvatarFunctionManager
 - (BOOL)shouldShowSaveAvatarItem {
-    BOOL shouldEnable = DYYYGetBool(@"DYYYEnableSaveAvatar");
-    if (shouldEnable) {
+    if (DYYYShouldEnableSaveAvatar()) {
         return YES;
     }
     return %orig;

--- a/DYYY.xm
+++ b/DYYY.xm
@@ -1086,6 +1086,11 @@ static BOOL DYYYShouldBlockFeedNowPlayingSystemInfoWrite(void) {
 
 %end
 
+static BOOL DYYYShouldDisableAllHDR(void);
+static NSArray *DYYYFilteredSDRBitrateModels(NSArray *models);
+static NSArray *DYYYFilteredSDRRawBitrateData(NSArray *rawData);
+static void DYYYStripHDRHintsFromBitrateModels(NSArray *models);
+
 // 默认视频流最高画质
 %hook AWEVideoModel
 
@@ -1137,6 +1142,12 @@ static BOOL DYYYShouldBlockFeedNowPlayingSystemInfoWrite(void) {
 
     NSArray *originalModels = %orig;
 
+    if (DYYYShouldDisableAllHDR()) {
+        NSArray *filteredModels = DYYYFilteredSDRBitrateModels(originalModels);
+        DYYYStripHDRHintsFromBitrateModels(filteredModels);
+        originalModels = filteredModels;
+    }
+
     if (!DYYYGetBool(@"DYYYEnableVideoHighestQuality")) {
         return originalModels;
     }
@@ -1175,6 +1186,73 @@ static BOOL DYYYShouldBlockFeedNowPlayingSystemInfoWrite(void) {
     }
 
     return originalModels;
+}
+
+- (void)setBitrateModels:(NSArray *)bitrateModels {
+    if (DYYYShouldDisableAllHDR()) {
+        NSArray *filteredModels = DYYYFilteredSDRBitrateModels(bitrateModels);
+        DYYYStripHDRHintsFromBitrateModels(filteredModels);
+        %orig(filteredModels);
+        return;
+    }
+    %orig;
+}
+
+- (void)setManualBitrateModels:(NSArray *)manualBitrateModels {
+    if (DYYYShouldDisableAllHDR()) {
+        NSArray *filteredModels = DYYYFilteredSDRBitrateModels(manualBitrateModels);
+        DYYYStripHDRHintsFromBitrateModels(filteredModels);
+        %orig(filteredModels);
+        return;
+    }
+    %orig;
+}
+
+- (NSArray *)manualBitrateModels {
+    NSArray *models = %orig;
+    if (DYYYShouldDisableAllHDR()) {
+        models = DYYYFilteredSDRBitrateModels(models);
+        DYYYStripHDRHintsFromBitrateModels(models);
+    }
+    return models;
+}
+
+- (void)setBitrateRawData:(NSArray *)bitrateRawData {
+    if (DYYYShouldDisableAllHDR()) {
+        %orig(DYYYFilteredSDRRawBitrateData(bitrateRawData));
+        return;
+    }
+    %orig;
+}
+
+- (NSArray *)bitrateRawData {
+    NSArray *rawData = %orig;
+    if (DYYYShouldDisableAllHDR()) {
+        rawData = DYYYFilteredSDRRawBitrateData(rawData);
+    }
+    return rawData;
+}
+
+- (void)setHasFilterHDR:(BOOL)hasFilterHDR {
+    %orig(DYYYShouldDisableAllHDR() ? NO : hasFilterHDR);
+}
+
+- (BOOL)hasFilterHDR {
+    if (DYYYShouldDisableAllHDR()) {
+        return NO;
+    }
+    return %orig;
+}
+
+- (void)setIsSourceHDR:(NSInteger)isSourceHDR {
+    %orig(DYYYShouldDisableAllHDR() ? 0 : isSourceHDR);
+}
+
+- (NSInteger)isSourceHDR {
+    if (DYYYShouldDisableAllHDR()) {
+        return 0;
+    }
+    return %orig;
 }
 
 %end
@@ -1219,6 +1297,376 @@ static BOOL DYYYShouldDisableAllHDR(void) {
 
 static BOOL DYYYShouldFilterGlobalHDR(void) {
     return [[[NSUserDefaults standardUserDefaults] stringForKey:kDYYYHDRModeKey] isEqualToString:kDYYYHDRModeFilter];
+}
+
+static id DYYYKVCValueIfPossible(id object, NSString *key) {
+    if (!object || key.length == 0) {
+        return nil;
+    }
+
+    @try {
+        return [object valueForKey:key];
+    } @catch (__unused NSException *exception) {
+        return nil;
+    }
+}
+
+static void DYYYSetKVCValueIfPossible(id object, NSString *key, id value) {
+    if (!object || key.length == 0) {
+        return;
+    }
+
+    @try {
+        [object setValue:value forKey:key];
+    } @catch (__unused NSException *exception) {
+    }
+}
+
+static id DYYYIvarValueIfPossible(id object, const char *ivarName) {
+    if (!object || !ivarName) {
+        return nil;
+    }
+
+    Class cls = object_getClass(object);
+    while (cls) {
+        Ivar ivar = class_getInstanceVariable(cls, ivarName);
+        if (ivar) {
+            return object_getIvar(object, ivar);
+        }
+        cls = class_getSuperclass(cls);
+    }
+
+    return nil;
+}
+
+static id DYYYValuePreferringIvar(id object, const char *ivarName, NSString *key) {
+    id ivarValue = DYYYIvarValueIfPossible(object, ivarName);
+    if (ivarValue) {
+        return ivarValue;
+    }
+    return DYYYKVCValueIfPossible(object, key);
+}
+
+static NSInteger DYYYIntegerValueForKeyIfPossible(id object, NSString *key, NSInteger fallback) {
+    id value = DYYYKVCValueIfPossible(object, key);
+    if ([value respondsToSelector:@selector(integerValue)]) {
+        return [value integerValue];
+    }
+    return fallback;
+}
+
+static BOOL DYYYStringValueLooksHDR(id value) {
+    if (![value isKindOfClass:[NSString class]]) {
+        return NO;
+    }
+
+    NSString *lowercaseValue = [(NSString *)value lowercaseString];
+    return [lowercaseValue containsString:@"hdr"] ||
+           [lowercaseValue containsString:@"hlg"] ||
+           [lowercaseValue containsString:@"dolby"] ||
+           [lowercaseValue containsString:@"vivid"] ||
+           [lowercaseValue isEqualToString:@"pq"] ||
+           [lowercaseValue containsString:@"_pq"] ||
+           [lowercaseValue containsString:@"pq_"];
+}
+
+static BOOL DYYYRawBitrateDictionaryLooksHDR(NSDictionary *dictionary);
+
+static BOOL DYYYBitrateModelLooksHDR(id bitrateModel) {
+    if (!bitrateModel) {
+        return NO;
+    }
+
+    if ([bitrateModel isKindOfClass:[NSDictionary class]]) {
+        return DYYYRawBitrateDictionaryLooksHDR((NSDictionary *)bitrateModel);
+    }
+
+    id hdrTypeValue = DYYYKVCValueIfPossible(bitrateModel, @"hdrType");
+    id hdrBitValue = DYYYKVCValueIfPossible(bitrateModel, @"hdrBit");
+    NSInteger hdrType = DYYYIntegerValueForKeyIfPossible(bitrateModel, @"hdrType", 0);
+    NSInteger hdrBit = DYYYIntegerValueForKeyIfPossible(bitrateModel, @"hdrBit", 0);
+    BOOL hasHdrType = DYYYIntegerValueForKeyIfPossible(bitrateModel, @"hasHdrType", 0) > 0;
+    BOOL hasHdrBit = DYYYIntegerValueForKeyIfPossible(bitrateModel, @"hasHdrBit", 0) > 0;
+
+    return hdrType > 0 ||
+           hdrBit >= 10 ||
+           hasHdrType ||
+           hasHdrBit ||
+           DYYYStringValueLooksHDR(hdrTypeValue) ||
+           DYYYStringValueLooksHDR(hdrBitValue);
+}
+
+static BOOL DYYYStringKeyLooksVideoBitrateList(NSString *key) {
+    NSString *lowercaseKey = key.lowercaseString;
+    if (lowercaseKey.length == 0 || [lowercaseKey containsString:@"audio"]) {
+        return NO;
+    }
+
+    return [lowercaseKey containsString:@"bit_rate"] ||
+           [lowercaseKey containsString:@"bitrate"] ||
+           [lowercaseKey containsString:@"bit_rate_model"] ||
+           [lowercaseKey containsString:@"bitratemodel"];
+}
+
+static BOOL DYYYRawBitrateDictionaryLooksHDR(NSDictionary *dictionary) {
+    if (![dictionary isKindOfClass:[NSDictionary class]]) {
+        return NO;
+    }
+
+    for (id rawKey in dictionary) {
+        id value = dictionary[rawKey];
+        NSString *key = [[rawKey description] lowercaseString];
+        NSInteger numericValue = [value respondsToSelector:@selector(integerValue)] ? [value integerValue] : 0;
+
+        if (([key isEqualToString:@"hdr_type"] ||
+             [key isEqualToString:@"hdrtype"] ||
+             [key isEqualToString:@"videohdrtype"] ||
+             [key isEqualToString:@"video_hdr_type"] ||
+             [key isEqualToString:@"source_hdr_type"]) && numericValue > 0) {
+            return YES;
+        }
+
+        if (([key isEqualToString:@"hdr_bit"] ||
+             [key isEqualToString:@"hdrbit"] ||
+             [key isEqualToString:@"bit_depth"] ||
+             [key isEqualToString:@"bitdepth"]) && numericValue >= 10) {
+            return YES;
+        }
+
+        if (([key isEqualToString:@"is_source_hdr"] ||
+             [key isEqualToString:@"source_hdr"] ||
+             [key isEqualToString:@"is_hdr"] ||
+             [key isEqualToString:@"ishdr"] ||
+             [key isEqualToString:@"has_hdr"] ||
+             [key isEqualToString:@"hashdr"] ||
+             [key isEqualToString:@"has_filter_hdr"] ||
+             [key isEqualToString:@"filter_hdr"] ||
+             [key isEqualToString:@"has_hdr_type"] ||
+             [key isEqualToString:@"hashdrtype"] ||
+             [key isEqualToString:@"has_hdr_bit"] ||
+             [key isEqualToString:@"hashdrbit"]) && numericValue > 0) {
+            return YES;
+        }
+
+        if (DYYYStringValueLooksHDR(value)) {
+            return YES;
+        }
+    }
+
+    return NO;
+}
+
+static void DYYYCollectRawBitrateHDRStatus(id object, NSUInteger depth, BOOL *foundHDRBitrate, BOOL *foundSDRBitrate) {
+    if (!object || depth > 8 || (foundSDRBitrate && *foundSDRBitrate)) {
+        return;
+    }
+
+    if ([object isKindOfClass:[NSDictionary class]]) {
+        NSDictionary *dictionary = (NSDictionary *)object;
+        for (id rawKey in dictionary) {
+            id value = dictionary[rawKey];
+            NSString *key = [rawKey description];
+
+            if (DYYYStringKeyLooksVideoBitrateList(key) && [value isKindOfClass:[NSArray class]]) {
+                for (id entry in (NSArray *)value) {
+                    if (![entry isKindOfClass:[NSDictionary class]]) {
+                        continue;
+                    }
+
+                    if (DYYYRawBitrateDictionaryLooksHDR((NSDictionary *)entry)) {
+                        if (foundHDRBitrate) {
+                            *foundHDRBitrate = YES;
+                        }
+                    } else if (foundSDRBitrate) {
+                        *foundSDRBitrate = YES;
+                        return;
+                    }
+                }
+                continue;
+            }
+
+            if ([value isKindOfClass:[NSDictionary class]] || [value isKindOfClass:[NSArray class]]) {
+                DYYYCollectRawBitrateHDRStatus(value, depth + 1, foundHDRBitrate, foundSDRBitrate);
+            }
+        }
+    } else if ([object isKindOfClass:[NSArray class]]) {
+        for (id value in (NSArray *)object) {
+            DYYYCollectRawBitrateHDRStatus(value, depth + 1, foundHDRBitrate, foundSDRBitrate);
+        }
+    }
+}
+
+static BOOL DYYYRawObjectHasOnlyHDRBitrateModels(id object) {
+    BOOL foundHDRBitrate = NO;
+    BOOL foundSDRBitrate = NO;
+    DYYYCollectRawBitrateHDRStatus(object, 0, &foundHDRBitrate, &foundSDRBitrate);
+    return foundHDRBitrate && !foundSDRBitrate;
+}
+
+static BOOL DYYYVideoModelHasOnlyHDRBitrateModels(id video) {
+    if (!video) {
+        return NO;
+    }
+
+    NSMutableArray *models = [NSMutableArray array];
+    NSArray *bitrateModels = DYYYValuePreferringIvar(video, "_bitrateModels", @"bitrateModels");
+    if ([bitrateModels isKindOfClass:[NSArray class]]) {
+        [models addObjectsFromArray:bitrateModels];
+    }
+
+    NSArray *manualBitrateModels = DYYYValuePreferringIvar(video, "_manualBitrateModels", @"manualBitrateModels");
+    if ([manualBitrateModels isKindOfClass:[NSArray class]]) {
+        [models addObjectsFromArray:manualBitrateModels];
+    }
+
+    NSArray *bitrateRawData = DYYYValuePreferringIvar(video, "_bitrateRawData", @"bitrateRawData");
+    if ([bitrateRawData isKindOfClass:[NSArray class]]) {
+        [models addObjectsFromArray:bitrateRawData];
+    }
+
+    if (models.count == 0) {
+        return NO;
+    }
+
+    for (id model in models) {
+        if (!DYYYBitrateModelLooksHDR(model)) {
+            return NO;
+        }
+    }
+
+    return YES;
+}
+
+static BOOL DYYYAwemeModelHasOnlyHDRBitrateModels(id aweme) {
+    if (!aweme) {
+        return NO;
+    }
+
+    id video = DYYYValuePreferringIvar(aweme, "_video", @"video");
+    if (DYYYVideoModelHasOnlyHDRBitrateModels(video)) {
+        return YES;
+    }
+
+    NSArray *albumImages = DYYYValuePreferringIvar(aweme, "_albumImages", @"albumImages");
+    if ([albumImages isKindOfClass:[NSArray class]]) {
+        for (id imageModel in albumImages) {
+            id clipVideo = DYYYValuePreferringIvar(imageModel, "_clipVideo", @"clipVideo");
+            if (DYYYVideoModelHasOnlyHDRBitrateModels(clipVideo)) {
+                return YES;
+            }
+        }
+    }
+
+    return NO;
+}
+
+static NSArray *DYYYFilteredSDRRawBitrateData(NSArray *rawData) {
+    if (![rawData isKindOfClass:[NSArray class]] || rawData.count == 0) {
+        return rawData;
+    }
+
+    NSMutableArray *sdrData = [NSMutableArray arrayWithCapacity:rawData.count];
+    NSUInteger hdrCount = 0;
+    for (id entry in rawData) {
+        if ([entry isKindOfClass:[NSDictionary class]] && DYYYRawBitrateDictionaryLooksHDR((NSDictionary *)entry)) {
+            hdrCount++;
+            continue;
+        }
+        [sdrData addObject:entry];
+    }
+
+    if (hdrCount == 0 || sdrData.count == 0) {
+        return rawData;
+    }
+
+    return [sdrData copy];
+}
+
+static NSArray *DYYYFilteredSDRBitrateModels(NSArray *models) {
+    if (![models isKindOfClass:[NSArray class]] || models.count == 0) {
+        return models;
+    }
+
+    NSMutableArray *sdrModels = [NSMutableArray arrayWithCapacity:models.count];
+    NSUInteger hdrCount = 0;
+    for (id model in models) {
+        if (DYYYBitrateModelLooksHDR(model)) {
+            hdrCount++;
+            continue;
+        }
+        [sdrModels addObject:model];
+    }
+
+    // 只有 HDR 档的作品在模型层过滤；这里不清空列表，避免播放器拿不到可播档导致有声黑屏。
+    if (hdrCount == 0 || sdrModels.count == 0) {
+        return models;
+    }
+
+    return [sdrModels copy];
+}
+
+static void DYYYStripHDRHintsFromBitrateModels(NSArray *models) {
+    if (![models isKindOfClass:[NSArray class]]) {
+        return;
+    }
+
+    for (id model in models) {
+        DYYYSetKVCValueIfPossible(model, @"hdrType", @0);
+        DYYYSetKVCValueIfPossible(model, @"hdrBit", @8);
+        DYYYSetKVCValueIfPossible(model, @"hasHdrType", @NO);
+        DYYYSetKVCValueIfPossible(model, @"hasHdrBit", @NO);
+    }
+}
+
+static void DYYYStripHDRHintsFromVideoModel(id video) {
+    if (!DYYYShouldDisableAllHDR() || !video) {
+        return;
+    }
+
+    if ([video respondsToSelector:@selector(setIsSourceHDR:)]) {
+        ((void (*)(id, SEL, NSInteger))objc_msgSend)(video, @selector(setIsSourceHDR:), 0);
+    }
+    if ([video respondsToSelector:@selector(setHasFilterHDR:)]) {
+        ((void (*)(id, SEL, BOOL))objc_msgSend)(video, @selector(setHasFilterHDR:), NO);
+    }
+
+    NSArray *bitrateModels = DYYYKVCValueIfPossible(video, @"bitrateModels");
+    NSArray *filteredBitrateModels = DYYYFilteredSDRBitrateModels(bitrateModels);
+    if (filteredBitrateModels && filteredBitrateModels != bitrateModels) {
+        DYYYSetKVCValueIfPossible(video, @"bitrateModels", filteredBitrateModels);
+        bitrateModels = filteredBitrateModels;
+    }
+    DYYYStripHDRHintsFromBitrateModels(bitrateModels);
+
+    NSArray *manualBitrateModels = DYYYKVCValueIfPossible(video, @"manualBitrateModels");
+    NSArray *filteredManualBitrateModels = DYYYFilteredSDRBitrateModels(manualBitrateModels);
+    if (filteredManualBitrateModels && filteredManualBitrateModels != manualBitrateModels) {
+        DYYYSetKVCValueIfPossible(video, @"manualBitrateModels", filteredManualBitrateModels);
+        manualBitrateModels = filteredManualBitrateModels;
+    }
+    DYYYStripHDRHintsFromBitrateModels(manualBitrateModels);
+
+    NSArray *bitrateRawData = DYYYValuePreferringIvar(video, "_bitrateRawData", @"bitrateRawData");
+    NSArray *filteredBitrateRawData = DYYYFilteredSDRRawBitrateData(bitrateRawData);
+    if (filteredBitrateRawData && filteredBitrateRawData != bitrateRawData) {
+        DYYYSetKVCValueIfPossible(video, @"bitrateRawData", filteredBitrateRawData);
+    }
+}
+
+static void DYYYStripHDRHintsFromAwemeModel(id aweme) {
+    if (!DYYYShouldDisableAllHDR() || !aweme) {
+        return;
+    }
+
+    id video = DYYYKVCValueIfPossible(aweme, @"video");
+    DYYYStripHDRHintsFromVideoModel(video);
+
+    NSArray *albumImages = DYYYKVCValueIfPossible(aweme, @"albumImages");
+    if ([albumImages isKindOfClass:[NSArray class]]) {
+        for (id imageModel in albumImages) {
+            DYYYStripHDRHintsFromVideoModel(DYYYKVCValueIfPossible(imageModel, @"clipVideo"));
+        }
+    }
 }
 
 static id DYYYStandardCADynamicRange(void) {
@@ -1546,7 +1994,63 @@ static void DYYYDisableAVPlayerItemHDRMetadata(AVPlayerItem *item) {
 
 %end
 
+%hook AWEDPlayerVideoDisplayOptState
+
+- (BOOL)enableHDR {
+    if (DYYYShouldDisableAllHDR()) {
+        return NO;
+    }
+    return %orig;
+}
+
+- (void)setEnableHDR:(BOOL)enableHDR {
+    %orig(DYYYShouldDisableAllHDR() ? NO : enableHDR);
+}
+
+%end
+
+%hook AWEPlayVideoPlayerContext
+
+- (BOOL)enableHDR {
+    if (DYYYShouldDisableAllHDR()) {
+        return NO;
+    }
+    return %orig;
+}
+
+- (void)setEnableHDR:(BOOL)enableHDR {
+    %orig(DYYYShouldDisableAllHDR() ? NO : enableHDR);
+}
+
+%end
+
+%hook AWEDPlayerVideoModel
+
+- (BOOL)awe_isHDRVideo {
+    if (DYYYShouldDisableAllHDR()) {
+        return NO;
+    }
+    return %orig;
+}
+
+- (void)setAwe_isHDRVideo:(BOOL)awe_isHDRVideo {
+    %orig(DYYYShouldDisableAllHDR() ? NO : awe_isHDRVideo);
+}
+
+%end
+
 %hook AWEPlayVideoViewController
+
+- (BOOL)enableHDR {
+    if (DYYYShouldDisableAllHDR()) {
+        return NO;
+    }
+    return %orig;
+}
+
+- (void)setEnableHDR:(BOOL)enableHDR {
+    %orig(DYYYShouldDisableAllHDR() ? NO : enableHDR);
+}
 
 - (BOOL)awe_isCurrentVideoHDR {
     if (DYYYShouldDisableAllHDR()) {
@@ -6877,6 +7381,15 @@ static NSHashTable *processedParentViews = nil;
             }
         }
 
+        // 4. 全局屏蔽 HDR 时，若作品没有 SDR 码率档，直接过滤，避免强播纯 HDR 源导致黑屏或 HDR 漏出。
+        if (DYYYShouldDisableAllHDR() &&
+            ![m dyyy_shouldExcludeFromGlobalHDRFilter] &&
+            DYYYAwemeModelHasOnlyHDRBitrateModels(m)) {
+            continue;
+        }
+
+        DYYYStripHDRHintsFromAwemeModel(m);
+
         [baseFiltered addObject:obj];
     }
 
@@ -6940,7 +7453,14 @@ static NSHashTable *processedParentViews = nil;
 - (id)initWithDictionary:(id)arg1 error:(id *)arg2 {
     id orig = %orig;
     if (orig) {
+        BOOL shouldFilterOnlyHDRSource = DYYYShouldDisableAllHDR() &&
+                                         ![self dyyy_shouldExcludeFromGlobalHDRFilter] &&
+                                         (DYYYRawObjectHasOnlyHDRBitrateModels(arg1) ||
+                                          DYYYAwemeModelHasOnlyHDRBitrateModels(self));
         BOOL shouldFilter = [self contentFilter];
+        if (!shouldFilter && shouldFilterOnlyHDRSource) {
+            shouldFilter = YES;
+        }
         if (!shouldFilter && DYYYShouldFilterGlobalHDR() &&
             ![self dyyy_shouldExcludeFromGlobalHDRFilter] &&
             [self dyyy_containsHDRMetadataInObject:arg1 depth:0]) {
@@ -6949,8 +7469,50 @@ static NSHashTable *processedParentViews = nil;
         if (shouldFilter) {
             return nil;
         }
+        DYYYStripHDRHintsFromAwemeModel(self);
     }
     return orig;
+}
+
+- (void)setVideo:(AWEVideoModel *)video {
+    DYYYStripHDRHintsFromVideoModel(video);
+    %orig;
+}
+
+- (AWEVideoModel *)video {
+    AWEVideoModel *video = %orig;
+    DYYYStripHDRHintsFromVideoModel(video);
+    return video;
+}
+
+- (void)setAlbumImages:(NSArray<AWEImageAlbumImageModel *> *)albumImages {
+    if (DYYYShouldDisableAllHDR()) {
+        for (AWEImageAlbumImageModel *imageModel in albumImages) {
+            DYYYStripHDRHintsFromVideoModel(imageModel.clipVideo);
+        }
+    }
+    %orig;
+}
+
+- (NSArray<AWEImageAlbumImageModel *> *)albumImages {
+    NSArray<AWEImageAlbumImageModel *> *albumImages = %orig;
+    if (DYYYShouldDisableAllHDR()) {
+        for (AWEImageAlbumImageModel *imageModel in albumImages) {
+            DYYYStripHDRHintsFromVideoModel(imageModel.clipVideo);
+        }
+    }
+    return albumImages;
+}
+
+- (BOOL)awe_enableHDR {
+    if (DYYYShouldDisableAllHDR()) {
+        return NO;
+    }
+    return %orig;
+}
+
+- (id)awe_HDRValueFor:(long long)value enableHDR:(BOOL)enableHDR {
+    return %orig(value, DYYYShouldDisableAllHDR() ? NO : enableHDR);
 }
 
 %new
@@ -7105,6 +7667,13 @@ static NSHashTable *processedParentViews = nil;
                 }
             }
         }
+    }
+
+    // 全局屏蔽 HDR 时，仍允许有 SDR 档的作品降档播放；纯 HDR 档作品直接过滤，避免黑屏或 HDR 漏出。
+    if (DYYYShouldDisableAllHDR() &&
+        ![self dyyy_shouldExcludeFromGlobalHDRFilter] &&
+        DYYYAwemeModelHasOnlyHDRBitrateModels(self)) {
+        shouldFilterHDR = YES;
     }
 
     // 全场景过滤 HDR 作品，但保留私信、消息详情和转发链路。
@@ -9954,6 +10523,13 @@ static Class tabBarButtonClass = nil;
 
 %hook AWEDPlayerFeedPlayerViewController
 
+- (BOOL)enableHDR {
+    if (DYYYShouldDisableAllHDR()) {
+        return NO;
+    }
+    return %orig;
+}
+
 - (void)viewDidLayoutSubviews {
     %orig;
     if (DYYYGetBool(@"DYYYEnableFullScreen")) {
@@ -9995,6 +10571,13 @@ static Class tabBarButtonClass = nil;
 %end
 
 %hook AWEDPlayerViewController_Merge
+
+- (BOOL)enableHDR {
+    if (DYYYShouldDisableAllHDR()) {
+        return NO;
+    }
+    return %orig;
+}
 
 - (void)viewDidLayoutSubviews {
     %orig;

--- a/DYYY.xm
+++ b/DYYY.xm
@@ -4744,7 +4744,7 @@ static BOOL DYYYSaveAvatarShouldShowItemHook(id self, SEL _cmd) {
     }
 
     NSString *className = NSStringFromClass([self class]);
-    DYYYSaveAvatarShouldShowItemIMP originalIMP = (DYYYSaveAvatarShouldShowItemIMP)[DYYYSaveAvatarOriginalShouldShowItemIMPs()[className] pointerValue];
+    DYYYSaveAvatarShouldShowItemIMP originalIMP = (DYYYSaveAvatarShouldShowItemIMP)(uintptr_t)[DYYYSaveAvatarOriginalShouldShowItemIMPs()[className] pointerValue];
     if (originalIMP) {
         return originalIMP(self, _cmd);
     }
@@ -4769,7 +4769,7 @@ static void DYYYRegisterSaveAvatarManagerClass(Class cls) {
     DYYYSaveAvatarShouldShowItemIMP originalIMP = NULL;
     MSHookMessageEx(cls, @selector(shouldShowSaveAvatarItem), (IMP)DYYYSaveAvatarShouldShowItemHook, (IMP *)&originalIMP);
     if (originalIMP) {
-        DYYYSaveAvatarOriginalShouldShowItemIMPs()[className] = [NSValue valueWithPointer:originalIMP];
+        DYYYSaveAvatarOriginalShouldShowItemIMPs()[className] = [NSValue valueWithPointer:(const void *)(uintptr_t)originalIMP];
     }
 }
 

--- a/DYYY.xm
+++ b/DYYY.xm
@@ -1261,6 +1261,10 @@ static NSString *const kDYYYHDRModeKey = @"DYYYHDRMode";
 static NSString *const kDYYYHDRModeOff = @"关闭";
 static NSString *const kDYYYHDRModeDisable = @"全局屏蔽HDR效果";
 static NSString *const kDYYYHDRModeFilter = @"全局过滤HDR作品";
+static char kDYYYHDRStrippedAwemeModelKey;
+static char kDYYYHDRStrippedVideoModelKey;
+static char kDYYYHDROnlyAwemeModelKey;
+static char kDYYYHDROnlyVideoModelKey;
 
 static void DYYYMigrateCombinedHDRModeIfNeeded(void) {
     static dispatch_once_t onceToken;
@@ -1508,6 +1512,11 @@ static BOOL DYYYVideoModelHasOnlyHDRBitrateModels(id video) {
         return NO;
     }
 
+    NSNumber *cachedResult = objc_getAssociatedObject(video, &kDYYYHDROnlyVideoModelKey);
+    if (cachedResult) {
+        return cachedResult.boolValue;
+    }
+
     NSMutableArray *models = [NSMutableArray array];
     NSArray *bitrateModels = DYYYValuePreferringIvar(video, "_bitrateModels", @"bitrateModels");
     if ([bitrateModels isKindOfClass:[NSArray class]]) {
@@ -1528,13 +1537,16 @@ static BOOL DYYYVideoModelHasOnlyHDRBitrateModels(id video) {
         return NO;
     }
 
+    BOOL onlyHDR = YES;
     for (id model in models) {
         if (!DYYYBitrateModelLooksHDR(model)) {
-            return NO;
+            onlyHDR = NO;
+            break;
         }
     }
 
-    return YES;
+    objc_setAssociatedObject(video, &kDYYYHDROnlyVideoModelKey, @(onlyHDR), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    return onlyHDR;
 }
 
 static BOOL DYYYAwemeModelHasOnlyHDRBitrateModels(id aweme) {
@@ -1542,22 +1554,37 @@ static BOOL DYYYAwemeModelHasOnlyHDRBitrateModels(id aweme) {
         return NO;
     }
 
-    id video = DYYYValuePreferringIvar(aweme, "_video", @"video");
-    if (DYYYVideoModelHasOnlyHDRBitrateModels(video)) {
-        return YES;
+    NSNumber *cachedResult = objc_getAssociatedObject(aweme, &kDYYYHDROnlyAwemeModelKey);
+    if (cachedResult) {
+        return cachedResult.boolValue;
     }
 
-    NSArray *albumImages = DYYYValuePreferringIvar(aweme, "_albumImages", @"albumImages");
-    if ([albumImages isKindOfClass:[NSArray class]]) {
-        for (id imageModel in albumImages) {
-            id clipVideo = DYYYValuePreferringIvar(imageModel, "_clipVideo", @"clipVideo");
-            if (DYYYVideoModelHasOnlyHDRBitrateModels(clipVideo)) {
-                return YES;
+    BOOL onlyHDR = NO;
+    BOOL shouldCacheResult = NO;
+    id video = DYYYValuePreferringIvar(aweme, "_video", @"video");
+    if (video) {
+        shouldCacheResult = YES;
+    }
+    if (DYYYVideoModelHasOnlyHDRBitrateModels(video)) {
+        onlyHDR = YES;
+    } else {
+        NSArray *albumImages = DYYYValuePreferringIvar(aweme, "_albumImages", @"albumImages");
+        if ([albumImages isKindOfClass:[NSArray class]]) {
+            shouldCacheResult = shouldCacheResult || albumImages.count > 0;
+            for (id imageModel in albumImages) {
+                id clipVideo = DYYYValuePreferringIvar(imageModel, "_clipVideo", @"clipVideo");
+                if (DYYYVideoModelHasOnlyHDRBitrateModels(clipVideo)) {
+                    onlyHDR = YES;
+                    break;
+                }
             }
         }
     }
 
-    return NO;
+    if (shouldCacheResult || onlyHDR) {
+        objc_setAssociatedObject(aweme, &kDYYYHDROnlyAwemeModelKey, @(onlyHDR), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+    return onlyHDR;
 }
 
 static NSArray *DYYYFilteredSDRRawBitrateData(NSArray *rawData) {
@@ -1623,6 +1650,11 @@ static void DYYYStripHDRHintsFromVideoModel(id video) {
         return;
     }
 
+    if (objc_getAssociatedObject(video, &kDYYYHDRStrippedVideoModelKey)) {
+        return;
+    }
+    objc_setAssociatedObject(video, &kDYYYHDRStrippedVideoModelKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+
     if ([video respondsToSelector:@selector(setIsSourceHDR:)]) {
         ((void (*)(id, SEL, NSInteger))objc_msgSend)(video, @selector(setIsSourceHDR:), 0);
     }
@@ -1658,13 +1690,18 @@ static void DYYYStripHDRHintsFromAwemeModel(id aweme) {
         return;
     }
 
-    id video = DYYYKVCValueIfPossible(aweme, @"video");
+    if (objc_getAssociatedObject(aweme, &kDYYYHDRStrippedAwemeModelKey)) {
+        return;
+    }
+    objc_setAssociatedObject(aweme, &kDYYYHDRStrippedAwemeModelKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+
+    id video = DYYYValuePreferringIvar(aweme, "_video", @"video");
     DYYYStripHDRHintsFromVideoModel(video);
 
-    NSArray *albumImages = DYYYKVCValueIfPossible(aweme, @"albumImages");
+    NSArray *albumImages = DYYYValuePreferringIvar(aweme, "_albumImages", @"albumImages");
     if ([albumImages isKindOfClass:[NSArray class]]) {
         for (id imageModel in albumImages) {
-            DYYYStripHDRHintsFromVideoModel(DYYYKVCValueIfPossible(imageModel, @"clipVideo"));
+            DYYYStripHDRHintsFromVideoModel(DYYYValuePreferringIvar(imageModel, "_clipVideo", @"clipVideo"));
         }
     }
 }
@@ -7325,6 +7362,7 @@ static NSHashTable *processedParentViews = nil;
     NSInteger minLikesThreshold = DYYYGetInteger(@"DYYYFilterLowLikes"); // 读取低赞过滤阈值 (例如: 1000)
     BOOL skipPhotoText = DYYYGetBool(@"DYYYSkipPhotoText"); // 图文过滤
     BOOL skipPhoto = DYYYGetBool(@"DYYYSkipPhoto"); // 图集过滤
+    BOOL shouldDisableHDR = DYYYShouldDisableAllHDR();
 
     NSTimeInterval now = [[NSDate date] timeIntervalSince1970];
     NSTimeInterval thresholdInSeconds = MAX(daysThreshold, 0) * 86400.0;
@@ -7382,13 +7420,15 @@ static NSHashTable *processedParentViews = nil;
         }
 
         // 4. 全局屏蔽 HDR 时，若作品没有 SDR 码率档，直接过滤，避免强播纯 HDR 源导致黑屏或 HDR 漏出。
-        if (DYYYShouldDisableAllHDR() &&
+        if (shouldDisableHDR &&
             ![m dyyy_shouldExcludeFromGlobalHDRFilter] &&
             DYYYAwemeModelHasOnlyHDRBitrateModels(m)) {
             continue;
         }
 
-        DYYYStripHDRHintsFromAwemeModel(m);
+        if (shouldDisableHDR) {
+            DYYYStripHDRHintsFromAwemeModel(m);
+        }
 
         [baseFiltered addObject:obj];
     }
@@ -7453,10 +7493,17 @@ static NSHashTable *processedParentViews = nil;
 - (id)initWithDictionary:(id)arg1 error:(id *)arg2 {
     id orig = %orig;
     if (orig) {
-        BOOL shouldFilterOnlyHDRSource = DYYYShouldDisableAllHDR() &&
-                                         ![self dyyy_shouldExcludeFromGlobalHDRFilter] &&
-                                         (DYYYRawObjectHasOnlyHDRBitrateModels(arg1) ||
-                                          DYYYAwemeModelHasOnlyHDRBitrateModels(self));
+        BOOL shouldDisableHDR = DYYYShouldDisableAllHDR();
+        BOOL shouldFilterOnlyHDRSource = NO;
+        if (shouldDisableHDR && ![self dyyy_shouldExcludeFromGlobalHDRFilter]) {
+            shouldFilterOnlyHDRSource = DYYYAwemeModelHasOnlyHDRBitrateModels(self);
+            if (!shouldFilterOnlyHDRSource) {
+                shouldFilterOnlyHDRSource = DYYYRawObjectHasOnlyHDRBitrateModels(arg1);
+                if (shouldFilterOnlyHDRSource) {
+                    objc_setAssociatedObject(self, &kDYYYHDROnlyAwemeModelKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+                }
+            }
+        }
         BOOL shouldFilter = [self contentFilter];
         if (!shouldFilter && shouldFilterOnlyHDRSource) {
             shouldFilter = YES;
@@ -7469,7 +7516,9 @@ static NSHashTable *processedParentViews = nil;
         if (shouldFilter) {
             return nil;
         }
-        DYYYStripHDRHintsFromAwemeModel(self);
+        if (shouldDisableHDR) {
+            DYYYStripHDRHintsFromAwemeModel(self);
+        }
     }
     return orig;
 }
@@ -7480,28 +7529,20 @@ static NSHashTable *processedParentViews = nil;
 }
 
 - (AWEVideoModel *)video {
-    AWEVideoModel *video = %orig;
-    DYYYStripHDRHintsFromVideoModel(video);
-    return video;
+    return %orig;
 }
 
 - (void)setAlbumImages:(NSArray<AWEImageAlbumImageModel *> *)albumImages {
     if (DYYYShouldDisableAllHDR()) {
         for (AWEImageAlbumImageModel *imageModel in albumImages) {
-            DYYYStripHDRHintsFromVideoModel(imageModel.clipVideo);
+            DYYYStripHDRHintsFromVideoModel(DYYYValuePreferringIvar(imageModel, "_clipVideo", @"clipVideo"));
         }
     }
     %orig;
 }
 
 - (NSArray<AWEImageAlbumImageModel *> *)albumImages {
-    NSArray<AWEImageAlbumImageModel *> *albumImages = %orig;
-    if (DYYYShouldDisableAllHDR()) {
-        for (AWEImageAlbumImageModel *imageModel in albumImages) {
-            DYYYStripHDRHintsFromVideoModel(imageModel.clipVideo);
-        }
-    }
-    return albumImages;
+    return %orig;
 }
 
 - (BOOL)awe_enableHDR {
@@ -7614,6 +7655,7 @@ static NSHashTable *processedParentViews = nil;
 
     // 获取需要过滤的用户列表
     NSString *filterUsers = [[NSUserDefaults standardUserDefaults] objectForKey:@"DYYYFilterUsers"];
+    BOOL disableHDR = DYYYShouldDisableAllHDR();
 
     // 检查是否需要过滤特定用户
     if (isRecommendFeed && filterUsers.length > 0 && self.author) {
@@ -7670,7 +7712,7 @@ static NSHashTable *processedParentViews = nil;
     }
 
     // 全局屏蔽 HDR 时，仍允许有 SDR 档的作品降档播放；纯 HDR 档作品直接过滤，避免黑屏或 HDR 漏出。
-    if (DYYYShouldDisableAllHDR() &&
+    if (disableHDR &&
         ![self dyyy_shouldExcludeFromGlobalHDRFilter] &&
         DYYYAwemeModelHasOnlyHDRBitrateModels(self)) {
         shouldFilterHDR = YES;

--- a/DYYYLongPressPanel.xm
+++ b/DYYYLongPressPanel.xm
@@ -1,3 +1,7 @@
+#import <objc/message.h>
+#import <objc/runtime.h>
+#import <substrate.h>
+
 #import "AwemeHeaders.h"
 #import "DYYYBottomAlertView.h"
 #import "DYYYConfirmCloseView.h"
@@ -1475,6 +1479,393 @@
 
 // 隐藏评论分享功能
 
+typedef void (*DYYYCommentLongPressSetModelsArrayIMP)(id, SEL, id);
+
+static NSMutableDictionary<NSString *, NSValue *> *DYYYCommentLongPressOriginalSetModelsArrayIMPs(void) {
+    static NSMutableDictionary<NSString *, NSValue *> *imps = nil;
+    if (!imps) {
+        imps = [NSMutableDictionary dictionary];
+    }
+    return imps;
+}
+
+static BOOL DYYYCommentLongPressSettingEnabled(NSString *key) {
+    return [[NSUserDefaults standardUserDefaults] boolForKey:key];
+}
+
+static BOOL DYYYCommentLongPressAnyHideSettingEnabled(void) {
+    return DYYYCommentLongPressSettingEnabled(@"DYYYHideCommentShareToFriends") ||
+           DYYYCommentLongPressSettingEnabled(@"DYYYHideCommentLongPressCopy") ||
+           DYYYCommentLongPressSettingEnabled(@"DYYYHideCommentLongPressSaveImage") ||
+           DYYYCommentLongPressSettingEnabled(@"DYYYHideCommentLongPressReport") ||
+           DYYYCommentLongPressSettingEnabled(@"DYYYHideCommentLongPressSearch") ||
+           DYYYCommentLongPressSettingEnabled(@"DYYYHideCommentLongPressDaily") ||
+           DYYYCommentLongPressSettingEnabled(@"DYYYHideCommentLongPressVideoReply") ||
+           DYYYCommentLongPressSettingEnabled(@"DYYYHideCommentLongPressPictureSearch");
+}
+
+static void DYYYCommentLongPressAddSignal(NSMutableArray<NSString *> *signals, id value) {
+    if (!value || value == (id)kCFNull) {
+        return;
+    }
+
+    NSString *signal = nil;
+    if ([value isKindOfClass:[NSString class]]) {
+        signal = (NSString *)value;
+    } else if ([value isKindOfClass:[NSAttributedString class]]) {
+        signal = [(NSAttributedString *)value string];
+    } else if ([value respondsToSelector:@selector(stringValue)]) {
+        signal = [value stringValue];
+    }
+
+    if (signal.length > 0) {
+        [signals addObject:signal.lowercaseString];
+    }
+}
+
+static id DYYYCommentLongPressObjectValueForSelector(id object, SEL selector) {
+    if (!object || ![object respondsToSelector:selector]) {
+        return nil;
+    }
+
+    Method method = class_getInstanceMethod([object class], selector);
+    if (!method) {
+        return nil;
+    }
+
+    char returnType[16] = {0};
+    method_getReturnType(method, returnType, sizeof(returnType));
+    if (returnType[0] != '@') {
+        return nil;
+    }
+
+    @try {
+        return ((id (*)(id, SEL))objc_msgSend)(object, selector);
+    } @catch (__unused NSException *exception) {
+        return nil;
+    }
+}
+
+static NSString *DYYYCommentLongPressSelectorValueForSelector(id object, SEL selector) {
+    if (!object || ![object respondsToSelector:selector]) {
+        return nil;
+    }
+
+    Method method = class_getInstanceMethod([object class], selector);
+    if (!method) {
+        return nil;
+    }
+
+    char returnType[16] = {0};
+    method_getReturnType(method, returnType, sizeof(returnType));
+    if (returnType[0] != ':') {
+        return nil;
+    }
+
+    @try {
+        SEL value = ((SEL (*)(id, SEL))objc_msgSend)(object, selector);
+        return value ? NSStringFromSelector(value) : nil;
+    } @catch (__unused NSException *exception) {
+        return nil;
+    }
+}
+
+static NSArray<NSString *> *DYYYCommentLongPressSignalsForItem(id item) {
+    NSMutableArray<NSString *> *signals = [NSMutableArray array];
+    DYYYCommentLongPressAddSignal(signals, NSStringFromClass([item class]));
+
+    NSArray<NSString *> *objectSelectors = @[
+        @"title",
+        @"itemTitle",
+        @"panelTitle",
+        @"displayTitle",
+        @"describeString",
+        @"descString",
+        @"text",
+        @"labelText",
+        @"name",
+        @"identifier",
+        @"elementIdentifier",
+        @"actionName",
+        @"type"
+    ];
+
+    for (NSString *selectorName in objectSelectors) {
+        DYYYCommentLongPressAddSignal(signals, DYYYCommentLongPressObjectValueForSelector(item, NSSelectorFromString(selectorName)));
+    }
+
+    NSArray<NSString *> *selectorSelectors = @[
+        @"selector",
+        @"actionSelector",
+        @"tapSelector",
+        @"clickSelector",
+        @"eventSelector"
+    ];
+
+    for (NSString *selectorName in selectorSelectors) {
+        DYYYCommentLongPressAddSignal(signals, DYYYCommentLongPressSelectorValueForSelector(item, NSSelectorFromString(selectorName)));
+    }
+
+    NSArray<NSString *> *kvcKeys = @[
+        @"title",
+        @"itemTitle",
+        @"panelTitle",
+        @"displayTitle",
+        @"describeString",
+        @"text",
+        @"labelText",
+        @"name",
+        @"identifier",
+        @"elementIdentifier",
+        @"actionName"
+    ];
+
+    for (NSString *key in kvcKeys) {
+        @try {
+            DYYYCommentLongPressAddSignal(signals, [item valueForKey:key]);
+        } @catch (__unused NSException *exception) {
+        }
+    }
+
+    return signals;
+}
+
+static BOOL DYYYCommentLongPressSignalMatches(NSString *signal, NSArray<NSString *> *includeTokens, NSArray<NSString *> *excludeTokens) {
+    if (signal.length == 0) {
+        return NO;
+    }
+
+    for (NSString *exclude in excludeTokens) {
+        if (exclude.length > 0 && [signal containsString:exclude.lowercaseString]) {
+            return NO;
+        }
+    }
+
+    for (NSString *include in includeTokens) {
+        if (include.length > 0 && [signal containsString:include.lowercaseString]) {
+            return YES;
+        }
+    }
+
+    return NO;
+}
+
+static BOOL DYYYCommentLongPressSignalsMatch(NSArray<NSString *> *signals, NSArray<NSString *> *includeTokens, NSArray<NSString *> *excludeTokens) {
+    for (NSString *signal in signals) {
+        if (DYYYCommentLongPressSignalMatches(signal, includeTokens, excludeTokens)) {
+            return YES;
+        }
+    }
+    return NO;
+}
+
+static BOOL DYYYCommentLongPressClassHasSelectorMatch(id item, NSArray<NSString *> *includeTokens, NSArray<NSString *> *excludeTokens) {
+    for (Class cls = [item class]; cls && cls != [NSObject class]; cls = class_getSuperclass(cls)) {
+        unsigned int methodCount = 0;
+        Method *methods = class_copyMethodList(cls, &methodCount);
+        if (!methods) {
+            continue;
+        }
+
+        BOOL matched = NO;
+        for (unsigned int i = 0; i < methodCount; i++) {
+            NSString *selectorName = NSStringFromSelector(method_getName(methods[i])).lowercaseString;
+            if (DYYYCommentLongPressSignalMatches(selectorName, includeTokens, excludeTokens)) {
+                matched = YES;
+                break;
+            }
+        }
+
+        free(methods);
+        if (matched) {
+            return YES;
+        }
+    }
+
+    return NO;
+}
+
+static BOOL DYYYCommentLongPressItemMatches(id item, NSArray<NSString *> *signals, NSArray<NSString *> *signalTokens, NSArray<NSString *> *selectorTokens, NSArray<NSString *> *excludeTokens) {
+    return DYYYCommentLongPressSignalsMatch(signals, signalTokens, excludeTokens) ||
+           DYYYCommentLongPressClassHasSelectorMatch(item, selectorTokens, excludeTokens);
+}
+
+static BOOL DYYYCommentLongPressShouldFilterItem(id item) {
+    NSArray<NSString *> *signals = DYYYCommentLongPressSignalsForItem(item);
+
+    if (DYYYCommentLongPressSettingEnabled(@"DYYYHideCommentShareToFriends") &&
+        DYYYCommentLongPressItemMatches(item,
+                                        signals,
+                                        @[@"privatemessage", @"shareuser", @"sharetofriend", @"sendtofriend", @"分享给朋友", @"发给朋友", @"好友", @"私信"],
+                                        @[@"privatemessage", @"shareuser", @"sharetofriend", @"sendtofriend", @"sendmessage", @"share"],
+                                        @[@"daily", @"moment", @"日常", @"转发日常"])) {
+        return YES;
+    }
+
+    if (DYYYCommentLongPressSettingEnabled(@"DYYYHideCommentLongPressCopy") &&
+        DYYYCommentLongPressItemMatches(item,
+                                        signals,
+                                        @[@"copyelement", @"copy", @"复制"],
+                                        @[@"copycomment", @"copytext", @"copycontent", @"copyaction", @"copyelement", @"performcopy", @"handlcopy", @"handlecopy", @"didtapcopy"],
+                                        @[@"copywithzone", @"mutablecopy"])) {
+        return YES;
+    }
+
+    if (DYYYCommentLongPressSettingEnabled(@"DYYYHideCommentLongPressSaveImage") &&
+        DYYYCommentLongPressItemMatches(item,
+                                        signals,
+                                        @[@"saveimage", @"savephoto", @"save_image", @"保存图片", @"保存"],
+                                        @[@"saveimage", @"savephoto", @"downloadimage", @"saveaction", @"handlesave", @"didtapsave"],
+                                        @[@"picturesearch", @"imagesearch", @"识别图片", @"搜图"])) {
+        return YES;
+    }
+
+    if (DYYYCommentLongPressSettingEnabled(@"DYYYHideCommentLongPressReport") &&
+        DYYYCommentLongPressItemMatches(item,
+                                        signals,
+                                        @[@"reportelement", @"report", @"举报"],
+                                        @[@"reportcomment", @"reportaction", @"handlereport", @"didtapreport"],
+                                        @[])) {
+        return YES;
+    }
+
+    if (DYYYCommentLongPressSettingEnabled(@"DYYYHideCommentLongPressDaily") &&
+        DYYYCommentLongPressItemMatches(item,
+                                        signals,
+                                        @[@"forwardelement", @"forwarddaily", @"publishdaily", @"daily", @"moment", @"转发日常", @"发日常", @"日常"],
+                                        @[@"forwarddaily", @"publishdaily", @"dailyaction", @"handledaily", @"forwardaction"],
+                                        @[@"privatemessage", @"sharetofriend", @"分享给朋友", @"好友", @"私信"])) {
+        return YES;
+    }
+
+    if (DYYYCommentLongPressSettingEnabled(@"DYYYHideCommentLongPressVideoReply") &&
+        DYYYCommentLongPressItemMatches(item,
+                                        signals,
+                                        @[@"videoreply", @"video_reply", @"视频回复"],
+                                        @[@"videoreply", @"replywithvideo", @"handlevideoreply"],
+                                        @[])) {
+        return YES;
+    }
+
+    if (DYYYCommentLongPressSettingEnabled(@"DYYYHideCommentLongPressPictureSearch") &&
+        DYYYCommentLongPressItemMatches(item,
+                                        signals,
+                                        @[@"picturesearch", @"imagesearch", @"photosearch", @"searchpicture", @"searchimage", @"identifyimage", @"recognizeimage", @"识别图片", @"图片搜索", @"搜图"],
+                                        @[@"picturesearch", @"imagesearch", @"photosearch", @"searchpicture", @"searchimage", @"identifyimage", @"recognizeimage"],
+                                        @[])) {
+        return YES;
+    }
+
+    if (DYYYCommentLongPressSettingEnabled(@"DYYYHideCommentLongPressSearch") &&
+        DYYYCommentLongPressItemMatches(item,
+                                        signals,
+                                        @[@"searchelement", @"search", @"搜索"],
+                                        @[@"searchcomment", @"searchaction", @"handlesearch", @"didtapsearch", @"gosearch"],
+                                        @[@"picturesearch", @"imagesearch", @"photosearch", @"searchpicture", @"searchimage", @"identifyimage", @"recognizeimage", @"识别图片", @"图片", @"搜图"])) {
+        return YES;
+    }
+
+    return NO;
+}
+
+static NSArray *DYYYCommentLongPressFilteredModelsArray(NSArray *inputArray) {
+    if (!DYYYCommentLongPressAnyHideSettingEnabled()) {
+        return inputArray;
+    }
+
+    NSMutableArray *filteredArray = nil;
+    for (id item in inputArray) {
+        if (DYYYCommentLongPressShouldFilterItem(item)) {
+            if (!filteredArray) {
+                filteredArray = [NSMutableArray arrayWithCapacity:inputArray.count];
+                for (id keepItem in inputArray) {
+                    if (keepItem == item) {
+                        break;
+                    }
+                    [filteredArray addObject:keepItem];
+                }
+            }
+            continue;
+        }
+
+        if (filteredArray) {
+            [filteredArray addObject:item];
+        }
+    }
+
+    return filteredArray ? [filteredArray copy] : inputArray;
+}
+
+static DYYYCommentLongPressSetModelsArrayIMP DYYYCommentLongPressOriginalSetModelsArrayIMPForObject(id object) {
+    NSMutableDictionary<NSString *, NSValue *> *imps = DYYYCommentLongPressOriginalSetModelsArrayIMPs();
+    for (Class cls = object_getClass(object); cls; cls = class_getSuperclass(cls)) {
+        NSValue *value = imps[NSStringFromClass(cls)];
+        if (value) {
+            return (DYYYCommentLongPressSetModelsArrayIMP)[value pointerValue];
+        }
+    }
+    return NULL;
+}
+
+static void DYYYCommentLongPressSetModelsArray(id self, SEL _cmd, id arg1) {
+    DYYYCommentLongPressSetModelsArrayIMP original = DYYYCommentLongPressOriginalSetModelsArrayIMPForObject(self);
+    if (!original) {
+        return;
+    }
+
+    if (![arg1 isKindOfClass:[NSArray class]]) {
+        original(self, _cmd, arg1);
+        return;
+    }
+
+    original(self, _cmd, DYYYCommentLongPressFilteredModelsArray((NSArray *)arg1));
+}
+
+static void DYYYHookCommentLongPressOwnerClass(Class ownerClass, NSMutableSet<NSString *> *hookedClasses) {
+    if (!ownerClass || ![ownerClass instancesRespondToSelector:@selector(setModelsArray:)]) {
+        return;
+    }
+
+    NSString *className = NSStringFromClass(ownerClass);
+    if ([hookedClasses containsObject:className]) {
+        return;
+    }
+
+    DYYYCommentLongPressSetModelsArrayIMP original = NULL;
+    MSHookMessageEx(ownerClass, @selector(setModelsArray:), (IMP)DYYYCommentLongPressSetModelsArray, (IMP *)&original);
+    if (original) {
+        DYYYCommentLongPressOriginalSetModelsArrayIMPs()[className] = [NSValue valueWithPointer:(const void *)original];
+        [hookedClasses addObject:className];
+    }
+}
+
+static void DYYYHookCommentLongPressOwnerClassNamed(NSString *className, NSMutableSet<NSString *> *hookedClasses) {
+    Class ownerClass = objc_getClass(className.UTF8String);
+    DYYYHookCommentLongPressOwnerClass(ownerClass, hookedClasses);
+}
+
+static void DYYYInitCommentLongPressSetModelsHooks(void) {
+    NSMutableSet<NSString *> *hookedClasses = [NSMutableSet set];
+    NSArray<NSString *> *candidateOwnerClasses = @[
+        @"AWECommentLongPressPanelSwiftImpl.CommentLongPressPanelNormalSectionViewModel",
+        @"AWECommentLongPressPanelSwiftImpl.CommentLongPressPanelHorizonSectionViewModel",
+        @"AWECommentLongPressPanelSwiftImpl.CommentLongPressPanelFooterSectionViewModel",
+        @"AWECommentLongPressPanelSwiftImpl.CommentLongPressPanelCollectionViewModel",
+        @"AWECommentLongPressPanelSwiftImpl.AWECommentLongPressPanelListViewModel",
+        @"AWECommentLongPressPanelSwiftImpl.CommentLongPressPanelHorizonModel",
+        @"_TtC33AWECommentLongPressPanelSwiftImpl43CommentLongPressPanelNormalSectionViewModel",
+        @"_TtC33AWECommentLongPressPanelSwiftImpl44CommentLongPressPanelHorizonSectionViewModel",
+        @"_TtC33AWECommentLongPressPanelSwiftImpl43CommentLongPressPanelFooterSectionViewModel",
+        @"_TtC33AWECommentLongPressPanelSwiftImpl40CommentLongPressPanelCollectionViewModel",
+        @"_TtC33AWECommentLongPressPanelSwiftImpl37AWECommentLongPressPanelListViewModel",
+        @"_TtC33AWECommentLongPressPanelSwiftImpl33CommentLongPressPanelHorizonModel"
+    ];
+
+    for (NSString *className in candidateOwnerClasses) {
+        DYYYHookCommentLongPressOwnerClassNamed(className, hookedClasses);
+    }
+}
+
 %hook AWEIMCommentShareUserHorizontalCollectionViewCell
 
 - (void)layoutSubviews {
@@ -1513,73 +1904,6 @@
     }
 }
 
-%group DYYYFilterSetterGroup
-
-%hook HOOK_TARGET_OWNER_CLASS
-
-- (void)setModelsArray:(id)arg1 {
-    if (![arg1 isKindOfClass:[NSArray class]]) {
-        %orig(arg1);
-        return;
-    }
-
-    NSArray *inputArray = (NSArray *)arg1;
-    NSMutableArray *filteredArray = nil;
-
-    for (id item in inputArray) {
-        NSString *className = NSStringFromClass([item class]);
-
-        BOOL shouldFilter = ([className isEqualToString:@"AWECommentIMSwiftImpl.CommentLongPressPanelForwardElement"] &&
-                             [[NSUserDefaults standardUserDefaults] boolForKey:@"DYYYHideCommentLongPressDaily"]) ||
-
-                            ([className isEqualToString:@"AWECommentLongPressPanelSwiftImpl.CommentLongPressPanelCopyElement"] &&
-                             [[NSUserDefaults standardUserDefaults] boolForKey:@"DYYYHideCommentLongPressCopy"]) ||
-
-                            ([className isEqualToString:@"AWECommentLongPressPanelSwiftImpl.CommentLongPressPanelSaveImageElement"] &&
-                             [[NSUserDefaults standardUserDefaults] boolForKey:@"DYYYHideCommentLongPressSaveImage"]) ||
-
-                            ([className isEqualToString:@"AWECommentLongPressPanelSwiftImpl.CommentLongPressPanelReportElement"] &&
-                             [[NSUserDefaults standardUserDefaults] boolForKey:@"DYYYHideCommentLongPressReport"]) ||
-
-                            ([className isEqualToString:@"AWECommentStudioSwiftImpl.CommentLongPressPanelVideoReplyElement"] &&
-                             [[NSUserDefaults standardUserDefaults] boolForKey:@"DYYYHideCommentLongPressVideoReply"]) ||
-
-                            ([className isEqualToString:@"AWECommentSearchSwiftImpl.CommentLongPressPanelPictureSearchElement"] &&
-                             [[NSUserDefaults standardUserDefaults] boolForKey:@"DYYYHideCommentLongPressPictureSearch"]) ||
-
-                            ([className isEqualToString:@"AWECommentSearchSwiftImpl.CommentLongPressPanelSearchElement"] &&
-                             [[NSUserDefaults standardUserDefaults] boolForKey:@"DYYYHideCommentLongPressSearch"]);
-
-        if (shouldFilter) {
-            if (!filteredArray) {
-                filteredArray = [NSMutableArray arrayWithCapacity:inputArray.count];
-                for (id keepItem in inputArray) {
-                    if (keepItem == item)
-                        break;
-                    [filteredArray addObject:keepItem];
-                }
-            }
-            continue;
-        }
-
-        if (filteredArray) {
-            [filteredArray addObject:item];
-        }
-    }
-
-    if (filteredArray) {
-        %orig([filteredArray copy]);
-    } else {
-        %orig(arg1);
-    }
-}
-
-%end
-%end
-
 %ctor {
-    Class ownerClass = objc_getClass("AWECommentLongPressPanelSwiftImpl.CommentLongPressPanelNormalSectionViewModel");
-    if (ownerClass) {
-        %init(DYYYFilterSetterGroup, HOOK_TARGET_OWNER_CLASS = ownerClass);
-    }
+    DYYYInitCommentLongPressSetModelsHooks();
 }

--- a/DYYYSettingViewController.m
+++ b/DYYYSettingViewController.m
@@ -1,6 +1,5 @@
 #import "DYYYSettingViewController.h"
 #import <Foundation/Foundation.h>
-#import <math.h>
 #import <UIKit/UIKit.h>
 #import "DYYYConstants.h"
 #import "DYYYFloatClearButton.h"
@@ -37,15 +36,10 @@ typedef NS_ENUM(NSInteger, DYYYSettingItemType) { DYYYSettingItemTypeSwitch, DYY
 
 @end
 
-@interface DYYYSettingViewController () <UITableViewDelegate, UITableViewDataSource, UITextFieldDelegate>
+@interface DYYYSettingViewController () <UITableViewDelegate, UITableViewDataSource>
 
 @property(nonatomic, strong) UITableView *tableView;
-@property(nonatomic, strong) UIView *searchHeaderView;
-@property(nonatomic, strong) UIView *searchContainerView;
-@property(nonatomic, strong) UITextField *searchTextField;
-@property(nonatomic, strong) UIImageView *searchPlaceholderIconView;
 @property(nonatomic, strong) NSArray<NSArray<DYYYSettingItem *> *> *settingSections;
-@property(nonatomic, strong) NSArray<NSIndexPath *> *filteredSettingIndexPaths;
 @property(nonatomic, strong) UILabel *footerLabel;
 @property(nonatomic, strong) NSMutableArray<NSString *> *sectionTitles;
 @property(nonatomic, strong) NSMutableSet *expandedSections;
@@ -62,7 +56,6 @@ typedef NS_ENUM(NSInteger, DYYYSettingItemType) { DYYYSettingItemTypeSwitch, DYY
 
     self.title = @"DYYY设置";
     self.expandedSections = [NSMutableSet set];
-    self.filteredSettingIndexPaths = @[];
     self.isAgreementShown = NO;
 
     [self setupAppearance];
@@ -73,11 +66,6 @@ typedef NS_ENUM(NSInteger, DYYYSettingItemType) { DYYYSettingItemTypeSwitch, DYY
     [self setupSectionTitles];
     [self setupFooterLabel];
     [self addTitleGradientAnimation];
-}
-
-- (void)viewDidLayoutSubviews {
-    [super viewDidLayoutSubviews];
-    [self updateSearchHeaderLayout];
 }
 
 - (void)setupDefaultValues {
@@ -140,76 +128,6 @@ typedef NS_ENUM(NSInteger, DYYYSettingItemType) { DYYYSettingItemTypeSwitch, DYY
     self.tableView.contentInset = UIEdgeInsetsMake(20, 0, 0, 0);
     self.tableView.sectionHeaderTopPadding = 0;
     [self.view addSubview:self.tableView];
-    [self setupSearchHeaderView];
-}
-
-- (void)setupSearchHeaderView {
-    self.searchHeaderView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, self.view.bounds.size.width, 64)];
-    self.searchHeaderView.backgroundColor = [UIColor clearColor];
-    self.searchHeaderView.autoresizingMask = UIViewAutoresizingFlexibleWidth;
-
-    self.searchContainerView = [[UIView alloc] initWithFrame:CGRectMake(16, 8, self.searchHeaderView.bounds.size.width - 32, 44)];
-    self.searchContainerView.backgroundColor = [UIColor colorWithWhite:1 alpha:0.12];
-    self.searchContainerView.layer.cornerRadius = 14;
-    self.searchContainerView.layer.masksToBounds = YES;
-    self.searchContainerView.autoresizingMask = UIViewAutoresizingFlexibleWidth;
-    [self.searchHeaderView addSubview:self.searchContainerView];
-
-    self.searchTextField = [[UITextField alloc] initWithFrame:self.searchContainerView.bounds];
-    self.searchTextField.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-    self.searchTextField.backgroundColor = [UIColor clearColor];
-    self.searchTextField.textColor = [UIColor whiteColor];
-    self.searchTextField.tintColor = [UIColor whiteColor];
-    self.searchTextField.font = [UIFont systemFontOfSize:16 weight:UIFontWeightRegular];
-    self.searchTextField.clearButtonMode = UITextFieldViewModeWhileEditing;
-    self.searchTextField.returnKeyType = UIReturnKeySearch;
-    self.searchTextField.autocorrectionType = UITextAutocorrectionTypeNo;
-    self.searchTextField.spellCheckingType = UITextSpellCheckingTypeNo;
-    self.searchTextField.delegate = self;
-
-    UIView *leftView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 38, 30)];
-    UIImageView *leftIconView = [[UIImageView alloc] initWithFrame:CGRectMake(14, 5, 18, 18)];
-    leftIconView.image = [UIImage systemImageNamed:@"magnifyingglass"];
-    leftIconView.tintColor = [UIColor colorWithWhite:1 alpha:0.65];
-    leftIconView.contentMode = UIViewContentModeScaleAspectFit;
-    [leftView addSubview:leftIconView];
-    self.searchTextField.leftView = leftView;
-    self.searchTextField.leftViewMode = UITextFieldViewModeNever;
-
-    [self.searchTextField addTarget:self action:@selector(searchTextDidChange:) forControlEvents:UIControlEventEditingChanged];
-    [self.searchContainerView addSubview:self.searchTextField];
-
-    self.searchPlaceholderIconView = [[UIImageView alloc] initWithImage:[UIImage systemImageNamed:@"magnifyingglass"]];
-    self.searchPlaceholderIconView.tintColor = [UIColor colorWithWhite:1 alpha:0.65];
-    self.searchPlaceholderIconView.contentMode = UIViewContentModeScaleAspectFit;
-    self.searchPlaceholderIconView.frame = CGRectMake(0, 0, 22, 22);
-    self.searchPlaceholderIconView.userInteractionEnabled = NO;
-    [self.searchContainerView addSubview:self.searchPlaceholderIconView];
-
-    [self updateSearchPlaceholderVisibility];
-    self.tableView.tableHeaderView = self.searchHeaderView;
-}
-
-- (void)updateSearchHeaderLayout {
-    if (!self.searchHeaderView || !self.searchContainerView || !self.searchPlaceholderIconView) {
-        return;
-    }
-
-    CGFloat width = self.tableView.bounds.size.width;
-    if (width <= 0) {
-        return;
-    }
-
-    CGRect headerFrame = self.searchHeaderView.frame;
-    BOOL needsHeaderUpdate = fabs(headerFrame.size.width - width) > 0.5 || fabs(headerFrame.size.height - 64) > 0.5;
-    self.searchHeaderView.frame = CGRectMake(0, 0, width, 64);
-    self.searchContainerView.frame = CGRectMake(16, 8, width - 32, 44);
-    self.searchTextField.frame = self.searchContainerView.bounds;
-    self.searchPlaceholderIconView.center = CGPointMake(CGRectGetMidX(self.searchContainerView.bounds), CGRectGetMidY(self.searchContainerView.bounds));
-
-    if (needsHeaderUpdate) {
-        self.tableView.tableHeaderView = self.searchHeaderView;
-    }
 }
 
 - (void)setupSettingItems {
@@ -468,121 +386,6 @@ typedef NS_ENUM(NSInteger, DYYYSettingItemType) { DYYYSettingItemTypeSwitch, DYY
     self.sectionTitles = [@[ @"基本设置", @"界面设置", @"隐藏设置", @"顶栏移除", @"隐藏面板", @"面板设置", @"功能设置", @"悬浮按钮" ] mutableCopy];
 }
 
-- (NSString *)sectionTitleAtIndex:(NSInteger)section {
-    if (section >= 0 && section < (NSInteger)self.sectionTitles.count) {
-        return self.sectionTitles[section];
-    }
-
-    NSArray<NSString *> *fallbackTitles = @[ @"基本设置", @"界面设置", @"隐藏设置", @"顶栏移除", @"隐藏面板", @"面板设置", @"功能设置", @"悬浮按钮" ];
-    if (section >= 0 && section < (NSInteger)fallbackTitles.count) {
-        return fallbackTitles[section];
-    }
-
-    return @"";
-}
-
-- (NSString *)trimmedSearchText {
-    NSString *text = self.searchTextField.text ?: @"";
-    return [text stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
-}
-
-- (BOOL)isSearchingSettings {
-    return [self trimmedSearchText].length > 0;
-}
-
-- (void)updateSearchPlaceholderVisibility {
-    BOOL shouldShowCenteredIcon = !self.searchTextField.isEditing && [self trimmedSearchText].length == 0;
-    self.searchPlaceholderIconView.hidden = !shouldShowCenteredIcon;
-    self.searchTextField.placeholder = shouldShowCenteredIcon ? nil : @"搜索设置项";
-    self.searchTextField.leftViewMode = shouldShowCenteredIcon ? UITextFieldViewModeNever : UITextFieldViewModeAlways;
-}
-
-- (void)searchTextDidChange:(UITextField *)textField {
-    [self updateSearchPlaceholderVisibility];
-    [self updateFilteredSettingIndexPaths];
-    [self.tableView reloadData];
-}
-
-- (void)updateFilteredSettingIndexPaths {
-    NSString *query = [[self trimmedSearchText] lowercaseString];
-    if (query.length == 0) {
-        self.filteredSettingIndexPaths = @[];
-        return;
-    }
-
-    NSMutableArray<NSIndexPath *> *matches = [NSMutableArray array];
-    for (NSInteger section = 0; section < (NSInteger)self.settingSections.count; section++) {
-        NSArray<DYYYSettingItem *> *items = self.settingSections[section];
-        for (NSInteger row = 0; row < (NSInteger)items.count; row++) {
-            NSIndexPath *sourceIndexPath = [NSIndexPath indexPathForRow:row inSection:section];
-            DYYYSettingItem *item = items[row];
-            NSString *path = [self pathForSettingAtSourceIndexPath:sourceIndexPath];
-            NSString *searchableText =
-                [NSString stringWithFormat:@"%@ %@ %@ %@", item.title ?: @"", item.key ?: @"", item.placeholder ?: @"", path ?: @""];
-
-            if ([[searchableText lowercaseString] containsString:query]) {
-                [matches addObject:sourceIndexPath];
-            }
-        }
-    }
-
-    self.filteredSettingIndexPaths = matches;
-}
-
-- (NSIndexPath *)sourceIndexPathForVisibleIndexPath:(NSIndexPath *)indexPath {
-    if ([self isSearchingSettings]) {
-        if (indexPath.section < (NSInteger)self.filteredSettingIndexPaths.count) {
-            return self.filteredSettingIndexPaths[indexPath.section];
-        }
-        return nil;
-    }
-
-    return indexPath;
-}
-
-- (NSIndexPath *)sourceIndexPathForControlTag:(NSInteger)tag {
-    return [NSIndexPath indexPathForRow:tag % 1000 inSection:tag / 1000];
-}
-
-- (DYYYSettingItem *)settingItemAtSourceIndexPath:(NSIndexPath *)sourceIndexPath {
-    if (!sourceIndexPath || sourceIndexPath.section >= (NSInteger)self.settingSections.count) {
-        return nil;
-    }
-
-    NSArray<DYYYSettingItem *> *items = self.settingSections[sourceIndexPath.section];
-    if (sourceIndexPath.row >= (NSInteger)items.count) {
-        return nil;
-    }
-
-    return items[sourceIndexPath.row];
-}
-
-- (NSString *)pathForSettingAtSourceIndexPath:(NSIndexPath *)sourceIndexPath {
-    NSString *sectionTitle = [self sectionTitleAtIndex:sourceIndexPath.section];
-    if (sectionTitle.length == 0) {
-        return @"DYYY设置";
-    }
-
-    return [NSString stringWithFormat:@"DYYY设置 - %@", sectionTitle];
-}
-
-- (NSString *)textFieldValueForKey:(NSString *)key {
-    id value = [[NSUserDefaults standardUserDefaults] objectForKey:key];
-    if (!value) {
-        return @"";
-    }
-
-    if ([value isKindOfClass:[NSString class]]) {
-        return value;
-    }
-
-    if ([value respondsToSelector:@selector(stringValue)]) {
-        return [value stringValue];
-    }
-
-    return [NSString stringWithFormat:@"%@", value];
-}
-
 - (void)setupFooterLabel {
     self.footerLabel = [[UILabel alloc] initWithFrame:CGRectMake(0, 0, self.view.bounds.size.width, 50)];
     self.footerLabel.text = [NSString stringWithFormat:@"Developer By @huamidev\nVersion: %@ (%@)", DYYY_VERSION, @"260104"];
@@ -724,39 +527,34 @@ typedef NS_ENUM(NSInteger, DYYYSettingItemType) { DYYYSettingItemTypeSwitch, DYY
 #pragma mark - UITableViewDataSource
 
 - (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView {
-    if ([self isSearchingSettings]) {
-        return MAX((NSInteger)self.filteredSettingIndexPaths.count, 1);
-    }
-
     return self.settingSections.count;
 }
 
 - (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section {
-    if ([self isSearchingSettings]) {
-        if (self.filteredSettingIndexPaths.count == 0) {
-            return @"未找到相关设置";
-        }
-
-        NSIndexPath *sourceIndexPath = self.filteredSettingIndexPaths[section];
-        return [self pathForSettingAtSourceIndexPath:sourceIndexPath];
+    switch (section) {
+        case 0:
+            return @"基本设置";
+        case 1:
+            return @"界面设置";
+        case 2:
+            return @"隐藏设置";
+        case 3:
+            return @"顶栏移除";
+        case 4:
+            return @"隐藏面板";
+        case 5:
+            return @"面板设置";
+        case 6:
+            return @"功能设置";
+        case 7:
+            return @"悬浮按钮";
+        default:
+            return @"";
     }
-
-    return [self sectionTitleAtIndex:section];
 }
 
 - (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section {
     UIView *headerView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, tableView.bounds.size.width, 44)];
-
-    if ([self isSearchingSettings]) {
-        UILabel *pathLabel = [[UILabel alloc] initWithFrame:CGRectMake(15, 0, headerView.bounds.size.width - 30, 36)];
-        pathLabel.autoresizingMask = UIViewAutoresizingFlexibleWidth;
-        pathLabel.text = [self tableView:tableView titleForHeaderInSection:section];
-        pathLabel.textAlignment = NSTextAlignmentCenter;
-        pathLabel.textColor = [UIColor colorWithWhite:1 alpha:0.62];
-        pathLabel.font = [UIFont systemFontOfSize:14 weight:UIFontWeightMedium];
-        [headerView addSubview:pathLabel];
-        return headerView;
-    }
 
     UILabel *titleLabel = [[UILabel alloc] initWithFrame:CGRectMake(15, 0, headerView.bounds.size.width - 50, 44)];
     titleLabel.text = [self tableView:tableView titleForHeaderInSection:section];
@@ -781,18 +579,10 @@ typedef NS_ENUM(NSInteger, DYYYSettingItemType) { DYYYSettingItemTypeSwitch, DYY
 }
 
 - (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section {
-    if ([self isSearchingSettings]) {
-        return self.filteredSettingIndexPaths.count == 0 ? 44 : 36;
-    }
-
     return 44;
 }
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
-    if ([self isSearchingSettings]) {
-        return self.filteredSettingIndexPaths.count == 0 ? 0 : 1;
-    }
-
     return [self.expandedSections containsObject:@(section)] ? self.settingSections[section].count : 0;
 }
 
@@ -808,8 +598,7 @@ typedef NS_ENUM(NSInteger, DYYYSettingItemType) { DYYYSettingItemTypeSwitch, DYY
 }
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
-    NSIndexPath *sourceIndexPath = [self sourceIndexPathForVisibleIndexPath:indexPath];
-    DYYYSettingItem *item = [self settingItemAtSourceIndexPath:sourceIndexPath];
+    DYYYSettingItem *item = self.settingSections[indexPath.section][indexPath.row];
 
     UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"SettingCell"];
     if (!cell) {
@@ -826,16 +615,10 @@ typedef NS_ENUM(NSInteger, DYYYSettingItemType) { DYYYSettingItemTypeSwitch, DYY
     cell.textLabel.text = item.title;
     cell.textLabel.textColor = [UIColor whiteColor];
     cell.backgroundColor = [UIColor colorWithWhite:1 alpha:0.1];
-    cell.accessoryView = nil;
-    cell.accessoryType = UITableViewCellAccessoryNone;
 
     cell.backgroundView = nil;
 
-    if ([self isSearchingSettings]) {
-        cell.layer.cornerRadius = 10;
-        cell.layer.maskedCorners = kCALayerMinXMinYCorner | kCALayerMaxXMinYCorner | kCALayerMinXMaxYCorner | kCALayerMaxXMaxYCorner;
-        cell.layer.masksToBounds = YES;
-    } else if (indexPath.row == [self.settingSections[indexPath.section] count] - 1) {
+    if (indexPath.row == [self.settingSections[indexPath.section] count] - 1) {
         cell.layer.cornerRadius = 10;
         cell.layer.maskedCorners = kCALayerMinXMaxYCorner | kCALayerMaxXMaxYCorner;
         cell.layer.masksToBounds = YES;
@@ -848,23 +631,20 @@ typedef NS_ENUM(NSInteger, DYYYSettingItemType) { DYYYSettingItemTypeSwitch, DYY
         UISwitch *switchView = [[UISwitch alloc] init];
         [switchView setOn:[[NSUserDefaults standardUserDefaults] boolForKey:item.key]];
         [switchView addTarget:self action:@selector(switchToggled:) forControlEvents:UIControlEventValueChanged];
-        switchView.tag = sourceIndexPath.section * 1000 + sourceIndexPath.row;
+        switchView.tag = indexPath.section * 1000 + indexPath.row;
         cell.accessoryView = switchView;
     } else if (item.type == DYYYSettingItemTypeTextField) {
         UITextField *textField = [[UITextField alloc] initWithFrame:CGRectMake(0, 0, 100, 30)];
         textField.borderStyle = UITextBorderStyleRoundedRect;
         textField.placeholder = item.placeholder;
-        if (item.placeholder.length > 0) {
-            textField.attributedPlaceholder =
-                [[NSAttributedString alloc] initWithString:item.placeholder attributes:@{NSForegroundColorAttributeName : [UIColor lightGrayColor]}];
-        }
-        textField.text = [self textFieldValueForKey:item.key];
+        textField.attributedPlaceholder = [[NSAttributedString alloc] initWithString:item.placeholder attributes:@{NSForegroundColorAttributeName : [UIColor lightGrayColor]}];
+        textField.text = [[NSUserDefaults standardUserDefaults] objectForKey:item.key];
         textField.textAlignment = NSTextAlignmentRight;
         textField.backgroundColor = [UIColor colorWithWhite:1 alpha:0.1];
         textField.textColor = [UIColor whiteColor];
 
         [textField addTarget:self action:@selector(textFieldDidChange:) forControlEvents:UIControlEventEditingDidEnd];
-        textField.tag = sourceIndexPath.section * 1000 + sourceIndexPath.row;
+        textField.tag = indexPath.section * 1000 + indexPath.row;
         cell.accessoryView = textField;
     } else if (item.type == DYYYSettingItemTypePicker) {
         cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
@@ -879,7 +659,7 @@ typedef NS_ENUM(NSInteger, DYYYSettingItemType) { DYYYSettingItemTypeSwitch, DYY
         pickerLabel.text = [self displayValueForKey:item.key value:currentValue];
         pickerLabel.textColor = [UIColor whiteColor];
         pickerLabel.textAlignment = NSTextAlignmentRight;
-        pickerLabel.tag = sourceIndexPath.section * 1000 + sourceIndexPath.row;
+        pickerLabel.tag = indexPath.section * 1000 + indexPath.row;
 
         // 添加垂直居中约束
         pickerLabel.translatesAutoresizingMaskIntoConstraints = NO;
@@ -905,8 +685,7 @@ typedef NS_ENUM(NSInteger, DYYYSettingItemType) { DYYYSettingItemTypeSwitch, DYY
 #pragma mark - UITableViewDelegate
 
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
-    NSIndexPath *sourceIndexPath = [self sourceIndexPathForVisibleIndexPath:indexPath];
-    DYYYSettingItem *item = [self settingItemAtSourceIndexPath:sourceIndexPath];
+    DYYYSettingItem *item = self.settingSections[indexPath.section][indexPath.row];
     if (item.type == DYYYSettingItemTypePicker) {
         [self showUniversalPickerForIndexPath:indexPath];
     }
@@ -914,8 +693,7 @@ typedef NS_ENUM(NSInteger, DYYYSettingItemType) { DYYYSettingItemTypeSwitch, DYY
 }
 
 - (void)showUniversalPickerForIndexPath:(NSIndexPath *)indexPath {
-    NSIndexPath *sourceIndexPath = [self sourceIndexPathForVisibleIndexPath:indexPath];
-    DYYYSettingItem *item = [self settingItemAtSourceIndexPath:sourceIndexPath];
+    DYYYSettingItem *item = self.settingSections[indexPath.section][indexPath.row];
 
     UIAlertController *alert = [UIAlertController alertControllerWithTitle:[NSString stringWithFormat:@"选择%@", item.title] message:nil preferredStyle:UIAlertControllerStyleActionSheet];
 
@@ -937,10 +715,6 @@ typedef NS_ENUM(NSInteger, DYYYSettingItemType) { DYYYSettingItemTypeSwitch, DYY
                                                                  pickerLabel.text = [self displayValueForKey:item.key value:option];
                                                              }
                                                          }
-
-                                                         if ([self isSearchingSettings]) {
-                                                             [self.tableView reloadData];
-                                                         }
                                                        }];
         [alert addAction:action];
     }
@@ -960,12 +734,8 @@ typedef NS_ENUM(NSInteger, DYYYSettingItemType) { DYYYSettingItemTypeSwitch, DYY
 #pragma mark - Actions
 
 - (void)switchToggled:(UISwitch *)sender {
-    NSIndexPath *indexPath = [self sourceIndexPathForControlTag:sender.tag];
-    DYYYSettingItem *item = [self settingItemAtSourceIndexPath:indexPath];
-    if (!item) {
-        return;
-    }
-
+    NSIndexPath *indexPath = [NSIndexPath indexPathForRow:sender.tag % 1000 inSection:sender.tag / 1000];
+    DYYYSettingItem *item = self.settingSections[indexPath.section][indexPath.row];
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
     [defaults setBool:sender.isOn forKey:item.key];
     if ([item.key isEqualToString:@"DYYYEnableFloatSpeedButton"] || [item.key isEqualToString:@"DYYYSpeedButtonShowX"]) {
@@ -998,12 +768,8 @@ typedef NS_ENUM(NSInteger, DYYYSettingItemType) { DYYYSettingItemTypeSwitch, DYY
 }
 
 - (void)textFieldDidChange:(UITextField *)textField {
-    NSIndexPath *indexPath = [self sourceIndexPathForControlTag:textField.tag];
-    DYYYSettingItem *item = [self settingItemAtSourceIndexPath:indexPath];
-    if (!item) {
-        return;
-    }
-
+    NSIndexPath *indexPath = [NSIndexPath indexPathForRow:textField.tag % 1000 inSection:textField.tag / 1000];
+    DYYYSettingItem *item = self.settingSections[indexPath.section][indexPath.row];
     [[NSUserDefaults standardUserDefaults] setObject:textField.text forKey:item.key];
     if ([item.key isEqualToString:@"DYYYSpeedSettings"] || [item.key isEqualToString:@"DYYYSpeedButtonSize"]) {
         [FloatingSpeedButton reloadConfiguration];
@@ -1030,29 +796,6 @@ typedef NS_ENUM(NSInteger, DYYYSettingItemType) { DYYYSettingItemTypeSwitch, DYY
                      }];
 
     [self.tableView reloadSections:[NSIndexSet indexSetWithIndex:sender.tag] withRowAnimation:UITableViewRowAnimationFade];
-}
-
-#pragma mark - UITextFieldDelegate
-
-- (void)textFieldDidBeginEditing:(UITextField *)textField {
-    if (textField == self.searchTextField) {
-        [self updateSearchPlaceholderVisibility];
-    }
-}
-
-- (void)textFieldDidEndEditing:(UITextField *)textField {
-    if (textField == self.searchTextField) {
-        [self updateSearchPlaceholderVisibility];
-    }
-}
-
-- (BOOL)textFieldShouldReturn:(UITextField *)textField {
-    if (textField == self.searchTextField) {
-        [textField resignFirstResponder];
-        return NO;
-    }
-
-    return YES;
 }
 
 @end

--- a/DYYYSettingViewController.m
+++ b/DYYYSettingViewController.m
@@ -1,5 +1,6 @@
 #import "DYYYSettingViewController.h"
 #import <Foundation/Foundation.h>
+#import <math.h>
 #import <UIKit/UIKit.h>
 #import "DYYYConstants.h"
 #import "DYYYFloatClearButton.h"
@@ -36,10 +37,15 @@ typedef NS_ENUM(NSInteger, DYYYSettingItemType) { DYYYSettingItemTypeSwitch, DYY
 
 @end
 
-@interface DYYYSettingViewController () <UITableViewDelegate, UITableViewDataSource>
+@interface DYYYSettingViewController () <UITableViewDelegate, UITableViewDataSource, UITextFieldDelegate>
 
 @property(nonatomic, strong) UITableView *tableView;
+@property(nonatomic, strong) UIView *searchHeaderView;
+@property(nonatomic, strong) UIView *searchContainerView;
+@property(nonatomic, strong) UITextField *searchTextField;
+@property(nonatomic, strong) UIImageView *searchPlaceholderIconView;
 @property(nonatomic, strong) NSArray<NSArray<DYYYSettingItem *> *> *settingSections;
+@property(nonatomic, strong) NSArray<NSIndexPath *> *filteredSettingIndexPaths;
 @property(nonatomic, strong) UILabel *footerLabel;
 @property(nonatomic, strong) NSMutableArray<NSString *> *sectionTitles;
 @property(nonatomic, strong) NSMutableSet *expandedSections;
@@ -56,6 +62,7 @@ typedef NS_ENUM(NSInteger, DYYYSettingItemType) { DYYYSettingItemTypeSwitch, DYY
 
     self.title = @"DYYY设置";
     self.expandedSections = [NSMutableSet set];
+    self.filteredSettingIndexPaths = @[];
     self.isAgreementShown = NO;
 
     [self setupAppearance];
@@ -66,6 +73,11 @@ typedef NS_ENUM(NSInteger, DYYYSettingItemType) { DYYYSettingItemTypeSwitch, DYY
     [self setupSectionTitles];
     [self setupFooterLabel];
     [self addTitleGradientAnimation];
+}
+
+- (void)viewDidLayoutSubviews {
+    [super viewDidLayoutSubviews];
+    [self updateSearchHeaderLayout];
 }
 
 - (void)setupDefaultValues {
@@ -128,6 +140,76 @@ typedef NS_ENUM(NSInteger, DYYYSettingItemType) { DYYYSettingItemTypeSwitch, DYY
     self.tableView.contentInset = UIEdgeInsetsMake(20, 0, 0, 0);
     self.tableView.sectionHeaderTopPadding = 0;
     [self.view addSubview:self.tableView];
+    [self setupSearchHeaderView];
+}
+
+- (void)setupSearchHeaderView {
+    self.searchHeaderView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, self.view.bounds.size.width, 64)];
+    self.searchHeaderView.backgroundColor = [UIColor clearColor];
+    self.searchHeaderView.autoresizingMask = UIViewAutoresizingFlexibleWidth;
+
+    self.searchContainerView = [[UIView alloc] initWithFrame:CGRectMake(16, 8, self.searchHeaderView.bounds.size.width - 32, 44)];
+    self.searchContainerView.backgroundColor = [UIColor colorWithWhite:1 alpha:0.12];
+    self.searchContainerView.layer.cornerRadius = 14;
+    self.searchContainerView.layer.masksToBounds = YES;
+    self.searchContainerView.autoresizingMask = UIViewAutoresizingFlexibleWidth;
+    [self.searchHeaderView addSubview:self.searchContainerView];
+
+    self.searchTextField = [[UITextField alloc] initWithFrame:self.searchContainerView.bounds];
+    self.searchTextField.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    self.searchTextField.backgroundColor = [UIColor clearColor];
+    self.searchTextField.textColor = [UIColor whiteColor];
+    self.searchTextField.tintColor = [UIColor whiteColor];
+    self.searchTextField.font = [UIFont systemFontOfSize:16 weight:UIFontWeightRegular];
+    self.searchTextField.clearButtonMode = UITextFieldViewModeWhileEditing;
+    self.searchTextField.returnKeyType = UIReturnKeySearch;
+    self.searchTextField.autocorrectionType = UITextAutocorrectionTypeNo;
+    self.searchTextField.spellCheckingType = UITextSpellCheckingTypeNo;
+    self.searchTextField.delegate = self;
+
+    UIView *leftView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 38, 30)];
+    UIImageView *leftIconView = [[UIImageView alloc] initWithFrame:CGRectMake(14, 5, 18, 18)];
+    leftIconView.image = [UIImage systemImageNamed:@"magnifyingglass"];
+    leftIconView.tintColor = [UIColor colorWithWhite:1 alpha:0.65];
+    leftIconView.contentMode = UIViewContentModeScaleAspectFit;
+    [leftView addSubview:leftIconView];
+    self.searchTextField.leftView = leftView;
+    self.searchTextField.leftViewMode = UITextFieldViewModeNever;
+
+    [self.searchTextField addTarget:self action:@selector(searchTextDidChange:) forControlEvents:UIControlEventEditingChanged];
+    [self.searchContainerView addSubview:self.searchTextField];
+
+    self.searchPlaceholderIconView = [[UIImageView alloc] initWithImage:[UIImage systemImageNamed:@"magnifyingglass"]];
+    self.searchPlaceholderIconView.tintColor = [UIColor colorWithWhite:1 alpha:0.65];
+    self.searchPlaceholderIconView.contentMode = UIViewContentModeScaleAspectFit;
+    self.searchPlaceholderIconView.frame = CGRectMake(0, 0, 22, 22);
+    self.searchPlaceholderIconView.userInteractionEnabled = NO;
+    [self.searchContainerView addSubview:self.searchPlaceholderIconView];
+
+    [self updateSearchPlaceholderVisibility];
+    self.tableView.tableHeaderView = self.searchHeaderView;
+}
+
+- (void)updateSearchHeaderLayout {
+    if (!self.searchHeaderView || !self.searchContainerView || !self.searchPlaceholderIconView) {
+        return;
+    }
+
+    CGFloat width = self.tableView.bounds.size.width;
+    if (width <= 0) {
+        return;
+    }
+
+    CGRect headerFrame = self.searchHeaderView.frame;
+    BOOL needsHeaderUpdate = fabs(headerFrame.size.width - width) > 0.5 || fabs(headerFrame.size.height - 64) > 0.5;
+    self.searchHeaderView.frame = CGRectMake(0, 0, width, 64);
+    self.searchContainerView.frame = CGRectMake(16, 8, width - 32, 44);
+    self.searchTextField.frame = self.searchContainerView.bounds;
+    self.searchPlaceholderIconView.center = CGPointMake(CGRectGetMidX(self.searchContainerView.bounds), CGRectGetMidY(self.searchContainerView.bounds));
+
+    if (needsHeaderUpdate) {
+        self.tableView.tableHeaderView = self.searchHeaderView;
+    }
 }
 
 - (void)setupSettingItems {
@@ -386,6 +468,121 @@ typedef NS_ENUM(NSInteger, DYYYSettingItemType) { DYYYSettingItemTypeSwitch, DYY
     self.sectionTitles = [@[ @"基本设置", @"界面设置", @"隐藏设置", @"顶栏移除", @"隐藏面板", @"面板设置", @"功能设置", @"悬浮按钮" ] mutableCopy];
 }
 
+- (NSString *)sectionTitleAtIndex:(NSInteger)section {
+    if (section >= 0 && section < (NSInteger)self.sectionTitles.count) {
+        return self.sectionTitles[section];
+    }
+
+    NSArray<NSString *> *fallbackTitles = @[ @"基本设置", @"界面设置", @"隐藏设置", @"顶栏移除", @"隐藏面板", @"面板设置", @"功能设置", @"悬浮按钮" ];
+    if (section >= 0 && section < (NSInteger)fallbackTitles.count) {
+        return fallbackTitles[section];
+    }
+
+    return @"";
+}
+
+- (NSString *)trimmedSearchText {
+    NSString *text = self.searchTextField.text ?: @"";
+    return [text stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+}
+
+- (BOOL)isSearchingSettings {
+    return [self trimmedSearchText].length > 0;
+}
+
+- (void)updateSearchPlaceholderVisibility {
+    BOOL shouldShowCenteredIcon = !self.searchTextField.isEditing && [self trimmedSearchText].length == 0;
+    self.searchPlaceholderIconView.hidden = !shouldShowCenteredIcon;
+    self.searchTextField.placeholder = shouldShowCenteredIcon ? nil : @"搜索设置项";
+    self.searchTextField.leftViewMode = shouldShowCenteredIcon ? UITextFieldViewModeNever : UITextFieldViewModeAlways;
+}
+
+- (void)searchTextDidChange:(UITextField *)textField {
+    [self updateSearchPlaceholderVisibility];
+    [self updateFilteredSettingIndexPaths];
+    [self.tableView reloadData];
+}
+
+- (void)updateFilteredSettingIndexPaths {
+    NSString *query = [[self trimmedSearchText] lowercaseString];
+    if (query.length == 0) {
+        self.filteredSettingIndexPaths = @[];
+        return;
+    }
+
+    NSMutableArray<NSIndexPath *> *matches = [NSMutableArray array];
+    for (NSInteger section = 0; section < (NSInteger)self.settingSections.count; section++) {
+        NSArray<DYYYSettingItem *> *items = self.settingSections[section];
+        for (NSInteger row = 0; row < (NSInteger)items.count; row++) {
+            NSIndexPath *sourceIndexPath = [NSIndexPath indexPathForRow:row inSection:section];
+            DYYYSettingItem *item = items[row];
+            NSString *path = [self pathForSettingAtSourceIndexPath:sourceIndexPath];
+            NSString *searchableText =
+                [NSString stringWithFormat:@"%@ %@ %@ %@", item.title ?: @"", item.key ?: @"", item.placeholder ?: @"", path ?: @""];
+
+            if ([[searchableText lowercaseString] containsString:query]) {
+                [matches addObject:sourceIndexPath];
+            }
+        }
+    }
+
+    self.filteredSettingIndexPaths = matches;
+}
+
+- (NSIndexPath *)sourceIndexPathForVisibleIndexPath:(NSIndexPath *)indexPath {
+    if ([self isSearchingSettings]) {
+        if (indexPath.section < (NSInteger)self.filteredSettingIndexPaths.count) {
+            return self.filteredSettingIndexPaths[indexPath.section];
+        }
+        return nil;
+    }
+
+    return indexPath;
+}
+
+- (NSIndexPath *)sourceIndexPathForControlTag:(NSInteger)tag {
+    return [NSIndexPath indexPathForRow:tag % 1000 inSection:tag / 1000];
+}
+
+- (DYYYSettingItem *)settingItemAtSourceIndexPath:(NSIndexPath *)sourceIndexPath {
+    if (!sourceIndexPath || sourceIndexPath.section >= (NSInteger)self.settingSections.count) {
+        return nil;
+    }
+
+    NSArray<DYYYSettingItem *> *items = self.settingSections[sourceIndexPath.section];
+    if (sourceIndexPath.row >= (NSInteger)items.count) {
+        return nil;
+    }
+
+    return items[sourceIndexPath.row];
+}
+
+- (NSString *)pathForSettingAtSourceIndexPath:(NSIndexPath *)sourceIndexPath {
+    NSString *sectionTitle = [self sectionTitleAtIndex:sourceIndexPath.section];
+    if (sectionTitle.length == 0) {
+        return @"DYYY设置";
+    }
+
+    return [NSString stringWithFormat:@"DYYY设置 - %@", sectionTitle];
+}
+
+- (NSString *)textFieldValueForKey:(NSString *)key {
+    id value = [[NSUserDefaults standardUserDefaults] objectForKey:key];
+    if (!value) {
+        return @"";
+    }
+
+    if ([value isKindOfClass:[NSString class]]) {
+        return value;
+    }
+
+    if ([value respondsToSelector:@selector(stringValue)]) {
+        return [value stringValue];
+    }
+
+    return [NSString stringWithFormat:@"%@", value];
+}
+
 - (void)setupFooterLabel {
     self.footerLabel = [[UILabel alloc] initWithFrame:CGRectMake(0, 0, self.view.bounds.size.width, 50)];
     self.footerLabel.text = [NSString stringWithFormat:@"Developer By @huamidev\nVersion: %@ (%@)", DYYY_VERSION, @"260104"];
@@ -527,34 +724,39 @@ typedef NS_ENUM(NSInteger, DYYYSettingItemType) { DYYYSettingItemTypeSwitch, DYY
 #pragma mark - UITableViewDataSource
 
 - (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView {
+    if ([self isSearchingSettings]) {
+        return MAX((NSInteger)self.filteredSettingIndexPaths.count, 1);
+    }
+
     return self.settingSections.count;
 }
 
 - (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section {
-    switch (section) {
-        case 0:
-            return @"基本设置";
-        case 1:
-            return @"界面设置";
-        case 2:
-            return @"隐藏设置";
-        case 3:
-            return @"顶栏移除";
-        case 4:
-            return @"隐藏面板";
-        case 5:
-            return @"面板设置";
-        case 6:
-            return @"功能设置";
-        case 7:
-            return @"悬浮按钮";
-        default:
-            return @"";
+    if ([self isSearchingSettings]) {
+        if (self.filteredSettingIndexPaths.count == 0) {
+            return @"未找到相关设置";
+        }
+
+        NSIndexPath *sourceIndexPath = self.filteredSettingIndexPaths[section];
+        return [self pathForSettingAtSourceIndexPath:sourceIndexPath];
     }
+
+    return [self sectionTitleAtIndex:section];
 }
 
 - (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section {
     UIView *headerView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, tableView.bounds.size.width, 44)];
+
+    if ([self isSearchingSettings]) {
+        UILabel *pathLabel = [[UILabel alloc] initWithFrame:CGRectMake(15, 0, headerView.bounds.size.width - 30, 36)];
+        pathLabel.autoresizingMask = UIViewAutoresizingFlexibleWidth;
+        pathLabel.text = [self tableView:tableView titleForHeaderInSection:section];
+        pathLabel.textAlignment = NSTextAlignmentCenter;
+        pathLabel.textColor = [UIColor colorWithWhite:1 alpha:0.62];
+        pathLabel.font = [UIFont systemFontOfSize:14 weight:UIFontWeightMedium];
+        [headerView addSubview:pathLabel];
+        return headerView;
+    }
 
     UILabel *titleLabel = [[UILabel alloc] initWithFrame:CGRectMake(15, 0, headerView.bounds.size.width - 50, 44)];
     titleLabel.text = [self tableView:tableView titleForHeaderInSection:section];
@@ -579,10 +781,18 @@ typedef NS_ENUM(NSInteger, DYYYSettingItemType) { DYYYSettingItemTypeSwitch, DYY
 }
 
 - (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section {
+    if ([self isSearchingSettings]) {
+        return self.filteredSettingIndexPaths.count == 0 ? 44 : 36;
+    }
+
     return 44;
 }
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
+    if ([self isSearchingSettings]) {
+        return self.filteredSettingIndexPaths.count == 0 ? 0 : 1;
+    }
+
     return [self.expandedSections containsObject:@(section)] ? self.settingSections[section].count : 0;
 }
 
@@ -598,7 +808,8 @@ typedef NS_ENUM(NSInteger, DYYYSettingItemType) { DYYYSettingItemTypeSwitch, DYY
 }
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
-    DYYYSettingItem *item = self.settingSections[indexPath.section][indexPath.row];
+    NSIndexPath *sourceIndexPath = [self sourceIndexPathForVisibleIndexPath:indexPath];
+    DYYYSettingItem *item = [self settingItemAtSourceIndexPath:sourceIndexPath];
 
     UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"SettingCell"];
     if (!cell) {
@@ -615,10 +826,16 @@ typedef NS_ENUM(NSInteger, DYYYSettingItemType) { DYYYSettingItemTypeSwitch, DYY
     cell.textLabel.text = item.title;
     cell.textLabel.textColor = [UIColor whiteColor];
     cell.backgroundColor = [UIColor colorWithWhite:1 alpha:0.1];
+    cell.accessoryView = nil;
+    cell.accessoryType = UITableViewCellAccessoryNone;
 
     cell.backgroundView = nil;
 
-    if (indexPath.row == [self.settingSections[indexPath.section] count] - 1) {
+    if ([self isSearchingSettings]) {
+        cell.layer.cornerRadius = 10;
+        cell.layer.maskedCorners = kCALayerMinXMinYCorner | kCALayerMaxXMinYCorner | kCALayerMinXMaxYCorner | kCALayerMaxXMaxYCorner;
+        cell.layer.masksToBounds = YES;
+    } else if (indexPath.row == [self.settingSections[indexPath.section] count] - 1) {
         cell.layer.cornerRadius = 10;
         cell.layer.maskedCorners = kCALayerMinXMaxYCorner | kCALayerMaxXMaxYCorner;
         cell.layer.masksToBounds = YES;
@@ -631,20 +848,23 @@ typedef NS_ENUM(NSInteger, DYYYSettingItemType) { DYYYSettingItemTypeSwitch, DYY
         UISwitch *switchView = [[UISwitch alloc] init];
         [switchView setOn:[[NSUserDefaults standardUserDefaults] boolForKey:item.key]];
         [switchView addTarget:self action:@selector(switchToggled:) forControlEvents:UIControlEventValueChanged];
-        switchView.tag = indexPath.section * 1000 + indexPath.row;
+        switchView.tag = sourceIndexPath.section * 1000 + sourceIndexPath.row;
         cell.accessoryView = switchView;
     } else if (item.type == DYYYSettingItemTypeTextField) {
         UITextField *textField = [[UITextField alloc] initWithFrame:CGRectMake(0, 0, 100, 30)];
         textField.borderStyle = UITextBorderStyleRoundedRect;
         textField.placeholder = item.placeholder;
-        textField.attributedPlaceholder = [[NSAttributedString alloc] initWithString:item.placeholder attributes:@{NSForegroundColorAttributeName : [UIColor lightGrayColor]}];
-        textField.text = [[NSUserDefaults standardUserDefaults] objectForKey:item.key];
+        if (item.placeholder.length > 0) {
+            textField.attributedPlaceholder =
+                [[NSAttributedString alloc] initWithString:item.placeholder attributes:@{NSForegroundColorAttributeName : [UIColor lightGrayColor]}];
+        }
+        textField.text = [self textFieldValueForKey:item.key];
         textField.textAlignment = NSTextAlignmentRight;
         textField.backgroundColor = [UIColor colorWithWhite:1 alpha:0.1];
         textField.textColor = [UIColor whiteColor];
 
         [textField addTarget:self action:@selector(textFieldDidChange:) forControlEvents:UIControlEventEditingDidEnd];
-        textField.tag = indexPath.section * 1000 + indexPath.row;
+        textField.tag = sourceIndexPath.section * 1000 + sourceIndexPath.row;
         cell.accessoryView = textField;
     } else if (item.type == DYYYSettingItemTypePicker) {
         cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
@@ -659,7 +879,7 @@ typedef NS_ENUM(NSInteger, DYYYSettingItemType) { DYYYSettingItemTypeSwitch, DYY
         pickerLabel.text = [self displayValueForKey:item.key value:currentValue];
         pickerLabel.textColor = [UIColor whiteColor];
         pickerLabel.textAlignment = NSTextAlignmentRight;
-        pickerLabel.tag = indexPath.section * 1000 + indexPath.row;
+        pickerLabel.tag = sourceIndexPath.section * 1000 + sourceIndexPath.row;
 
         // 添加垂直居中约束
         pickerLabel.translatesAutoresizingMaskIntoConstraints = NO;
@@ -685,7 +905,8 @@ typedef NS_ENUM(NSInteger, DYYYSettingItemType) { DYYYSettingItemTypeSwitch, DYY
 #pragma mark - UITableViewDelegate
 
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
-    DYYYSettingItem *item = self.settingSections[indexPath.section][indexPath.row];
+    NSIndexPath *sourceIndexPath = [self sourceIndexPathForVisibleIndexPath:indexPath];
+    DYYYSettingItem *item = [self settingItemAtSourceIndexPath:sourceIndexPath];
     if (item.type == DYYYSettingItemTypePicker) {
         [self showUniversalPickerForIndexPath:indexPath];
     }
@@ -693,7 +914,8 @@ typedef NS_ENUM(NSInteger, DYYYSettingItemType) { DYYYSettingItemTypeSwitch, DYY
 }
 
 - (void)showUniversalPickerForIndexPath:(NSIndexPath *)indexPath {
-    DYYYSettingItem *item = self.settingSections[indexPath.section][indexPath.row];
+    NSIndexPath *sourceIndexPath = [self sourceIndexPathForVisibleIndexPath:indexPath];
+    DYYYSettingItem *item = [self settingItemAtSourceIndexPath:sourceIndexPath];
 
     UIAlertController *alert = [UIAlertController alertControllerWithTitle:[NSString stringWithFormat:@"选择%@", item.title] message:nil preferredStyle:UIAlertControllerStyleActionSheet];
 
@@ -715,6 +937,10 @@ typedef NS_ENUM(NSInteger, DYYYSettingItemType) { DYYYSettingItemTypeSwitch, DYY
                                                                  pickerLabel.text = [self displayValueForKey:item.key value:option];
                                                              }
                                                          }
+
+                                                         if ([self isSearchingSettings]) {
+                                                             [self.tableView reloadData];
+                                                         }
                                                        }];
         [alert addAction:action];
     }
@@ -734,8 +960,12 @@ typedef NS_ENUM(NSInteger, DYYYSettingItemType) { DYYYSettingItemTypeSwitch, DYY
 #pragma mark - Actions
 
 - (void)switchToggled:(UISwitch *)sender {
-    NSIndexPath *indexPath = [NSIndexPath indexPathForRow:sender.tag % 1000 inSection:sender.tag / 1000];
-    DYYYSettingItem *item = self.settingSections[indexPath.section][indexPath.row];
+    NSIndexPath *indexPath = [self sourceIndexPathForControlTag:sender.tag];
+    DYYYSettingItem *item = [self settingItemAtSourceIndexPath:indexPath];
+    if (!item) {
+        return;
+    }
+
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
     [defaults setBool:sender.isOn forKey:item.key];
     if ([item.key isEqualToString:@"DYYYEnableFloatSpeedButton"] || [item.key isEqualToString:@"DYYYSpeedButtonShowX"]) {
@@ -768,8 +998,12 @@ typedef NS_ENUM(NSInteger, DYYYSettingItemType) { DYYYSettingItemTypeSwitch, DYY
 }
 
 - (void)textFieldDidChange:(UITextField *)textField {
-    NSIndexPath *indexPath = [NSIndexPath indexPathForRow:textField.tag % 1000 inSection:textField.tag / 1000];
-    DYYYSettingItem *item = self.settingSections[indexPath.section][indexPath.row];
+    NSIndexPath *indexPath = [self sourceIndexPathForControlTag:textField.tag];
+    DYYYSettingItem *item = [self settingItemAtSourceIndexPath:indexPath];
+    if (!item) {
+        return;
+    }
+
     [[NSUserDefaults standardUserDefaults] setObject:textField.text forKey:item.key];
     if ([item.key isEqualToString:@"DYYYSpeedSettings"] || [item.key isEqualToString:@"DYYYSpeedButtonSize"]) {
         [FloatingSpeedButton reloadConfiguration];
@@ -796,6 +1030,29 @@ typedef NS_ENUM(NSInteger, DYYYSettingItemType) { DYYYSettingItemTypeSwitch, DYY
                      }];
 
     [self.tableView reloadSections:[NSIndexSet indexSetWithIndex:sender.tag] withRowAnimation:UITableViewRowAnimationFade];
+}
+
+#pragma mark - UITextFieldDelegate
+
+- (void)textFieldDidBeginEditing:(UITextField *)textField {
+    if (textField == self.searchTextField) {
+        [self updateSearchPlaceholderVisibility];
+    }
+}
+
+- (void)textFieldDidEndEditing:(UITextField *)textField {
+    if (textField == self.searchTextField) {
+        [self updateSearchPlaceholderVisibility];
+    }
+}
+
+- (BOOL)textFieldShouldReturn:(UITextField *)textField {
+    if (textField == self.searchTextField) {
+        [textField resignFirstResponder];
+        return NO;
+    }
+
+    return YES;
 }
 
 @end

--- a/DYYYSettings.xm
+++ b/DYYYSettings.xm
@@ -1,6 +1,7 @@
 #import "AwemeHeaders.h"
 #import "DYYYManager.h"
 #import <MobileCoreServices/MobileCoreServices.h>
+#import <math.h>
 #import <UIKit/UIKit.h>
 #import <objc/runtime.h>
 
@@ -36,6 +37,9 @@ void *kViewModelKey = &kViewModelKey;
 static id dyyyRemoteConfigChangedToken = nil;
 static char kDYYYWeatherViewGestureInstalledKey;
 static char kDYYYWeatherSubviewGestureInstalledKey;
+static char kDYYYSettingsSearchCoordinatorKey;
+static BOOL DYYYBuildingSettingsSearchIndex = NO;
+static BOOL DYYYSettingsSearchIndexBuilt = NO;
 static NSString *const kDYYYFeedNowPlayingSettingTitle = @"屏蔽灵动岛抖音播放信息";
 static NSString *const kDYYYFeedNowPlayingSettingIdentifier = @"DYYYDisableFeedNowPlayingInfo";
 static NSString *const kDYYYFeedNowPlayingSVGIconName = @"ic_liveactivityplayslash_outlined_20";
@@ -147,6 +151,302 @@ static void DYYYRemoveRemoteConfigObserver(void) {
     }
 }
 
+static NSString *DYYYStringOrEmpty(id value) {
+    return [value isKindOfClass:[NSString class]] ? (NSString *)value : @"";
+}
+
+static NSMutableDictionary<NSString *, NSMutableDictionary *> *DYYYSettingsSearchIndexMap(void) {
+    static NSMutableDictionary<NSString *, NSMutableDictionary *> *map = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+      map = [NSMutableDictionary dictionary];
+    });
+    return map;
+}
+
+static NSMutableArray<NSString *> *DYYYSettingsSearchIndexKeys(void) {
+    static NSMutableArray<NSString *> *keys = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+      keys = [NSMutableArray array];
+    });
+    return keys;
+}
+
+static void DYYYRegisterSearchSections(NSString *categoryTitle, NSArray *sections) {
+    if (categoryTitle.length == 0 || sections.count == 0) {
+        return;
+    }
+
+    NSMutableDictionary *indexMap = DYYYSettingsSearchIndexMap();
+    NSMutableArray *orderedKeys = DYYYSettingsSearchIndexKeys();
+
+    for (AWESettingSectionModel *section in sections) {
+        if (![section respondsToSelector:@selector(itemArray)]) {
+            continue;
+        }
+
+        NSString *sectionTitle = DYYYStringOrEmpty(section.sectionHeaderTitle);
+        NSString *path = sectionTitle.length > 0 ? [NSString stringWithFormat:@"%@ - %@", categoryTitle, sectionTitle] : categoryTitle;
+
+        for (id itemObject in section.itemArray) {
+            if (![itemObject isKindOfClass:NSClassFromString(@"AWESettingItemModel")]) {
+                continue;
+            }
+
+            AWESettingItemModel *item = (AWESettingItemModel *)itemObject;
+            if (item.title.length == 0) {
+                continue;
+            }
+
+            NSString *identifier = item.identifier.length > 0 ? item.identifier : item.title;
+            NSString *entryKey = [NSString stringWithFormat:@"%@|%@|%@", path, identifier, item.title];
+            NSString *searchableText = [NSString stringWithFormat:@"%@ %@ %@ %@ %@", path, item.title ?: @"", item.subTitle ?: @"", item.detail ?: @"", item.identifier ?: @""];
+
+            if (!indexMap[entryKey]) {
+                [orderedKeys addObject:entryKey];
+            }
+            indexMap[entryKey] = [@{@"path" : path, @"item" : item, @"searchableText" : searchableText} mutableCopy];
+        }
+    }
+}
+
+static NSArray<NSDictionary *> *DYYYSettingsSearchEntries(void) {
+    NSMutableArray<NSDictionary *> *entries = [NSMutableArray array];
+    NSDictionary *indexMap = DYYYSettingsSearchIndexMap();
+    for (NSString *key in DYYYSettingsSearchIndexKeys()) {
+        NSDictionary *entry = indexMap[key];
+        if (entry) {
+            [entries addObject:entry];
+        }
+    }
+    return entries;
+}
+
+static void DYYYResetSettingsSearchIndex(void) {
+    [DYYYSettingsSearchIndexMap() removeAllObjects];
+    [DYYYSettingsSearchIndexKeys() removeAllObjects];
+    DYYYSettingsSearchIndexBuilt = NO;
+}
+
+static void DYYYRefreshSearchItemValue(AWESettingItemModel *item) {
+    if (item.identifier.length == 0) {
+        return;
+    }
+
+    id savedValue = [[NSUserDefaults standardUserDefaults] objectForKey:item.identifier];
+    if (item.cellType == 6 || item.cellType == 37) {
+        item.isSwitchOn = [savedValue respondsToSelector:@selector(boolValue)] ? [savedValue boolValue] : NO;
+    } else if (savedValue) {
+        if ([savedValue isKindOfClass:[NSString class]]) {
+            item.detail = savedValue;
+        } else if ([savedValue respondsToSelector:@selector(stringValue)]) {
+            item.detail = [savedValue stringValue];
+        }
+    }
+
+    [DYYYSettingsHelper applyDependencyRulesForItem:item];
+}
+
+@interface DYYYSettingsSearchCoordinator : NSObject <UITextFieldDelegate>
+@property(nonatomic, weak) AWESettingBaseViewController *settingsVC;
+@property(nonatomic, strong) AWESettingsViewModel *viewModel;
+@property(nonatomic, copy) NSArray *originalSections;
+@property(nonatomic, copy) NSArray<NSDictionary *> *searchEntries;
+@property(nonatomic, strong) UIView *headerView;
+@property(nonatomic, strong) UIView *containerView;
+@property(nonatomic, strong) UITextField *searchTextField;
+@property(nonatomic, strong) UIImageView *centerIconView;
+- (instancetype)initWithSettingsVC:(AWESettingBaseViewController *)settingsVC viewModel:(AWESettingsViewModel *)viewModel originalSections:(NSArray *)sections searchEntries:(NSArray<NSDictionary *> *)entries;
+- (void)installSearchHeader;
+- (void)updateLayout;
+@end
+
+@implementation DYYYSettingsSearchCoordinator
+
+- (instancetype)initWithSettingsVC:(AWESettingBaseViewController *)settingsVC viewModel:(AWESettingsViewModel *)viewModel originalSections:(NSArray *)sections searchEntries:(NSArray<NSDictionary *> *)entries {
+    self = [super init];
+    if (self) {
+        _settingsVC = settingsVC;
+        _viewModel = viewModel;
+        _originalSections = [sections copy];
+        _searchEntries = [entries copy];
+    }
+    return self;
+}
+
+- (void)installSearchHeader {
+    [self.settingsVC view];
+    UITableView *tableView = self.settingsVC.tableView;
+    if (!tableView) {
+        return;
+    }
+
+    self.headerView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, tableView.bounds.size.width, 64)];
+    self.headerView.backgroundColor = [UIColor clearColor];
+    self.headerView.autoresizingMask = UIViewAutoresizingFlexibleWidth;
+
+    self.containerView = [[UIView alloc] initWithFrame:CGRectMake(16, 8, self.headerView.bounds.size.width - 32, 44)];
+    self.containerView.backgroundColor = [UIColor whiteColor];
+    self.containerView.layer.cornerRadius = 12;
+    self.containerView.layer.masksToBounds = YES;
+    self.containerView.autoresizingMask = UIViewAutoresizingFlexibleWidth;
+    [self.headerView addSubview:self.containerView];
+
+    self.searchTextField = [[UITextField alloc] initWithFrame:self.containerView.bounds];
+    self.searchTextField.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    self.searchTextField.backgroundColor = [UIColor clearColor];
+    self.searchTextField.textColor = [UIColor colorWithRed:22.0 / 255.0 green:24.0 / 255.0 blue:35.0 / 255.0 alpha:1.0];
+    self.searchTextField.tintColor = self.searchTextField.textColor;
+    self.searchTextField.font = [UIFont systemFontOfSize:16 weight:UIFontWeightRegular];
+    self.searchTextField.clearButtonMode = UITextFieldViewModeWhileEditing;
+    self.searchTextField.returnKeyType = UIReturnKeySearch;
+    self.searchTextField.autocorrectionType = UITextAutocorrectionTypeNo;
+    self.searchTextField.spellCheckingType = UITextSpellCheckingTypeNo;
+    self.searchTextField.delegate = self;
+    self.searchTextField.accessibilityLabel = @"DYYY设置搜索";
+
+    UIView *leftView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 38, 30)];
+    UIImageView *leftIconView = [[UIImageView alloc] initWithFrame:CGRectMake(14, 5, 18, 18)];
+    leftIconView.image = [UIImage systemImageNamed:@"magnifyingglass"];
+    leftIconView.tintColor = [UIColor colorWithWhite:0 alpha:0.38];
+    leftIconView.contentMode = UIViewContentModeScaleAspectFit;
+    [leftView addSubview:leftIconView];
+    self.searchTextField.leftView = leftView;
+    self.searchTextField.leftViewMode = UITextFieldViewModeNever;
+    [self.searchTextField addTarget:self action:@selector(searchTextDidChange:) forControlEvents:UIControlEventEditingChanged];
+    [self.containerView addSubview:self.searchTextField];
+
+    self.centerIconView = [[UIImageView alloc] initWithImage:[UIImage systemImageNamed:@"magnifyingglass"]];
+    self.centerIconView.tintColor = [UIColor colorWithWhite:0 alpha:0.38];
+    self.centerIconView.contentMode = UIViewContentModeScaleAspectFit;
+    self.centerIconView.frame = CGRectMake(0, 0, 22, 22);
+    self.centerIconView.userInteractionEnabled = NO;
+    [self.containerView addSubview:self.centerIconView];
+
+    [self updateSearchPlaceholderVisibility];
+    [self updateLayout];
+    tableView.tableHeaderView = self.headerView;
+}
+
+- (void)updateLayout {
+    UITableView *tableView = self.settingsVC.tableView;
+    if (!tableView || !self.headerView || !self.containerView || !self.centerIconView) {
+        return;
+    }
+
+    CGFloat width = tableView.bounds.size.width;
+    if (width <= 0) {
+        return;
+    }
+
+    BOOL needsHeaderUpdate = fabs(self.headerView.frame.size.width - width) > 0.5;
+    self.headerView.frame = CGRectMake(0, 0, width, 64);
+    self.containerView.frame = CGRectMake(16, 8, width - 32, 44);
+    self.searchTextField.frame = self.containerView.bounds;
+    self.centerIconView.center = CGPointMake(CGRectGetMidX(self.containerView.bounds), CGRectGetMidY(self.containerView.bounds));
+
+    if (needsHeaderUpdate) {
+        tableView.tableHeaderView = self.headerView;
+    }
+}
+
+- (NSString *)trimmedSearchText {
+    return [self.searchTextField.text ?: @"" stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+}
+
+- (void)updateSearchPlaceholderVisibility {
+    BOOL showCenteredIcon = !self.searchTextField.isEditing && [self trimmedSearchText].length == 0;
+    self.centerIconView.hidden = !showCenteredIcon;
+    self.searchTextField.placeholder = showCenteredIcon ? nil : @"搜索设置项";
+    self.searchTextField.leftViewMode = showCenteredIcon ? UITextFieldViewModeNever : UITextFieldViewModeAlways;
+}
+
+- (NSArray *)sectionsForSearchText:(NSString *)searchText {
+    NSString *query = [searchText lowercaseString];
+    if (query.length == 0) {
+        return self.originalSections;
+    }
+
+    NSMutableArray *sections = [NSMutableArray array];
+    for (NSDictionary *entry in self.searchEntries) {
+        NSString *searchableText = [entry[@"searchableText"] lowercaseString];
+        if (![searchableText containsString:query]) {
+            continue;
+        }
+
+        AWESettingItemModel *item = entry[@"item"];
+        DYYYRefreshSearchItemValue(item);
+
+        AWESettingSectionModel *section = [[NSClassFromString(@"AWESettingSectionModel") alloc] init];
+        section.sectionHeaderTitle = entry[@"path"];
+        section.sectionHeaderHeight = 40;
+        section.type = 0;
+        section.itemArray = @[ item ];
+        [sections addObject:section];
+    }
+
+    if (sections.count == 0) {
+        AWESettingSectionModel *emptySection = [[NSClassFromString(@"AWESettingSectionModel") alloc] init];
+        emptySection.sectionHeaderTitle = @"未找到相关设置";
+        emptySection.sectionHeaderHeight = 40;
+        emptySection.type = 0;
+        emptySection.itemArray = @[];
+        [sections addObject:emptySection];
+    }
+
+    return sections;
+}
+
+- (void)searchTextDidChange:(UITextField *)textField {
+    [self updateSearchPlaceholderVisibility];
+    self.viewModel.sectionDataArray = [self sectionsForSearchText:[self trimmedSearchText]];
+    [self.settingsVC.tableView reloadData];
+}
+
+- (void)textFieldDidBeginEditing:(UITextField *)textField {
+    [self updateSearchPlaceholderVisibility];
+}
+
+- (void)textFieldDidEndEditing:(UITextField *)textField {
+    [self updateSearchPlaceholderVisibility];
+}
+
+- (BOOL)textFieldShouldReturn:(UITextField *)textField {
+    [textField resignFirstResponder];
+    return NO;
+}
+
+@end
+
+static void DYYYAttachSettingsSearchHeader(AWESettingBaseViewController *settingsVC, AWESettingsViewModel *viewModel, NSArray *sections) {
+    if (!settingsVC || !viewModel || sections.count == 0) {
+        return;
+    }
+
+    DYYYSettingsSearchCoordinator *coordinator = [[DYYYSettingsSearchCoordinator alloc] initWithSettingsVC:settingsVC viewModel:viewModel originalSections:sections searchEntries:DYYYSettingsSearchEntries()];
+    objc_setAssociatedObject(settingsVC, &kDYYYSettingsSearchCoordinatorKey, coordinator, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+      [coordinator installSearchHeader];
+    });
+}
+
+static void DYYYBuildSettingsSearchIndexIfNeeded(NSArray<AWESettingItemModel *> *categoryItems) {
+    if (DYYYSettingsSearchIndexBuilt) {
+        return;
+    }
+
+    DYYYSettingsSearchIndexBuilt = YES;
+    DYYYBuildingSettingsSearchIndex = YES;
+    for (AWESettingItemModel *item in categoryItems) {
+        if (item.cellTappedBlock) {
+            item.cellTappedBlock();
+        }
+    }
+    DYYYBuildingSettingsSearchIndex = NO;
+}
+
 %hook AWESettingBaseViewController
 - (BOOL)useCardUIStyle {
     return YES;
@@ -161,6 +461,8 @@ static void DYYYRemoveRemoteConfigObserver(void) {
 
 - (void)viewDidLayoutSubviews {
     %orig;
+    DYYYSettingsSearchCoordinator *coordinator = objc_getAssociatedObject(self, &kDYYYSettingsSearchCoordinatorKey);
+    [coordinator updateLayout];
     for (AWESettingsTableViewCell *cell in self.tableView.visibleCells) {
         if ([cell isKindOfClass:%c(AWESettingsTableViewCell)]) {
             DYYYApplyFeedNowPlayingIconToCell(cell);
@@ -943,6 +1245,11 @@ void showDYYYSettingsVC(UIViewController *rootVC, BOOL hasAgreed) {
       [sections addObject:[DYYYSettingsHelper createSectionWithTitle:@"过滤与屏蔽" footerTitle:@"请不要同时开启过多过滤推荐项目，这会增大视频流加载延迟。" items:filterItems]];
       [sections addObject:[DYYYSettingsHelper createSectionWithTitle:@"二次确认" items:securityItems]];
 
+      DYYYRegisterSearchSections(@"基本设置", sections);
+      if (DYYYBuildingSettingsSearchIndex) {
+          return;
+      }
+
       // 创建并推入二级设置页面
       AWESettingBaseViewController *subVC = [DYYYSettingsHelper createSubSettingsViewController:@"基本设置" sections:sections];
       [rootVC.navigationController pushViewController:(UIViewController *)subVC animated:YES];
@@ -1123,6 +1430,11 @@ void showDYYYSettingsVC(UIViewController *rootVC, BOOL hasAgreed) {
       [sections addObject:[DYYYSettingsHelper createSectionWithTitle:@"标题自定义" items:titleItems]];
       [sections addObject:[DYYYSettingsHelper createSectionWithTitle:@"图标自定义" items:iconItems]];
       // 创建并组织所有section
+      DYYYRegisterSearchSections(@"界面设置", sections);
+      if (DYYYBuildingSettingsSearchIndex) {
+          return;
+      }
+
       // 创建并推入二级设置页面
       AWESettingBaseViewController *subVC = [DYYYSettingsHelper createSubSettingsViewController:@"界面设置" sections:sections];
       [rootVC.navigationController pushViewController:(UIViewController *)subVC animated:YES];
@@ -1939,6 +2251,11 @@ void showDYYYSettingsVC(UIViewController *rootVC, BOOL hasAgreed) {
       [sections addObject:[DYYYSettingsHelper createSectionWithTitle:@"直播间界面" items:livestreamItems]];
       [sections addObject:[DYYYSettingsHelper createSectionWithTitle:@"隐藏面板功能" footerTitle:@"隐藏视频长按面板中的功能" items:modernpanels]];
       [sections addObject:[DYYYSettingsHelper createSectionWithTitle:@"隐藏长按评论功能" footerTitle:@"隐藏评论长按面板中的功能" items:commentpanel]];
+      DYYYRegisterSearchSections(@"隐藏设置", sections);
+      if (DYYYBuildingSettingsSearchIndex) {
+          return;
+      }
+
       // 创建并推入二级设置页面
       AWESettingBaseViewController *subVC = [DYYYSettingsHelper createSubSettingsViewController:@"隐藏设置" sections:sections];
       [rootVC.navigationController pushViewController:(UIViewController *)subVC animated:YES];
@@ -2061,6 +2378,11 @@ void showDYYYSettingsVC(UIViewController *rootVC, BOOL hasAgreed) {
 
       NSMutableArray *sections = [NSMutableArray array];
       [sections addObject:[DYYYSettingsHelper createSectionWithTitle:@"顶栏选项" items:removeSettingsItems]];
+
+      DYYYRegisterSearchSections(@"顶栏移除", sections);
+      if (DYYYBuildingSettingsSearchIndex) {
+          return;
+      }
 
       AWESettingBaseViewController *subVC = [DYYYSettingsHelper createSubSettingsViewController:@"顶栏移除" sections:sections];
       [rootVC.navigationController pushViewController:(UIViewController *)subVC animated:YES];
@@ -3074,6 +3396,11 @@ void showDYYYSettingsVC(UIViewController *rootVC, BOOL hasAgreed) {
       [sections addObject:[DYYYSettingsHelper createSectionWithTitle:@"ABTest"
                                                          footerTitle:@"允许用户导出或导入抖音的 ABTest 配置。远程配置由 Nathalie 维护，在应用启动时自动更新远程配置。"
                                                                items:hotUpdateItems]];
+      DYYYRegisterSearchSections(@"增强设置", sections);
+      if (DYYYBuildingSettingsSearchIndex) {
+          return;
+      }
+
       // 创建并推入二级设置页面
       AWESettingBaseViewController *subVC = [DYYYSettingsHelper createSubSettingsViewController:@"增强设置" sections:sections];
       [rootVC.navigationController pushViewController:(UIViewController *)subVC animated:YES];
@@ -3410,6 +3737,11 @@ void showDYYYSettingsVC(UIViewController *rootVC, BOOL hasAgreed) {
       NSMutableArray *sections = [NSMutableArray array];
       [sections addObject:[DYYYSettingsHelper createSectionWithTitle:@"快捷倍速" items:speedButtonItems]];
       [sections addObject:[DYYYSettingsHelper createSectionWithTitle:@"一键清屏" items:clearButtonItems]];
+
+      DYYYRegisterSearchSections(@"悬浮按钮", sections);
+      if (DYYYBuildingSettingsSearchIndex) {
+          return;
+      }
 
       // 创建并推入二级设置页面
       AWESettingBaseViewController *subVC = [DYYYSettingsHelper createSubSettingsViewController:@"悬浮按钮" sections:sections];
@@ -3830,8 +4162,14 @@ void showDYYYSettingsVC(UIViewController *rootVC, BOOL hasAgreed) {
     mainSection.itemArray = mainItems;
     aboutSection.itemArray = aboutItems;
 
-    viewModel.sectionDataArray = @[ mainSection, cleanupSection, backupSection, aboutSection ];
+    DYYYResetSettingsSearchIndex();
+    DYYYBuildSettingsSearchIndexIfNeeded(mainItems);
+    DYYYRegisterSearchSections(@"DYYY", @[ cleanupSection, backupSection, aboutSection ]);
+
+    NSArray *rootSections = @[ mainSection, cleanupSection, backupSection, aboutSection ];
+    viewModel.sectionDataArray = rootSections;
     objc_setAssociatedObject(settingsVC, &kViewModelKey, viewModel, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    DYYYAttachSettingsSearchHeader(settingsVC, viewModel, rootSections);
     [rootVC.navigationController pushViewController:(UIViewController *)settingsVC animated:YES];
 }
 

--- a/DYYYSettings.xm
+++ b/DYYYSettings.xm
@@ -252,18 +252,24 @@ static void DYYYRefreshSearchItemValue(AWESettingItemModel *item) {
 @property(nonatomic, weak) AWESettingBaseViewController *settingsVC;
 @property(nonatomic, weak) UINavigationController *navigationController;
 @property(nonatomic, weak) id<UIGestureRecognizerDelegate> previousInteractivePopGestureDelegate;
+@property(nonatomic, assign) BOOL previousInteractivePopGestureEnabled;
+@property(nonatomic, assign) BOOL hasStoredInteractivePopGestureEnabled;
 @property(nonatomic, strong) AWESettingsViewModel *viewModel;
 @property(nonatomic, copy) NSArray *originalSections;
 @property(nonatomic, copy) NSArray<NSDictionary *> *searchEntries;
 @property(nonatomic, strong) UIView *headerView;
 @property(nonatomic, strong) UIView *containerView;
 @property(nonatomic, strong) UITextField *searchTextField;
+@property(nonatomic, strong) UIScreenEdgePanGestureRecognizer *searchBackGestureRecognizer;
 @property(nonatomic, strong) UIView *centerPlaceholderView;
 @property(nonatomic, strong) UIImageView *centerIconView;
 @property(nonatomic, strong) UILabel *centerPlaceholderLabel;
 - (instancetype)initWithSettingsVC:(AWESettingBaseViewController *)settingsVC viewModel:(AWESettingsViewModel *)viewModel originalSections:(NSArray *)sections searchEntries:(NSArray<NSDictionary *> *)entries;
 - (void)installSearchHeader;
+- (void)installNavigationInterceptors;
 - (void)updateLayout;
+- (void)updateNavigationGestureState;
+- (void)restoreNavigationGestureState;
 - (BOOL)handleBackNavigationRequest;
 @end
 
@@ -341,6 +347,7 @@ static void DYYYRefreshSearchItemValue(AWESettingItemModel *item) {
     [self updateLayout];
     tableView.tableHeaderView = self.headerView;
     [self installNavigationInterceptors];
+    [self updateNavigationGestureState];
 }
 
 - (void)updateLayout {
@@ -376,6 +383,7 @@ static void DYYYRefreshSearchItemValue(AWESettingItemModel *item) {
     }
 
     [self installNavigationInterceptors];
+    [self updateNavigationGestureState];
 }
 
 - (NSString *)trimmedSearchText {
@@ -446,6 +454,7 @@ static void DYYYRefreshSearchItemValue(AWESettingItemModel *item) {
     [self updateSearchPlaceholderVisibility];
     self.viewModel.sectionDataArray = [self sectionsForSearchText:[self trimmedSearchText]];
     [self.settingsVC.tableView reloadData];
+    [self updateNavigationGestureState];
 }
 
 - (BOOL)isSearchInteractionActive {
@@ -462,22 +471,79 @@ static void DYYYRefreshSearchItemValue(AWESettingItemModel *item) {
     [self updateSearchPlaceholderVisibility];
     self.viewModel.sectionDataArray = self.originalSections;
     [self.settingsVC.tableView reloadData];
+    [self updateNavigationGestureState];
     return YES;
 }
 
 - (void)installNavigationInterceptors {
     UINavigationController *navigationController = self.settingsVC.navigationController;
     UIGestureRecognizer *popGesture = navigationController.interactivePopGestureRecognizer;
-    if (!navigationController || !popGesture || popGesture.delegate == (id<UIGestureRecognizerDelegate>)self) {
+    if (!navigationController || !popGesture) {
         return;
     }
 
     self.navigationController = navigationController;
-    self.previousInteractivePopGestureDelegate = popGesture.delegate;
-    popGesture.delegate = (id<UIGestureRecognizerDelegate>)self;
+    if (!self.hasStoredInteractivePopGestureEnabled) {
+        self.previousInteractivePopGestureEnabled = popGesture.enabled;
+        self.hasStoredInteractivePopGestureEnabled = YES;
+    }
+    if (popGesture.delegate != (id<UIGestureRecognizerDelegate>)self) {
+        self.previousInteractivePopGestureDelegate = popGesture.delegate;
+        popGesture.delegate = (id<UIGestureRecognizerDelegate>)self;
+    }
+
+    if (!self.searchBackGestureRecognizer) {
+        self.searchBackGestureRecognizer = [[UIScreenEdgePanGestureRecognizer alloc] initWithTarget:self action:@selector(handleSearchBackGesture:)];
+        self.searchBackGestureRecognizer.edges = UIRectEdgeLeft;
+        self.searchBackGestureRecognizer.delegate = (id<UIGestureRecognizerDelegate>)self;
+        self.searchBackGestureRecognizer.enabled = NO;
+        [self.settingsVC.view addGestureRecognizer:self.searchBackGestureRecognizer];
+    }
+}
+
+- (void)updateNavigationGestureState {
+    UINavigationController *navigationController = self.settingsVC.navigationController ?: self.navigationController;
+    UIGestureRecognizer *popGesture = navigationController.interactivePopGestureRecognizer;
+    BOOL searchActive = [self isSearchInteractionActive];
+
+    if (popGesture) {
+        if (!self.hasStoredInteractivePopGestureEnabled) {
+            self.previousInteractivePopGestureEnabled = popGesture.enabled;
+            self.hasStoredInteractivePopGestureEnabled = YES;
+        }
+        if (searchActive) {
+            popGesture.enabled = NO;
+        } else {
+            popGesture.enabled = self.previousInteractivePopGestureEnabled;
+        }
+    }
+
+    self.searchBackGestureRecognizer.enabled = searchActive;
+}
+
+- (void)restoreNavigationGestureState {
+    UINavigationController *navigationController = self.settingsVC.navigationController ?: self.navigationController;
+    UIGestureRecognizer *popGesture = navigationController.interactivePopGestureRecognizer;
+    if (popGesture.delegate == (id<UIGestureRecognizerDelegate>)self) {
+        popGesture.delegate = self.previousInteractivePopGestureDelegate;
+    }
+    if (self.hasStoredInteractivePopGestureEnabled) {
+        popGesture.enabled = self.previousInteractivePopGestureEnabled;
+    }
+    self.searchBackGestureRecognizer.enabled = NO;
+}
+
+- (void)handleSearchBackGesture:(UIScreenEdgePanGestureRecognizer *)gestureRecognizer {
+    if (gestureRecognizer.state == UIGestureRecognizerStateBegan) {
+        [self handleBackNavigationRequest];
+    }
 }
 
 - (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer {
+    if (gestureRecognizer == self.searchBackGestureRecognizer) {
+        return [self isSearchInteractionActive];
+    }
+
     if (gestureRecognizer == self.navigationController.interactivePopGestureRecognizer && [self handleBackNavigationRequest]) {
         return NO;
     }
@@ -492,10 +558,12 @@ static void DYYYRefreshSearchItemValue(AWESettingItemModel *item) {
 
 - (void)textFieldDidBeginEditing:(UITextField *)textField {
     [self updateSearchPlaceholderVisibility];
+    [self updateNavigationGestureState];
 }
 
 - (void)textFieldDidEndEditing:(UITextField *)textField {
     [self updateSearchPlaceholderVisibility];
+    [self updateNavigationGestureState];
 }
 
 - (BOOL)textFieldShouldReturn:(UITextField *)textField {
@@ -504,10 +572,7 @@ static void DYYYRefreshSearchItemValue(AWESettingItemModel *item) {
 }
 
 - (void)dealloc {
-    UIGestureRecognizer *popGesture = self.navigationController.interactivePopGestureRecognizer;
-    if (popGesture.delegate == (id<UIGestureRecognizerDelegate>)self) {
-        popGesture.delegate = self.previousInteractivePopGestureDelegate;
-    }
+    [self restoreNavigationGestureState];
 }
 
 @end
@@ -550,6 +615,19 @@ static void DYYYBuildSettingsSearchIndexIfNeeded(NSArray<AWESettingItemModel *> 
     if (!original)
         return objc_getAssociatedObject(self, &kViewModelKey);
     return original;
+}
+
+- (void)viewWillAppear:(BOOL)animated {
+    %orig;
+    DYYYSettingsSearchCoordinator *coordinator = objc_getAssociatedObject(self, &kDYYYSettingsSearchCoordinatorKey);
+    [coordinator installNavigationInterceptors];
+    [coordinator updateNavigationGestureState];
+}
+
+- (void)viewWillDisappear:(BOOL)animated {
+    DYYYSettingsSearchCoordinator *coordinator = objc_getAssociatedObject(self, &kDYYYSettingsSearchCoordinatorKey);
+    [coordinator restoreNavigationGestureState];
+    %orig;
 }
 
 - (void)viewDidLayoutSubviews {

--- a/DYYYSettings.xm
+++ b/DYYYSettings.xm
@@ -201,7 +201,7 @@ static void DYYYRegisterSearchSections(NSString *categoryTitle, NSArray *section
 
             NSString *identifier = item.identifier.length > 0 ? item.identifier : item.title;
             NSString *entryKey = [NSString stringWithFormat:@"%@|%@|%@", path, identifier, item.title];
-            NSString *searchableText = [NSString stringWithFormat:@"%@ %@ %@ %@ %@", path, item.title ?: @"", item.subTitle ?: @"", item.detail ?: @"", item.identifier ?: @""];
+            NSString *searchableText = [NSString stringWithFormat:@"%@ %@", item.title ?: @"", item.subTitle ?: @""];
 
             if (!indexMap[entryKey]) {
                 [orderedKeys addObject:entryKey];

--- a/DYYYSettings.xm
+++ b/DYYYSettings.xm
@@ -248,18 +248,23 @@ static void DYYYRefreshSearchItemValue(AWESettingItemModel *item) {
     [DYYYSettingsHelper applyDependencyRulesForItem:item];
 }
 
-@interface DYYYSettingsSearchCoordinator : NSObject <UITextFieldDelegate>
+@interface DYYYSettingsSearchCoordinator : NSObject <UITextFieldDelegate, UIGestureRecognizerDelegate>
 @property(nonatomic, weak) AWESettingBaseViewController *settingsVC;
+@property(nonatomic, weak) UINavigationController *navigationController;
+@property(nonatomic, weak) id<UIGestureRecognizerDelegate> previousInteractivePopGestureDelegate;
 @property(nonatomic, strong) AWESettingsViewModel *viewModel;
 @property(nonatomic, copy) NSArray *originalSections;
 @property(nonatomic, copy) NSArray<NSDictionary *> *searchEntries;
 @property(nonatomic, strong) UIView *headerView;
 @property(nonatomic, strong) UIView *containerView;
 @property(nonatomic, strong) UITextField *searchTextField;
+@property(nonatomic, strong) UIView *centerPlaceholderView;
 @property(nonatomic, strong) UIImageView *centerIconView;
+@property(nonatomic, strong) UILabel *centerPlaceholderLabel;
 - (instancetype)initWithSettingsVC:(AWESettingBaseViewController *)settingsVC viewModel:(AWESettingsViewModel *)viewModel originalSections:(NSArray *)sections searchEntries:(NSArray<NSDictionary *> *)entries;
 - (void)installSearchHeader;
 - (void)updateLayout;
+- (BOOL)handleBackNavigationRequest;
 @end
 
 @implementation DYYYSettingsSearchCoordinator
@@ -317,21 +322,30 @@ static void DYYYRefreshSearchItemValue(AWESettingItemModel *item) {
     [self.searchTextField addTarget:self action:@selector(searchTextDidChange:) forControlEvents:UIControlEventEditingChanged];
     [self.containerView addSubview:self.searchTextField];
 
+    self.centerPlaceholderView = [[UIView alloc] initWithFrame:CGRectZero];
+    self.centerPlaceholderView.userInteractionEnabled = NO;
+    [self.containerView addSubview:self.centerPlaceholderView];
+
     self.centerIconView = [[UIImageView alloc] initWithImage:[UIImage systemImageNamed:@"magnifyingglass"]];
     self.centerIconView.tintColor = [UIColor colorWithWhite:0 alpha:0.38];
     self.centerIconView.contentMode = UIViewContentModeScaleAspectFit;
-    self.centerIconView.frame = CGRectMake(0, 0, 22, 22);
-    self.centerIconView.userInteractionEnabled = NO;
-    [self.containerView addSubview:self.centerIconView];
+    [self.centerPlaceholderView addSubview:self.centerIconView];
+
+    self.centerPlaceholderLabel = [[UILabel alloc] initWithFrame:CGRectZero];
+    self.centerPlaceholderLabel.text = @"搜索设置项";
+    self.centerPlaceholderLabel.textColor = [UIColor colorWithWhite:0 alpha:0.38];
+    self.centerPlaceholderLabel.font = [UIFont systemFontOfSize:16 weight:UIFontWeightRegular];
+    [self.centerPlaceholderView addSubview:self.centerPlaceholderLabel];
 
     [self updateSearchPlaceholderVisibility];
     [self updateLayout];
     tableView.tableHeaderView = self.headerView;
+    [self installNavigationInterceptors];
 }
 
 - (void)updateLayout {
     UITableView *tableView = self.settingsVC.tableView;
-    if (!tableView || !self.headerView || !self.containerView || !self.centerIconView) {
+    if (!tableView || !self.headerView || !self.containerView || !self.centerPlaceholderView || !self.centerIconView || !self.centerPlaceholderLabel) {
         return;
     }
 
@@ -344,11 +358,24 @@ static void DYYYRefreshSearchItemValue(AWESettingItemModel *item) {
     self.headerView.frame = CGRectMake(0, 0, width, 64);
     self.containerView.frame = CGRectMake(16, 8, width - 32, 44);
     self.searchTextField.frame = self.containerView.bounds;
-    self.centerIconView.center = CGPointMake(CGRectGetMidX(self.containerView.bounds), CGRectGetMidY(self.containerView.bounds));
+
+    CGFloat iconSize = 18.0;
+    CGFloat spacing = 8.0;
+    CGSize labelSize = [self.centerPlaceholderLabel.text sizeWithAttributes:@{NSFontAttributeName : self.centerPlaceholderLabel.font}];
+    CGFloat placeholderWidth = iconSize + spacing + ceil(labelSize.width);
+    CGFloat placeholderHeight = MAX(iconSize, ceil(labelSize.height));
+    self.centerPlaceholderView.frame = CGRectMake((CGRectGetWidth(self.containerView.bounds) - placeholderWidth) / 2.0,
+                                                  (CGRectGetHeight(self.containerView.bounds) - placeholderHeight) / 2.0,
+                                                  placeholderWidth,
+                                                  placeholderHeight);
+    self.centerIconView.frame = CGRectMake(0, (placeholderHeight - iconSize) / 2.0, iconSize, iconSize);
+    self.centerPlaceholderLabel.frame = CGRectMake(iconSize + spacing, 0, ceil(labelSize.width), placeholderHeight);
 
     if (needsHeaderUpdate) {
         tableView.tableHeaderView = self.headerView;
     }
+
+    [self installNavigationInterceptors];
 }
 
 - (NSString *)trimmedSearchText {
@@ -356,10 +383,10 @@ static void DYYYRefreshSearchItemValue(AWESettingItemModel *item) {
 }
 
 - (void)updateSearchPlaceholderVisibility {
-    BOOL showCenteredIcon = !self.searchTextField.isEditing && [self trimmedSearchText].length == 0;
-    self.centerIconView.hidden = !showCenteredIcon;
-    self.searchTextField.placeholder = showCenteredIcon ? nil : @"搜索设置项";
-    self.searchTextField.leftViewMode = showCenteredIcon ? UITextFieldViewModeNever : UITextFieldViewModeAlways;
+    BOOL showCenteredPlaceholder = !self.searchTextField.isEditing && [self trimmedSearchText].length == 0;
+    self.centerPlaceholderView.hidden = !showCenteredPlaceholder;
+    self.searchTextField.placeholder = showCenteredPlaceholder ? nil : @"搜索设置项";
+    self.searchTextField.leftViewMode = showCenteredPlaceholder ? UITextFieldViewModeNever : UITextFieldViewModeAlways;
 }
 
 - (NSArray *)sectionsForSearchText:(NSString *)searchText {
@@ -368,7 +395,8 @@ static void DYYYRefreshSearchItemValue(AWESettingItemModel *item) {
         return self.originalSections;
     }
 
-    NSMutableArray *sections = [NSMutableArray array];
+    NSMutableDictionary<NSString *, NSMutableArray *> *groupedItems = [NSMutableDictionary dictionary];
+    NSMutableArray<NSString *> *orderedPaths = [NSMutableArray array];
     for (NSDictionary *entry in self.searchEntries) {
         NSString *searchableText = [entry[@"searchableText"] lowercaseString];
         if (![searchableText containsString:query]) {
@@ -377,12 +405,28 @@ static void DYYYRefreshSearchItemValue(AWESettingItemModel *item) {
 
         AWESettingItemModel *item = entry[@"item"];
         DYYYRefreshSearchItemValue(item);
+        NSString *path = entry[@"path"] ?: @"DYYY";
+        NSMutableArray *items = groupedItems[path];
+        if (!items) {
+            items = [NSMutableArray array];
+            groupedItems[path] = items;
+            [orderedPaths addObject:path];
+        }
+        [items addObject:item];
+    }
+
+    NSMutableArray *sections = [NSMutableArray array];
+    for (NSString *path in orderedPaths) {
+        NSArray *items = groupedItems[path];
+        if (items.count == 0) {
+            continue;
+        }
 
         AWESettingSectionModel *section = [[NSClassFromString(@"AWESettingSectionModel") alloc] init];
-        section.sectionHeaderTitle = entry[@"path"];
+        section.sectionHeaderTitle = path;
         section.sectionHeaderHeight = 40;
         section.type = 0;
-        section.itemArray = @[ item ];
+        section.itemArray = items;
         [sections addObject:section];
     }
 
@@ -404,6 +448,48 @@ static void DYYYRefreshSearchItemValue(AWESettingItemModel *item) {
     [self.settingsVC.tableView reloadData];
 }
 
+- (BOOL)isSearchInteractionActive {
+    return self.searchTextField.isFirstResponder || [self trimmedSearchText].length > 0;
+}
+
+- (BOOL)handleBackNavigationRequest {
+    if (![self isSearchInteractionActive]) {
+        return NO;
+    }
+
+    self.searchTextField.text = @"";
+    [self.searchTextField resignFirstResponder];
+    [self updateSearchPlaceholderVisibility];
+    self.viewModel.sectionDataArray = self.originalSections;
+    [self.settingsVC.tableView reloadData];
+    return YES;
+}
+
+- (void)installNavigationInterceptors {
+    UINavigationController *navigationController = self.settingsVC.navigationController;
+    UIGestureRecognizer *popGesture = navigationController.interactivePopGestureRecognizer;
+    if (!navigationController || !popGesture || popGesture.delegate == (id<UIGestureRecognizerDelegate>)self) {
+        return;
+    }
+
+    self.navigationController = navigationController;
+    self.previousInteractivePopGestureDelegate = popGesture.delegate;
+    popGesture.delegate = (id<UIGestureRecognizerDelegate>)self;
+}
+
+- (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer {
+    if (gestureRecognizer == self.navigationController.interactivePopGestureRecognizer && [self handleBackNavigationRequest]) {
+        return NO;
+    }
+
+    id<UIGestureRecognizerDelegate> delegate = self.previousInteractivePopGestureDelegate;
+    if (delegate && delegate != (id<UIGestureRecognizerDelegate>)self && [delegate respondsToSelector:@selector(gestureRecognizerShouldBegin:)]) {
+        return [delegate gestureRecognizerShouldBegin:gestureRecognizer];
+    }
+
+    return YES;
+}
+
 - (void)textFieldDidBeginEditing:(UITextField *)textField {
     [self updateSearchPlaceholderVisibility];
 }
@@ -415,6 +501,13 @@ static void DYYYRefreshSearchItemValue(AWESettingItemModel *item) {
 - (BOOL)textFieldShouldReturn:(UITextField *)textField {
     [textField resignFirstResponder];
     return NO;
+}
+
+- (void)dealloc {
+    UIGestureRecognizer *popGesture = self.navigationController.interactivePopGestureRecognizer;
+    if (popGesture.delegate == (id<UIGestureRecognizerDelegate>)self) {
+        popGesture.delegate = self.previousInteractivePopGestureDelegate;
+    }
 }
 
 @end
@@ -474,6 +567,19 @@ static void DYYYBuildSettingsSearchIndexIfNeeded(NSArray<AWESettingItemModel *> 
     DYYYRemoveRemoteConfigObserver();
     %orig;
 }
+%end
+
+%hook UINavigationController
+
+- (UIViewController *)popViewControllerAnimated:(BOOL)animated {
+    DYYYSettingsSearchCoordinator *coordinator = objc_getAssociatedObject(self.topViewController, &kDYYYSettingsSearchCoordinatorKey);
+    if ([coordinator handleBackNavigationRequest]) {
+        return nil;
+    }
+
+    return %orig;
+}
+
 %end
 
 %hook AWESettingsTableViewCell


### PR DESCRIPTION
## 摘要
- 新增并接入设置项搜索，补齐搜索交互、返回手势、匹配范围限制，并优化 Release 更新日志对同批回滚的过滤。
- 强化全局 HDR 屏蔽链路，保留纯 HDR 过滤、SDR 降档以及直播、IM、图片等兜底，同时加入对象级缓存降低视频切换热路径开销。
- 修复保存他人头像入口，补齐头像长按开关、头像 Cell 状态和动态头像功能管理器 Hook，并确保保存头像项进入更多选项。
- 扩展隐藏暂停相关和评论长按菜单隐藏覆盖，清理暂停弹窗、暂停搜索和推荐模型，拦截长条搜索、相关推荐、评论复制、保存图片、举报、搜索、发日常、视频回复、图片搜索和分享给朋友等漏出入口。

## 验证
- `git diff --check origin/main..HEAD`
- `make clean && make package FINALPACKAGE=1 INSTALL=0`

## 说明
- 当前分支已基于 upstream/main 的最新提交，保留上游合并与 `Remove legacy HDR hook groups` 后再补充以上改动。