### PR TITLE
完善播放隐藏、登录提示、小程序广告与设置体验

### DIFF
--- a/.github/scripts/generate-release-notes.sh
+++ b/.github/scripts/generate-release-notes.sh
@@ -22,7 +22,8 @@ revert_file=$(mktemp)
 records_file=$(mktemp)
 skip_file=$(mktemp)
 contributors_file=$(mktemp)
-trap 'rm -f "$feat_file" "$fix_file" "$perf_file" "$refactor_file" "$docs_file" "$style_file" "$chore_file" "$revert_file" "$records_file" "$skip_file" "$contributors_file"' EXIT
+groups_file=$(mktemp)
+trap 'rm -f "$feat_file" "$fix_file" "$perf_file" "$refactor_file" "$docs_file" "$style_file" "$chore_file" "$revert_file" "$records_file" "$skip_file" "$contributors_file" "$groups_file"' EXIT
 
 trim_text() {
     local value=$1
@@ -208,6 +209,22 @@ keyword_content_for_subject() {
     esac
 }
 
+feature_group_for_subject() {
+    local subject=$1
+
+    case "$subject" in
+        *快捷倍速*|*倍速侧边*|*倍速锁定*|*倍速长按*|*倍速设置*|*倍速悬浮*|*倍速按钮*)
+            printf '快捷倍速'
+            ;;
+        *隐藏头像及周边*|*头像加号*|*圆形底板*)
+            printf '隐藏头像及周边'
+            ;;
+        *推荐音乐过滤*|*推荐低赞过滤*|*搜索视频广告*|*推荐特效*|*合集*广告*)
+            printf '推荐流过滤'
+            ;;
+    esac
+}
+
 summarize_commit_title() {
     local hash=$1
     local subject=$2
@@ -288,6 +305,62 @@ summarize_commit_title() {
     esac
 }
 
+normalize_group_text() {
+    local value=$1
+
+    value=$(strip_commit_type_prefix "$value")
+    value=$(printf '%s' "$value" |
+        sed -E 's/^(新增|增加|添加|支持|引入|实现|兜底修复|修复|解决|恢复|纠正|修改|调整|优化|完善|重构|简化|清理|整理|更新|规范|回滚|撤销|取消)[[:space:]:：]*//')
+    value=$(printf '%s' "$value" |
+        sed -E 's/(相关功能|相关问题|相关逻辑|相关配置|已知问题|的问题|问题|异常|失效|漏放|不能|闪退|逻辑|功能|选项|状态|改动|变更|同步|显示|隐藏|判定|配置|结构)$//')
+    value=$(printf '%s' "$value" |
+        tr -d '[:space:]' |
+        sed -E 's/[[:punct:]，。；：“”"'\''（）()、]//g')
+
+    printf '%s' "$value"
+}
+
+summary_group_key() {
+    local hash=$1
+    local subject=$2
+    local commit_type=$3
+    local summary_title=$4
+    local feature_group
+    local keyword_content
+    local normalized
+
+    if commit_touches_control "$hash"; then
+        printf 'version:版本号'
+        return
+    fi
+
+    if commit_touches_path "$hash" "Makefile" &&
+       ! commit_touches_direct_build_path "$hash"; then
+        printf 'build:Deb 构建配置'
+        return
+    fi
+
+    feature_group=$(feature_group_for_subject "$subject")
+    if [[ -n "$feature_group" ]]; then
+        printf 'feature:%s' "$feature_group"
+        return
+    fi
+
+    keyword_content=$(keyword_content_for_subject "$subject" "$commit_type")
+    if [[ -n "$keyword_content" ]]; then
+        printf 'keyword:%s' "$keyword_content"
+        return
+    fi
+
+    normalized=$(normalize_group_text "$summary_title")
+    if [[ -n "$normalized" ]]; then
+        printf 'text:%s' "$normalized"
+        return
+    fi
+
+    printf 'hash:%s' "$hash"
+}
+
 section_file_for_type() {
     case "$1" in
         feat) printf '%s' "$feat_file" ;;
@@ -303,14 +376,20 @@ section_file_for_type() {
 
 reverted_commit_hash() {
     local hash=$1
+    local body
     local target_hash
     local resolved_hash
 
-    target_hash=$(
-        git show -s --format=%B "$hash" |
-            sed -nE 's/^This reverts commit ([0-9a-fA-F]{7,40})\.$/\1/p' |
-            head -n 1
-    )
+    body=$(git show -s --format=%B "$hash")
+    target_hash=$(printf '%s\n' "$body" |
+        sed -nE 's/^This reverts commit ([0-9a-fA-F]{7,40})\.$/\1/p' |
+        head -n 1)
+
+    if [[ -z "$target_hash" ]]; then
+        target_hash=$(printf '%s\n' "$body" |
+            grep -Eoi '[0-9a-f]{7,40}' |
+            head -n 1 || true)
+    fi
 
     if [[ -z "$target_hash" ]]; then
         return
@@ -318,6 +397,17 @@ reverted_commit_hash() {
 
     resolved_hash=$(git rev-parse --verify "${target_hash}^{commit}" 2>/dev/null || true)
     printf '%s' "${resolved_hash:-$target_hash}"
+}
+
+record_hash_for() {
+    local target_hash=$1
+
+    awk -F $'\t' -v target="$target_hash" '
+        $1 == target || index($1, target) == 1 || index(target, $1) == 1 {
+            print $1
+            exit
+        }
+    ' "$records_file"
 }
 
 reverted_subject_from_title() {
@@ -343,7 +433,7 @@ normalize_revert_match_text() {
     value=$(printf '%s' "$value" |
         sed -E 's/^(新增|增加|添加|支持|引入|实现|修复|解决|恢复|纠正|修改|调整|优化|完善|重构|简化|清理|整理)[[:space:]:：]*//')
     value=$(printf '%s' "$value" |
-        sed -E 's/(的问题|问题|逻辑|优化|功能|选项|状态)$//')
+        sed -E 's/(的问题|问题|逻辑|优化|功能|选项|状态|改动|变更|同步|显示|隐藏|判定|异常|失效|不能|闪退)$//')
     value=$(printf '%s' "$value" |
         tr -d '[:space:]' |
         sed -E 's/[[:punct:]，。；：“”"'\''（）()、]//g')
@@ -351,17 +441,22 @@ normalize_revert_match_text() {
     printf '%s' "$value"
 }
 
-record_contains_hash() {
-    local target_hash=$1
+revert_key_matches_candidate() {
+    local target_key=$1
+    local candidate_key=$2
 
-    awk -F $'\t' -v target="$target_hash" '
-        $1 == target || index($1, target) == 1 || index(target, $1) == 1 {
-            found = 1
-        }
-        END {
-            exit found ? 0 : 1
-        }
-    ' "$records_file"
+    [[ -n "$target_key" && -n "$candidate_key" ]] || return 1
+
+    if [[ "$target_key" == "$candidate_key" ]]; then
+        return 0
+    fi
+
+    if (( ${#target_key} >= 6 && ${#candidate_key} >= 6 )); then
+        [[ "$target_key" == *"$candidate_key"* || "$candidate_key" == *"$target_key"* ]]
+        return
+    fi
+
+    return 1
 }
 
 mark_skip_pair() {
@@ -376,6 +471,7 @@ detect_same_range_reverts() {
     local subject
     local commit_type
     local target_hash
+    local matched_hash
     local target_subject
     local target_key
     local candidate_hash
@@ -388,8 +484,12 @@ detect_same_range_reverts() {
         [[ "$commit_type" == "revert" ]] || continue
 
         target_hash=$(reverted_commit_hash "$hash")
-        if [[ -n "$target_hash" ]] && record_contains_hash "$target_hash"; then
-            mark_skip_pair "$hash" "$target_hash"
+        matched_hash=""
+        if [[ -n "$target_hash" ]]; then
+            matched_hash=$(record_hash_for "$target_hash")
+        fi
+        if [[ -n "$matched_hash" ]]; then
+            mark_skip_pair "$hash" "$matched_hash"
             continue
         fi
 
@@ -402,9 +502,10 @@ detect_same_range_reverts() {
         while IFS=$'\t' read -r candidate_hash candidate_subject candidate_type; do
             [[ -n "$candidate_hash" ]] || continue
             [[ "$candidate_hash" == "$hash" ]] && continue
+            git merge-base --is-ancestor "$candidate_hash" "$hash" 2>/dev/null || continue
 
             candidate_key=$(normalize_revert_match_text "$candidate_subject")
-            if [[ -n "$candidate_key" && "$candidate_key" == "$target_key" ]]; then
+            if revert_key_matches_candidate "$target_key" "$candidate_key"; then
                 mark_skip_pair "$hash" "$candidate_hash"
                 break
             fi
@@ -415,7 +516,120 @@ detect_same_range_reverts() {
 commit_is_skipped() {
     local hash=$1
 
-    grep -Fxq "$hash" "$skip_file"
+    awk -v target="$hash" '
+        $1 == target || index($1, target) == 1 || index(target, $1) == 1 {
+            found = 1
+        }
+        END {
+            exit found ? 0 : 1
+        }
+    ' "$skip_file"
+}
+
+group_label() {
+    local group_key=$1
+
+    printf '%s' "${group_key#*:}"
+}
+
+aggregate_group_title() {
+    local commit_type=$1
+    local group_key=$2
+    local titles_file=$3
+    local title_count=$4
+    local label
+
+    if (( title_count <= 1 )); then
+        head -n 1 "$titles_file"
+        return
+    fi
+
+    label=$(group_label "$group_key")
+    case "$label" in
+        版本号)
+            printf '更新版本号'
+            return
+            ;;
+        Deb\ 构建配置)
+            printf '调整 Deb 构建配置'
+            return
+            ;;
+    esac
+
+    case "$commit_type" in
+        feat)
+            printf '新增%s相关功能' "$label"
+            ;;
+        fix)
+            printf '修正%s相关问题' "$label"
+            ;;
+        perf)
+            printf '优化%s运行表现' "$label"
+            ;;
+        refactor)
+            printf '整理%s相关逻辑' "$label"
+            ;;
+        docs)
+            printf '更新%s相关说明' "$label"
+            ;;
+        style)
+            printf '规范%s相关格式' "$label"
+            ;;
+        revert)
+            printf '回滚%s相关变更' "$label"
+            ;;
+        *)
+            printf '调整%s相关配置' "$label"
+            ;;
+    esac
+}
+
+append_grouped_entries_for_type() {
+    local commit_type=$1
+    local section_file=$2
+    local group_key
+    local title
+    local hash
+    local short_hash
+    local title_count
+    local hash_links
+    local summary_title
+    local titles_file
+
+    while IFS= read -r group_key; do
+        [[ -n "$group_key" ]] || continue
+
+        titles_file=$(mktemp)
+        hash_links=""
+        while IFS=$'\t' read -r title hash; do
+            [[ -n "$hash" ]] || continue
+            if ! grep -Fxq "$title" "$titles_file"; then
+                printf '%s\n' "$title" >> "$titles_file"
+            fi
+
+            short_hash=${hash:0:8}
+            if [[ -n "$hash_links" ]]; then
+                hash_links+=", "
+            fi
+            hash_links+="[\`${short_hash}\`](${server_url}/${repository}/commit/${hash})"
+        done < <(
+            awk -F $'\t' -v type="$commit_type" -v key="$group_key" '
+                $1 == type && $2 == key { print $3 "\t" $4 }
+            ' "$groups_file"
+        )
+
+        title_count=$(awk 'NF { count++ } END { print count + 0 }' "$titles_file")
+        summary_title=$(aggregate_group_title "$commit_type" "$group_key" "$titles_file" "$title_count")
+        rm -f "$titles_file"
+
+        if [[ -n "$summary_title" && -n "$hash_links" ]]; then
+            printf -- '- `%s` **%s** (%s)\n' "$commit_type" "$summary_title" "$hash_links" >> "$section_file"
+        fi
+    done < <(
+        awk -F $'\t' -v type="$commit_type" '
+            $1 == type && !seen[$2]++ { print $2 }
+        ' "$groups_file"
+    )
 }
 
 commit_touches_control() {
@@ -546,12 +760,21 @@ while IFS=$'\t' read -r hash subject commit_type; do
     fi
 
     relevant_count=$((relevant_count + 1))
-    short_hash=${hash:0:8}
     summary_title=$(summarize_commit_title "$hash" "$subject" "$commit_type")
-    entry="- \`${commit_type}\` **${summary_title}** ([\`${short_hash}\`](${server_url}/${repository}/commit/${hash}))"
-    printf '%s\n' "$entry" >> "$(section_file_for_type "$commit_type")"
+    group_key=$(summary_group_key "$hash" "$subject" "$commit_type" "$summary_title")
+    summary_title=$(printf '%s' "$summary_title" | tr '\t' ' ')
+    printf '%s\t%s\t%s\t%s\n' "$commit_type" "$group_key" "$summary_title" "$hash" >> "$groups_file"
     record_contributor_for_commit "$hash"
 done < "$records_file"
+
+append_grouped_entries_for_type "feat" "$feat_file"
+append_grouped_entries_for_type "fix" "$fix_file"
+append_grouped_entries_for_type "perf" "$perf_file"
+append_grouped_entries_for_type "refactor" "$refactor_file"
+append_grouped_entries_for_type "docs" "$docs_file"
+append_grouped_entries_for_type "style" "$style_file"
+append_grouped_entries_for_type "chore" "$chore_file"
+append_grouped_entries_for_type "revert" "$revert_file"
 
 cat > "$notes_file" <<EOF
 ## ${release_title} 更新日志

--- a/AwemeHeaders.h
+++ b/AwemeHeaders.h
@@ -746,7 +746,28 @@ typedef NS_ENUM(NSUInteger, DYEdgeMode) {
 @interface AWEProfileMixItemCollectionViewCell : UICollectionViewCell
 @end
 
+@interface AWEProfilePublishGuideCollectionViewCell : UICollectionViewCell
+@end
+
 @interface AWEProfileTaskCardStyleListCollectionViewCell : UIView
+@end
+
+@interface AWEUserProfileUGCContributionGuideCollectionViewCell : UICollectionViewCell
+@end
+
+@interface AWEUserProfileUGCContributionGuideEmptyCollectionViewCell : UICollectionViewCell
+@end
+
+@interface AWEUserProfileUGCHeaderContributionGuideBannerSectionCell : UICollectionViewCell
+@end
+
+@interface AWEUserProfileUGCHeaderContributionGuideBannerSectionController : NSObject
+@end
+
+@interface AWEUserProfileUGCHeaderContributionGuideBannerSectionViewModel : NSObject
+@end
+
+@interface AWEUserProfileUGCTaskCardStyleListCollectionViewCell : UICollectionViewCell
 @end
 
 @interface AWEProfileUserDetailComponent : NSObject

--- a/DYYY.xm
+++ b/DYYY.xm
@@ -1073,10 +1073,110 @@ static void DYYYHandleCurrentSpeedAwemeChanged(id aweme) {
 %end
 
 // 抖音 39.1.0 访问他人主页时会由详情组件直接上传访客记录
+static NSString *const kDYYYDisableProfileVisitRecordUploadKey = @"DYYYDisableProfileVisitRecordUpload";
+static NSString *const kDYYYProfileVisitRecordUploadPath = @"/aweme/v1/profile/record/";
+
+static BOOL DYYYShouldBlockProfileVisitRecordUpload(void) {
+    return DYYYGetBool(kDYYYDisableProfileVisitRecordUploadKey);
+}
+
+static id DYYYProfileVisitRecordValueForSelector(id object, SEL selector) {
+    if (!object || !selector || ![object respondsToSelector:selector]) {
+        return nil;
+    }
+
+    @try {
+        return ((id (*)(id, SEL))objc_msgSend)(object, selector);
+    } @catch (__unused NSException *exception) {
+        return nil;
+    }
+}
+
+static NSString *DYYYProfileVisitRecordURLStringFromObject(id object, NSUInteger depth) {
+    if (!object || depth > 3) {
+        return nil;
+    }
+
+    if ([object isKindOfClass:NSString.class]) {
+        return (NSString *)object;
+    }
+
+    if ([object isKindOfClass:NSURL.class]) {
+        return [(NSURL *)object absoluteString];
+    }
+
+    if ([object isKindOfClass:NSURLRequest.class]) {
+        return ((NSURLRequest *)object).URL.absoluteString;
+    }
+
+    SEL selectors[] = {
+        @selector(URL),
+        @selector(url),
+        @selector(requestURL),
+        @selector(requestUrl),
+        @selector(requestUrlString),
+        @selector(URLString),
+        @selector(urlString),
+        @selector(absoluteString),
+        @selector(request)
+    };
+
+    for (NSUInteger idx = 0; idx < sizeof(selectors) / sizeof(selectors[0]); idx++) {
+        id value = DYYYProfileVisitRecordValueForSelector(object, selectors[idx]);
+        if (!value || value == object) {
+            continue;
+        }
+
+        NSString *urlString = DYYYProfileVisitRecordURLStringFromObject(value, depth + 1);
+        if (urlString.length > 0) {
+            return urlString;
+        }
+    }
+
+    return nil;
+}
+
+static BOOL DYYYIsProfileVisitRecordUploadURLString(NSString *urlString) {
+    if (![urlString isKindOfClass:NSString.class] || urlString.length == 0) {
+        return NO;
+    }
+
+    if ([urlString isEqualToString:kDYYYProfileVisitRecordUploadPath]) {
+        return YES;
+    }
+
+    if ([urlString containsString:kDYYYProfileVisitRecordUploadPath]) {
+        NSURLComponents *components = [NSURLComponents componentsWithString:urlString];
+        NSString *path = components.path;
+        if (path.length > 0) {
+            return [path isEqualToString:kDYYYProfileVisitRecordUploadPath];
+        }
+
+        return [urlString containsString:kDYYYProfileVisitRecordUploadPath];
+    }
+
+    return NO;
+}
+
+static BOOL DYYYShouldBlockProfileVisitRecordRequestObject(id requestObject) {
+    if (!DYYYShouldBlockProfileVisitRecordUpload()) {
+        return NO;
+    }
+
+    NSString *urlString = DYYYProfileVisitRecordURLStringFromObject(requestObject, 0);
+    return DYYYIsProfileVisitRecordUploadURLString(urlString);
+}
+
+static NSError *DYYYProfileVisitRecordBlockedError(void) {
+    return [NSError errorWithDomain:@"DYYY.ProfileVisitRecordUpload"
+                               code:NSURLErrorCancelled
+                           userInfo:@{NSLocalizedDescriptionKey : @"DYYY blocked profile visit record upload"}];
+}
+
 %hook AWEProfileUserDetailComponent
 
 - (void)reportUserDetailVisitIfNeeded:(id)user {
-    if (DYYYGetBool(@"DYYYDisableProfileVisitRecordUpload")) {
+    if (DYYYShouldBlockProfileVisitRecordUpload()) {
         return;
     }
 
@@ -1088,12 +1188,148 @@ static void DYYYHandleCurrentSpeedAwemeChanged(id aweme) {
 // 兼容旧版访客记录上传路径
 %hook AWEProfileRecordHelper
 
-+ (void)postProfileRecordWithParams:(id)params completionBlock:(id)completionBlock {
-    if (DYYYGetBool(@"DYYYDisableProfileVisitRecordUpload")) {
++ (void)postProfileRecordWithParams:(id)params {
+    if (DYYYShouldBlockProfileVisitRecordUpload()) {
         return;
     }
 
     %orig;
+}
+
++ (void)postProfileRecordWithParams:(id)params completionBlock:(id)completionBlock {
+    if (DYYYShouldBlockProfileVisitRecordUpload()) {
+        return;
+    }
+
+    %orig;
+}
+
++ (void)postProfileRecordWithKey:(id)key valueDic:(id)valueDic {
+    if (DYYYShouldBlockProfileVisitRecordUpload()) {
+        return;
+    }
+
+    %orig;
+}
+
++ (void)postProfileRecordWithKey:(id)key valueDic:(id)valueDic completionBlock:(id)completionBlock {
+    if (DYYYShouldBlockProfileVisitRecordUpload()) {
+        return;
+    }
+
+    %orig;
+}
+
+%end
+
+%hook TTHttpTask
+
+- (void)resume {
+    if (DYYYShouldBlockProfileVisitRecordRequestObject(self)) {
+        return;
+    }
+
+    %orig;
+}
+
+%end
+
+%hook TTHttpTaskChromium
+
+- (void)runRequestFiltersAndStart {
+    if (DYYYShouldBlockProfileVisitRecordRequestObject(self)) {
+        return;
+    }
+
+    %orig;
+}
+
+- (void)resume {
+    if (DYYYShouldBlockProfileVisitRecordRequestObject(self)) {
+        return;
+    }
+
+    %orig;
+}
+
+%end
+
+%hook NSURLSession
+
+- (NSURLSessionDataTask *)dataTaskWithURL:(NSURL *)url {
+    if (DYYYShouldBlockProfileVisitRecordRequestObject(url)) {
+        return nil;
+    }
+
+    return %orig;
+}
+
+- (NSURLSessionDataTask *)dataTaskWithURL:(NSURL *)url completionHandler:(void (^)(NSData *data, NSURLResponse *response, NSError *error))completionHandler {
+    if (DYYYShouldBlockProfileVisitRecordRequestObject(url)) {
+        if (completionHandler) {
+            completionHandler(nil, nil, DYYYProfileVisitRecordBlockedError());
+        }
+        return nil;
+    }
+
+    return %orig;
+}
+
+- (NSURLSessionDataTask *)dataTaskWithRequest:(NSURLRequest *)request {
+    if (DYYYShouldBlockProfileVisitRecordRequestObject(request)) {
+        return nil;
+    }
+
+    return %orig;
+}
+
+- (NSURLSessionDataTask *)dataTaskWithRequest:(NSURLRequest *)request completionHandler:(void (^)(NSData *data, NSURLResponse *response, NSError *error))completionHandler {
+    if (DYYYShouldBlockProfileVisitRecordRequestObject(request)) {
+        if (completionHandler) {
+            completionHandler(nil, nil, DYYYProfileVisitRecordBlockedError());
+        }
+        return nil;
+    }
+
+    return %orig;
+}
+
+- (NSURLSessionUploadTask *)uploadTaskWithRequest:(NSURLRequest *)request fromData:(NSData *)bodyData {
+    if (DYYYShouldBlockProfileVisitRecordRequestObject(request)) {
+        return nil;
+    }
+
+    return %orig;
+}
+
+- (NSURLSessionUploadTask *)uploadTaskWithRequest:(NSURLRequest *)request fromData:(NSData *)bodyData completionHandler:(void (^)(NSData *data, NSURLResponse *response, NSError *error))completionHandler {
+    if (DYYYShouldBlockProfileVisitRecordRequestObject(request)) {
+        if (completionHandler) {
+            completionHandler(nil, nil, DYYYProfileVisitRecordBlockedError());
+        }
+        return nil;
+    }
+
+    return %orig;
+}
+
+- (NSURLSessionUploadTask *)uploadTaskWithRequest:(NSURLRequest *)request fromFile:(NSURL *)fileURL {
+    if (DYYYShouldBlockProfileVisitRecordRequestObject(request)) {
+        return nil;
+    }
+
+    return %orig;
+}
+
+- (NSURLSessionUploadTask *)uploadTaskWithRequest:(NSURLRequest *)request fromFile:(NSURL *)fileURL completionHandler:(void (^)(NSData *data, NSURLResponse *response, NSError *error))completionHandler {
+    if (DYYYShouldBlockProfileVisitRecordRequestObject(request)) {
+        if (completionHandler) {
+            completionHandler(nil, nil, DYYYProfileVisitRecordBlockedError());
+        }
+        return nil;
+    }
+
+    return %orig;
 }
 
 %end

--- a/DYYY.xm
+++ b/DYYY.xm
@@ -13,6 +13,7 @@
 #import <math.h>
 #import <objc/message.h>
 #import <objc/runtime.h>
+#import <stdlib.h>
 #import <substrate.h>
 #import <syslog.h>
 
@@ -619,7 +620,9 @@ static NSString *dyyyLastAutoRestoredSpeedAwemeIdentifier = nil;
 static BOOL dyyyLongPressFastSpeedActive = NO;
 static BOOL dyyyLongPressLockedSpeedActive = NO;
 static __weak id dyyyCommentPausePlaybackTarget = nil;
+static __weak UIViewController *dyyyCommentPausePlaybackController = nil;
 static BOOL dyyyCommentPausePlaybackActive = NO;
+static NSUInteger dyyyCommentPausePlaybackRestoreGeneration = 0;
 
 static void DYYYClearLongPressSpeedState(void) {
     dyyyLongPressFastSpeedActive = NO;
@@ -931,8 +934,7 @@ static BOOL DYYYApplyPlaybackSpeedToVisiblePlayer(double speed) {
 static BOOL DYYYPlaybackTargetSupportsPlayPause(id target) {
     return target &&
            [target respondsToSelector:@selector(play)] &&
-           [target respondsToSelector:@selector(pause)] &&
-           [target respondsToSelector:@selector(isPlaying)];
+           [target respondsToSelector:@selector(pause)];
 }
 
 static id DYYYObjectReturnedBySelector(id object, SEL selector) {
@@ -948,35 +950,128 @@ static id DYYYObjectReturnedBySelector(id object, SEL selector) {
     }
 }
 
-static id DYYYPlaybackControlTargetFromObject(id object) {
-    if (DYYYPlaybackTargetSupportsPlayPause(object)) {
-        return object;
+static char DYYYMethodReturnTypePrefix(id object, SEL selector) {
+    if (!object || !selector) {
+        return '\0';
     }
+
+    Method method = class_getInstanceMethod([object class], selector);
+    if (!method) {
+        return '\0';
+    }
+
+    char *returnType = method_copyReturnType(method);
+    if (!returnType) {
+        return '\0';
+    }
+
+    char prefix = returnType[0];
+    free(returnType);
+    return prefix;
+}
+
+static BOOL DYYYBoolValueReturnedBySelector(id object, SEL selector, BOOL *value) {
+    if (!object || ![object respondsToSelector:selector]) {
+        return NO;
+    }
+
+    char returnType = DYYYMethodReturnTypePrefix(object, selector);
+    if (returnType != 'B' && returnType != 'c' && returnType != 'C') {
+        return NO;
+    }
+
+    @try {
+        BOOL (*messageSend)(id, SEL) = (BOOL (*)(id, SEL))objc_msgSend;
+        if (value) {
+            *value = messageSend(object, selector);
+        }
+        return YES;
+    } @catch (NSException *exception) {
+        return NO;
+    }
+}
+
+static BOOL DYYYFloatValueReturnedBySelector(id object, SEL selector, float *value) {
+    if (!object || ![object respondsToSelector:selector]) {
+        return NO;
+    }
+
+    char returnType = DYYYMethodReturnTypePrefix(object, selector);
+    if (returnType != 'f' && returnType != 'd') {
+        return NO;
+    }
+
+    @try {
+        float floatValue = 0.0f;
+        if (returnType == 'd') {
+            double (*messageSend)(id, SEL) = (double (*)(id, SEL))objc_msgSend;
+            floatValue = (float)messageSend(object, selector);
+        } else {
+            float (*messageSend)(id, SEL) = (float (*)(id, SEL))objc_msgSend;
+            floatValue = messageSend(object, selector);
+        }
+
+        if (value) {
+            *value = floatValue;
+        }
+        return YES;
+    } @catch (NSException *exception) {
+        return NO;
+    }
+}
+
+static void DYYYAddPlaybackCandidate(NSMutableArray *candidates, id candidate) {
+    if (!candidate || candidates.count >= 32) {
+        return;
+    }
+
+    for (id existingCandidate in candidates) {
+        if (existingCandidate == candidate) {
+            return;
+        }
+    }
+
+    [candidates addObject:candidate];
+}
+
+static NSArray *DYYYPlaybackCandidatesFromObject(id object) {
+    NSMutableArray *candidates = [NSMutableArray array];
+    DYYYAddPlaybackCandidate(candidates, object);
 
     SEL directSelectors[] = {
         @selector(playVideoViewController),
         @selector(playerViewController),
         @selector(videoDelegate),
         @selector(player),
+        NSSelectorFromString(@"playerController"),
+        NSSelectorFromString(@"playbackController"),
+        NSSelectorFromString(@"playerManager"),
+        NSSelectorFromString(@"playerAdapter"),
+        NSSelectorFromString(@"playbackEngine"),
+        NSSelectorFromString(@"avPlayer"),
     };
 
-    for (NSUInteger i = 0; i < sizeof(directSelectors) / sizeof(SEL); i++) {
-        id candidate = DYYYObjectReturnedBySelector(object, directSelectors[i]);
+    for (NSUInteger index = 0; index < candidates.count; index++) {
+        id current = candidates[index];
+        for (NSUInteger i = 0; i < sizeof(directSelectors) / sizeof(SEL); i++) {
+            DYYYAddPlaybackCandidate(candidates, DYYYObjectReturnedBySelector(current, directSelectors[i]));
+        }
+    }
+
+    return candidates;
+}
+
+static id DYYYPlaybackControlTargetFromObject(id object) {
+    for (id candidate in DYYYPlaybackCandidatesFromObject(object)) {
         if (DYYYPlaybackTargetSupportsPlayPause(candidate)) {
             return candidate;
-        }
-
-        id nestedPlayer = DYYYObjectReturnedBySelector(candidate, @selector(player));
-        if (DYYYPlaybackTargetSupportsPlayPause(nestedPlayer)) {
-            return nestedPlayer;
         }
     }
 
     return nil;
 }
 
-static id DYYYResolveCommentPausePlaybackTarget(void) {
-    AWEPlayInteractionViewController *interactionController = DYYYResolveCurrentSpeedInteractionController(nil);
+static id DYYYResolveCommentPausePlaybackTarget(AWEPlayInteractionViewController *interactionController) {
     Protocol *speedControllerProtocol = NSProtocolFromString(@"AWEFastSpeedControllerProtocol");
     if (interactionController && speedControllerProtocol && [interactionController respondsToSelector:@selector(controllerByProtocol:)]) {
         @try {
@@ -994,24 +1089,74 @@ static id DYYYResolveCommentPausePlaybackTarget(void) {
         return target;
     }
 
+    target = DYYYPlaybackControlTargetFromObject(dyyyActiveSpeedPlayerViewController);
+    if (target) {
+        return target;
+    }
+
     target = DYYYPlaybackControlTargetFromObject(DYYYBestVisiblePlaybackRateTarget(nil));
     return target;
 }
 
 static BOOL DYYYPlaybackTargetIsPlaying(id target, BOOL *isPlaying) {
-    if (!target || ![target respondsToSelector:@selector(isPlaying)]) {
+    if (!target) {
         return NO;
     }
 
-    @try {
-        BOOL (*messageSend)(id, SEL) = (BOOL (*)(id, SEL))objc_msgSend;
-        if (isPlaying) {
-            *isPlaying = messageSend(target, @selector(isPlaying));
+    SEL playingSelectors[] = {
+        @selector(isPlaying),
+        NSSelectorFromString(@"playing"),
+        NSSelectorFromString(@"isVideoPlaying"),
+        NSSelectorFromString(@"isPlayerPlaying"),
+    };
+
+    for (NSUInteger i = 0; i < sizeof(playingSelectors) / sizeof(SEL); i++) {
+        if (DYYYBoolValueReturnedBySelector(target, playingSelectors[i], isPlaying)) {
+            return YES;
         }
-        return YES;
-    } @catch (NSException *exception) {
-        return NO;
     }
+
+    SEL pausedSelectors[] = {
+        NSSelectorFromString(@"isPaused"),
+        NSSelectorFromString(@"paused"),
+    };
+
+    for (NSUInteger i = 0; i < sizeof(pausedSelectors) / sizeof(SEL); i++) {
+        BOOL isPaused = NO;
+        if (DYYYBoolValueReturnedBySelector(target, pausedSelectors[i], &isPaused)) {
+            if (isPlaying) {
+                *isPlaying = !isPaused;
+            }
+            return YES;
+        }
+    }
+
+    SEL rateSelectors[] = {
+        NSSelectorFromString(@"rate"),
+        NSSelectorFromString(@"playbackRate"),
+    };
+
+    for (NSUInteger i = 0; i < sizeof(rateSelectors) / sizeof(SEL); i++) {
+        float rate = 0.0f;
+        if (DYYYFloatValueReturnedBySelector(target, rateSelectors[i], &rate)) {
+            if (isPlaying) {
+                *isPlaying = fabsf(rate) > FLT_EPSILON;
+            }
+            return YES;
+        }
+    }
+
+    return NO;
+}
+
+static BOOL DYYYPlaybackObjectIsPlaying(id object, BOOL *isPlaying) {
+    for (id candidate in DYYYPlaybackCandidatesFromObject(object)) {
+        if (DYYYPlaybackTargetIsPlaying(candidate, isPlaying)) {
+            return YES;
+        }
+    }
+
+    return NO;
 }
 
 static BOOL DYYYSendPlaybackControl(id target, SEL selector) {
@@ -1028,6 +1173,44 @@ static BOOL DYYYSendPlaybackControl(id target, SEL selector) {
     }
 }
 
+static BOOL DYYYSendFirstPlaybackControl(id target, SEL *selectors, NSUInteger count) {
+    for (NSUInteger i = 0; i < count; i++) {
+        if (DYYYSendPlaybackControl(target, selectors[i])) {
+            return YES;
+        }
+    }
+
+    return NO;
+}
+
+static BOOL DYYYSendOfficialCommentPauseIfPossible(id target) {
+    SEL selectors[] = {
+        NSSelectorFromString(@"pauseVideoIfPlayingWithoutShowingPauseIcon"),
+        NSSelectorFromString(@"pauseVideoIfPlaying"),
+    };
+
+    return DYYYSendFirstPlaybackControl(target, selectors, sizeof(selectors) / sizeof(SEL));
+}
+
+static BOOL DYYYSendPauseToPlaybackTarget(id target) {
+    SEL selectors[] = {
+        @selector(pause),
+        NSSelectorFromString(@"pauseVideo"),
+    };
+
+    return DYYYSendFirstPlaybackControl(target, selectors, sizeof(selectors) / sizeof(SEL));
+}
+
+static BOOL DYYYSendPlayToPlaybackTarget(id target) {
+    SEL selectors[] = {
+        @selector(play),
+        NSSelectorFromString(@"playVideo"),
+        NSSelectorFromString(@"resumeVideo"),
+    };
+
+    return DYYYSendFirstPlaybackControl(target, selectors, sizeof(selectors) / sizeof(SEL));
+}
+
 static BOOL DYYYPlaybackTargetIsVisible(id target) {
     if ([target isKindOfClass:[UIViewController class]]) {
         return DYYYViewControllerVisibilityScore((UIViewController *)target) >= 0.0;
@@ -1039,19 +1222,45 @@ static BOOL DYYYPlaybackTargetIsVisible(id target) {
     return target != nil;
 }
 
+static BOOL DYYYCommentPausePlaybackStateIsPlaying(id target, AWEPlayInteractionViewController *interactionController, BOOL *isPlaying) {
+    if (DYYYPlaybackObjectIsPlaying(target, isPlaying)) {
+        return YES;
+    }
+
+    if (DYYYPlaybackObjectIsPlaying(interactionController, isPlaying)) {
+        return YES;
+    }
+
+    if (DYYYPlaybackObjectIsPlaying(dyyyActiveSpeedPlayerViewController, isPlaying)) {
+        return YES;
+    }
+
+    return DYYYPlaybackObjectIsPlaying(DYYYBestVisiblePlaybackRateTarget(nil), isPlaying);
+}
+
 static void DYYYCommentPausePlaybackIfNeeded(void) {
     if (!DYYYGetBool(@"DYYYCommentPausePlayback") || dyyyCommentPausePlaybackActive) {
         return;
     }
 
-    id target = DYYYResolveCommentPausePlaybackTarget();
+    dyyyCommentPausePlaybackRestoreGeneration++;
+    AWEPlayInteractionViewController *interactionController = (AWEPlayInteractionViewController *)DYYYCurrentSpeedInteractionController();
+    id target = DYYYResolveCommentPausePlaybackTarget(interactionController);
     BOOL isPlaying = NO;
-    if (!DYYYPlaybackTargetIsPlaying(target, &isPlaying) || !isPlaying) {
+    if (!DYYYCommentPausePlaybackStateIsPlaying(target, interactionController, &isPlaying) || !isPlaying) {
         return;
     }
 
-    if (DYYYSendPlaybackControl(target, @selector(pause))) {
-        dyyyCommentPausePlaybackTarget = target;
+    BOOL didPause = DYYYSendOfficialCommentPauseIfPossible(interactionController);
+    if (!didPause) {
+        didPause = DYYYSendPauseToPlaybackTarget(target);
+    }
+    if (!didPause && target != interactionController) {
+        didPause = DYYYSendPauseToPlaybackTarget(interactionController);
+    }
+
+    if (didPause) {
+        dyyyCommentPausePlaybackTarget = target ?: interactionController ?: DYYYBestVisiblePlaybackRateTarget(nil);
         dyyyCommentPausePlaybackActive = YES;
     }
 }
@@ -1064,17 +1273,140 @@ static void DYYYCommentRestorePlaybackIfNeeded(void) {
     id target = dyyyCommentPausePlaybackTarget;
     dyyyCommentPausePlaybackActive = NO;
     dyyyCommentPausePlaybackTarget = nil;
+    dyyyCommentPausePlaybackController = nil;
+    dyyyCommentPausePlaybackRestoreGeneration++;
 
     if (!target || !DYYYPlaybackTargetIsVisible(target)) {
-        return;
+        target = DYYYResolveCommentPausePlaybackTarget((AWEPlayInteractionViewController *)DYYYCurrentSpeedInteractionController());
+        if (!target || !DYYYPlaybackTargetIsVisible(target)) {
+            return;
+        }
     }
 
     BOOL isPlaying = NO;
-    if (DYYYPlaybackTargetIsPlaying(target, &isPlaying) && isPlaying) {
+    if (DYYYPlaybackObjectIsPlaying(target, &isPlaying) && isPlaying) {
         return;
     }
 
-    DYYYSendPlaybackControl(target, @selector(play));
+    DYYYSendPlayToPlaybackTarget(target);
+}
+
+static BOOL DYYYCommentPausePlaybackClassNameIsPreview(NSString *className) {
+    if (className.length == 0) {
+        return NO;
+    }
+
+    static NSArray<NSString *> *previewClassNameFragments = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+      previewClassNameFragments = @[
+          @"CommentMediaFeed",
+          @"CommentMedia",
+          @"CommentImagePreview",
+          @"CommentImage",
+          @"CommentCellSticker",
+          @"CommentSticker",
+          @"CommentEmoji",
+          @"CommentEmoticon",
+          @"EmoticonPreview",
+          @"EmojiPreview",
+          @"AWEIMEmoticon",
+          @"AWEIMEmoji"
+      ];
+    });
+
+    for (NSString *fragment in previewClassNameFragments) {
+        if ([className containsString:fragment]) {
+            return YES;
+        }
+    }
+
+    return NO;
+}
+
+static BOOL DYYYCommentPausePlaybackViewControllerTreeIsPreview(UIViewController *viewController, NSUInteger depth) {
+    if (!viewController || depth > 8) {
+        return NO;
+    }
+
+    if (DYYYCommentPausePlaybackClassNameIsPreview(NSStringFromClass([viewController class]))) {
+        return YES;
+    }
+
+    if ([viewController isKindOfClass:[UINavigationController class]]) {
+        UINavigationController *navigationController = (UINavigationController *)viewController;
+        if (DYYYCommentPausePlaybackViewControllerTreeIsPreview(navigationController.visibleViewController ?: navigationController.topViewController, depth + 1)) {
+            return YES;
+        }
+    } else if ([viewController isKindOfClass:[UITabBarController class]]) {
+        if (DYYYCommentPausePlaybackViewControllerTreeIsPreview(((UITabBarController *)viewController).selectedViewController, depth + 1)) {
+            return YES;
+        }
+    }
+
+    for (UIViewController *childViewController in viewController.childViewControllers) {
+        if (DYYYCommentPausePlaybackViewControllerTreeIsPreview(childViewController, depth + 1)) {
+            return YES;
+        }
+    }
+
+    return DYYYCommentPausePlaybackViewControllerTreeIsPreview(viewController.presentedViewController, depth + 1);
+}
+
+static BOOL DYYYCommentPausePlaybackShouldDeferRestore(UIViewController *commentViewController) {
+    if (!commentViewController || commentViewController.isBeingDismissed) {
+        return NO;
+    }
+
+    UINavigationController *navigationController = commentViewController.navigationController;
+    if (navigationController && navigationController.view.window && !navigationController.isBeingDismissed) {
+        UIViewController *topViewController = navigationController.visibleViewController ?: navigationController.topViewController;
+        if (topViewController && topViewController != commentViewController) {
+            return YES;
+        }
+
+        UIViewController *presentedViewController = navigationController.presentedViewController;
+        if (presentedViewController && !presentedViewController.isBeingDismissed) {
+            return YES;
+        }
+    }
+
+    UIViewController *presentedViewController = commentViewController.presentedViewController;
+    if (presentedViewController && !presentedViewController.isBeingDismissed) {
+        return YES;
+    }
+
+    UIViewController *topViewController = [DYYYUtils topView];
+    return topViewController &&
+           topViewController != commentViewController &&
+           DYYYCommentPausePlaybackViewControllerTreeIsPreview(topViewController, 0);
+}
+
+static void DYYYQueueCommentRestorePlaybackCheck(UIViewController *commentViewController, NSUInteger generation, NSTimeInterval delay) {
+    __weak UIViewController *weakCommentViewController = commentViewController;
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delay * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+      if (generation != dyyyCommentPausePlaybackRestoreGeneration || !dyyyCommentPausePlaybackActive) {
+          return;
+      }
+
+      UIViewController *strongCommentViewController = weakCommentViewController;
+      if (strongCommentViewController && DYYYCommentPausePlaybackShouldDeferRestore(strongCommentViewController)) {
+          DYYYQueueCommentRestorePlaybackCheck(strongCommentViewController, generation, 0.5);
+          return;
+      }
+
+      DYYYCommentRestorePlaybackIfNeeded();
+    });
+}
+
+static void DYYYScheduleCommentRestorePlaybackIfNeeded(UIViewController *commentViewController) {
+    if (!dyyyCommentPausePlaybackActive) {
+        return;
+    }
+
+    dyyyCommentPausePlaybackController = commentViewController;
+    dyyyCommentPausePlaybackRestoreGeneration++;
+    DYYYQueueCommentRestorePlaybackCheck(commentViewController, dyyyCommentPausePlaybackRestoreGeneration, 0.2);
 }
 
 static double DYYYConfiguredPlaybackSpeed(void) {
@@ -12843,6 +13175,8 @@ static Class tabBarButtonClass = nil;
 - (void)viewDidAppear:(BOOL)animated {
     %orig;
     dyyyCommentViewVisible = YES;
+    dyyyCommentPausePlaybackController = self;
+    dyyyCommentPausePlaybackRestoreGeneration++;
     updateSpeedButtonVisibility();
     updateClearButtonVisibility();
     DYYYCommentPausePlaybackIfNeeded();
@@ -12869,7 +13203,7 @@ static Class tabBarButtonClass = nil;
     dyyyCommentViewVisible = NO;
     updateSpeedButtonVisibility();
     updateClearButtonVisibility();
-    DYYYCommentRestorePlaybackIfNeeded();
+    DYYYScheduleCommentRestorePlaybackIfNeeded(self);
 }
 
 - (void)viewDidLayoutSubviews {

--- a/DYYY.xm
+++ b/DYYY.xm
@@ -6421,6 +6421,42 @@ static const void *kDYYYLiveDurationRoomKey = &kDYYYLiveDurationRoomKey;
 static NSString *const kDYYYLiveDurationCenterXPercentKey = @"DYYYLiveDurationCenterXPercent";
 static NSString *const kDYYYLiveDurationCenterYPercentKey = @"DYYYLiveDurationCenterYPercent";
 static NSString *const kDYYYLiveDurationPositionLockedKey = @"DYYYLiveDurationPositionLocked";
+static BOOL dyyyLiveDurationOfficialClearScreenActive = NO;
+
+static void DYYYLiveDurationUpdateView(UIView *root);
+static void DYYYLiveDurationSetOfficialClearScreenActive(BOOL active);
+
+static NSHashTable<UIView *> *DYYYLiveDurationTrackedRoots(void) {
+    static NSHashTable<UIView *> *trackedRoots = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+      trackedRoots = [NSHashTable weakObjectsHashTable];
+    });
+    return trackedRoots;
+}
+
+static void DYYYLiveDurationTrackRoot(UIView *root) {
+    if (!root) {
+        return;
+    }
+    [DYYYLiveDurationTrackedRoots() addObject:root];
+}
+
+static void DYYYLiveDurationUntrackRoot(UIView *root) {
+    if (!root) {
+        return;
+    }
+
+    NSHashTable<UIView *> *trackedRoots = DYYYLiveDurationTrackedRoots();
+    [trackedRoots removeObject:root];
+    if (trackedRoots.count == 0) {
+        dyyyLiveDurationOfficialClearScreenActive = NO;
+    }
+}
+
+static BOOL DYYYLiveDurationOfficialClearScreenActive(void) {
+    return dyyyLiveDurationOfficialClearScreenActive;
+}
 
 static UIEdgeInsets DYYYLiveDurationSafeInsets(UIView *root) {
     return [root respondsToSelector:@selector(safeAreaInsets)] ? root.safeAreaInsets : UIEdgeInsetsZero;
@@ -6577,6 +6613,33 @@ static CGPoint DYYYLiveDurationClampedCenter(CGPoint center, CGSize viewSize, UI
 }
 
 @end
+
+static void DYYYLiveDurationSetOfficialClearScreenActive(BOOL active) {
+    void (^applyBlock)(void) = ^{
+      dyyyLiveDurationOfficialClearScreenActive = active;
+      NSArray<UIView *> *roots = [[DYYYLiveDurationTrackedRoots() allObjects] copy];
+      for (UIView *root in roots) {
+          if (!root.window) {
+              DYYYLiveDurationUntrackRoot(root);
+              continue;
+          }
+
+          DYYYLiveDurationView *durationView = objc_getAssociatedObject(root, kDYYYLiveDurationViewKey);
+          if (active) {
+              durationView.dragging = NO;
+              durationView.hidden = YES;
+          } else {
+              DYYYLiveDurationUpdateView(root);
+          }
+      }
+    };
+
+    if ([NSThread isMainThread]) {
+        applyBlock();
+    } else {
+        dispatch_async(dispatch_get_main_queue(), applyBlock);
+    }
+}
 
 static id DYYYLiveDurationSafeValue(id obj, NSString *key) {
     if (!obj || key.length == 0) {
@@ -6811,6 +6874,7 @@ static void DYYYLiveDurationRemoveFromView(UIView *root) {
     [durationView removeFromSuperview];
     objc_setAssociatedObject(root, kDYYYLiveDurationViewKey, nil, OBJC_ASSOCIATION_ASSIGN);
     objc_setAssociatedObject(root, kDYYYLiveDurationRoomKey, nil, OBJC_ASSOCIATION_ASSIGN);
+    DYYYLiveDurationUntrackRoot(root);
 }
 
 static void DYYYLiveDurationUpdateView(UIView *root) {
@@ -6826,6 +6890,12 @@ static void DYYYLiveDurationUpdateView(UIView *root) {
     id roomModel = objc_getAssociatedObject(root, kDYYYLiveDurationRoomKey);
     NSTimeInterval elapsed = DYYYLiveDurationElapsedSeconds(roomModel);
     DYYYLiveDurationView *durationView = objc_getAssociatedObject(root, kDYYYLiveDurationViewKey);
+    if (DYYYLiveDurationOfficialClearScreenActive()) {
+        durationView.dragging = NO;
+        durationView.hidden = YES;
+        return;
+    }
+
     if (elapsed < 0.0) {
         durationView.hidden = YES;
         return;
@@ -6898,6 +6968,8 @@ static void DYYYLiveDurationInstallOnView(UIView *root, id carrier) {
           DYYYLiveDurationRemoveFromView(root);
           return;
       }
+
+      DYYYLiveDurationTrackRoot(root);
 
       id room = DYYYLiveDurationRoomFromCarrier(carrier);
       if (!DYYYLiveDurationHasValidLiveTime(room)) {
@@ -7133,6 +7205,54 @@ static void DYYYLiveDurationInstallFromInnerFeedCell(id cell) {
         DYYYLiveDurationRemoveFromView(viewController.view);
     }
     %orig;
+}
+
+%end
+
+%hook IESLiveCleanScreenNormalAbility
+
+- (void)switchToCleanScreenModeWithOffset:(double)offset duration:(double)duration completion:(id)completion {
+    DYYYLiveDurationSetOfficialClearScreenActive(YES);
+    %orig;
+}
+
+- (void)p_switchToCleanScreenModeWithOffset:(double)offset duration:(double)duration completion:(id)completion {
+    DYYYLiveDurationSetOfficialClearScreenActive(YES);
+    %orig;
+}
+
+- (void)p_prepareCleanScreenWithMode:(long long)mode type:(long long)type {
+    DYYYLiveDurationSetOfficialClearScreenActive(YES);
+    %orig;
+}
+
+- (void)exitCleanScreenIfNeed {
+    %orig;
+    DYYYLiveDurationSetOfficialClearScreenActive(NO);
+}
+
+- (void)p_exitCleanScreenWithType:(long long)type duration:(double)duration {
+    %orig;
+    DYYYLiveDurationSetOfficialClearScreenActive(NO);
+}
+
+- (void)p_exitCleanScreenWithType:(long long)type {
+    %orig;
+    DYYYLiveDurationSetOfficialClearScreenActive(NO);
+}
+
+%end
+
+%hook IESLiveClearScreenServiceImpl
+
+- (void)switchToCleanScreenModeWithOffset:(double)offset duration:(double)duration completion:(id)completion {
+    DYYYLiveDurationSetOfficialClearScreenActive(YES);
+    %orig;
+}
+
+- (void)exitCleanScreenIfNeed {
+    %orig;
+    DYYYLiveDurationSetOfficialClearScreenActive(NO);
 }
 
 %end

--- a/DYYY.xm
+++ b/DYYY.xm
@@ -13,7 +13,6 @@
 #import <math.h>
 #import <objc/message.h>
 #import <objc/runtime.h>
-#import <stdlib.h>
 #import <substrate.h>
 #import <syslog.h>
 
@@ -621,9 +620,7 @@ static NSString *dyyyLastAutoRestoredSpeedAwemeIdentifier = nil;
 static BOOL dyyyLongPressFastSpeedActive = NO;
 static BOOL dyyyLongPressLockedSpeedActive = NO;
 static __weak id dyyyCommentPausePlaybackTarget = nil;
-static __weak UIViewController *dyyyCommentPausePlaybackController = nil;
 static BOOL dyyyCommentPausePlaybackActive = NO;
-static NSUInteger dyyyCommentPausePlaybackRestoreGeneration = 0;
 
 static void DYYYClearLongPressSpeedState(void) {
     dyyyLongPressFastSpeedActive = NO;
@@ -935,7 +932,8 @@ static BOOL DYYYApplyPlaybackSpeedToVisiblePlayer(double speed) {
 static BOOL DYYYPlaybackTargetSupportsPlayPause(id target) {
     return target &&
            [target respondsToSelector:@selector(play)] &&
-           [target respondsToSelector:@selector(pause)];
+           [target respondsToSelector:@selector(pause)] &&
+           [target respondsToSelector:@selector(isPlaying)];
 }
 
 static id DYYYObjectReturnedBySelector(id object, SEL selector) {
@@ -951,128 +949,35 @@ static id DYYYObjectReturnedBySelector(id object, SEL selector) {
     }
 }
 
-static char DYYYMethodReturnTypePrefix(id object, SEL selector) {
-    if (!object || !selector) {
-        return '\0';
+static id DYYYPlaybackControlTargetFromObject(id object) {
+    if (DYYYPlaybackTargetSupportsPlayPause(object)) {
+        return object;
     }
-
-    Method method = class_getInstanceMethod([object class], selector);
-    if (!method) {
-        return '\0';
-    }
-
-    char *returnType = method_copyReturnType(method);
-    if (!returnType) {
-        return '\0';
-    }
-
-    char prefix = returnType[0];
-    free(returnType);
-    return prefix;
-}
-
-static BOOL DYYYBoolValueReturnedBySelector(id object, SEL selector, BOOL *value) {
-    if (!object || ![object respondsToSelector:selector]) {
-        return NO;
-    }
-
-    char returnType = DYYYMethodReturnTypePrefix(object, selector);
-    if (returnType != 'B' && returnType != 'c' && returnType != 'C') {
-        return NO;
-    }
-
-    @try {
-        BOOL (*messageSend)(id, SEL) = (BOOL (*)(id, SEL))objc_msgSend;
-        if (value) {
-            *value = messageSend(object, selector);
-        }
-        return YES;
-    } @catch (NSException *exception) {
-        return NO;
-    }
-}
-
-static BOOL DYYYFloatValueReturnedBySelector(id object, SEL selector, float *value) {
-    if (!object || ![object respondsToSelector:selector]) {
-        return NO;
-    }
-
-    char returnType = DYYYMethodReturnTypePrefix(object, selector);
-    if (returnType != 'f' && returnType != 'd') {
-        return NO;
-    }
-
-    @try {
-        float floatValue = 0.0f;
-        if (returnType == 'd') {
-            double (*messageSend)(id, SEL) = (double (*)(id, SEL))objc_msgSend;
-            floatValue = (float)messageSend(object, selector);
-        } else {
-            float (*messageSend)(id, SEL) = (float (*)(id, SEL))objc_msgSend;
-            floatValue = messageSend(object, selector);
-        }
-
-        if (value) {
-            *value = floatValue;
-        }
-        return YES;
-    } @catch (NSException *exception) {
-        return NO;
-    }
-}
-
-static void DYYYAddPlaybackCandidate(NSMutableArray *candidates, id candidate) {
-    if (!candidate || candidates.count >= 32) {
-        return;
-    }
-
-    for (id existingCandidate in candidates) {
-        if (existingCandidate == candidate) {
-            return;
-        }
-    }
-
-    [candidates addObject:candidate];
-}
-
-static NSArray *DYYYPlaybackCandidatesFromObject(id object) {
-    NSMutableArray *candidates = [NSMutableArray array];
-    DYYYAddPlaybackCandidate(candidates, object);
 
     SEL directSelectors[] = {
         @selector(playVideoViewController),
         @selector(playerViewController),
         @selector(videoDelegate),
         @selector(player),
-        NSSelectorFromString(@"playerController"),
-        NSSelectorFromString(@"playbackController"),
-        NSSelectorFromString(@"playerManager"),
-        NSSelectorFromString(@"playerAdapter"),
-        NSSelectorFromString(@"playbackEngine"),
-        NSSelectorFromString(@"avPlayer"),
     };
 
-    for (NSUInteger index = 0; index < candidates.count; index++) {
-        id current = candidates[index];
-        for (NSUInteger i = 0; i < sizeof(directSelectors) / sizeof(SEL); i++) {
-            DYYYAddPlaybackCandidate(candidates, DYYYObjectReturnedBySelector(current, directSelectors[i]));
-        }
-    }
-
-    return candidates;
-}
-
-static id DYYYPlaybackControlTargetFromObject(id object) {
-    for (id candidate in DYYYPlaybackCandidatesFromObject(object)) {
+    for (NSUInteger i = 0; i < sizeof(directSelectors) / sizeof(SEL); i++) {
+        id candidate = DYYYObjectReturnedBySelector(object, directSelectors[i]);
         if (DYYYPlaybackTargetSupportsPlayPause(candidate)) {
             return candidate;
+        }
+
+        id nestedPlayer = DYYYObjectReturnedBySelector(candidate, @selector(player));
+        if (DYYYPlaybackTargetSupportsPlayPause(nestedPlayer)) {
+            return nestedPlayer;
         }
     }
 
     return nil;
 }
 
-static id DYYYResolveCommentPausePlaybackTarget(AWEPlayInteractionViewController *interactionController) {
+static id DYYYResolveCommentPausePlaybackTarget(void) {
+    AWEPlayInteractionViewController *interactionController = DYYYResolveCurrentSpeedInteractionController(nil);
     Protocol *speedControllerProtocol = NSProtocolFromString(@"AWEFastSpeedControllerProtocol");
     if (interactionController && speedControllerProtocol && [interactionController respondsToSelector:@selector(controllerByProtocol:)]) {
         @try {
@@ -1090,74 +995,24 @@ static id DYYYResolveCommentPausePlaybackTarget(AWEPlayInteractionViewController
         return target;
     }
 
-    target = DYYYPlaybackControlTargetFromObject(dyyyActiveSpeedPlayerViewController);
-    if (target) {
-        return target;
-    }
-
     target = DYYYPlaybackControlTargetFromObject(DYYYBestVisiblePlaybackRateTarget(nil));
     return target;
 }
 
 static BOOL DYYYPlaybackTargetIsPlaying(id target, BOOL *isPlaying) {
-    if (!target) {
+    if (!target || ![target respondsToSelector:@selector(isPlaying)]) {
         return NO;
     }
 
-    SEL playingSelectors[] = {
-        @selector(isPlaying),
-        NSSelectorFromString(@"playing"),
-        NSSelectorFromString(@"isVideoPlaying"),
-        NSSelectorFromString(@"isPlayerPlaying"),
-    };
-
-    for (NSUInteger i = 0; i < sizeof(playingSelectors) / sizeof(SEL); i++) {
-        if (DYYYBoolValueReturnedBySelector(target, playingSelectors[i], isPlaying)) {
-            return YES;
+    @try {
+        BOOL (*messageSend)(id, SEL) = (BOOL (*)(id, SEL))objc_msgSend;
+        if (isPlaying) {
+            *isPlaying = messageSend(target, @selector(isPlaying));
         }
+        return YES;
+    } @catch (NSException *exception) {
+        return NO;
     }
-
-    SEL pausedSelectors[] = {
-        NSSelectorFromString(@"isPaused"),
-        NSSelectorFromString(@"paused"),
-    };
-
-    for (NSUInteger i = 0; i < sizeof(pausedSelectors) / sizeof(SEL); i++) {
-        BOOL isPaused = NO;
-        if (DYYYBoolValueReturnedBySelector(target, pausedSelectors[i], &isPaused)) {
-            if (isPlaying) {
-                *isPlaying = !isPaused;
-            }
-            return YES;
-        }
-    }
-
-    SEL rateSelectors[] = {
-        NSSelectorFromString(@"rate"),
-        NSSelectorFromString(@"playbackRate"),
-    };
-
-    for (NSUInteger i = 0; i < sizeof(rateSelectors) / sizeof(SEL); i++) {
-        float rate = 0.0f;
-        if (DYYYFloatValueReturnedBySelector(target, rateSelectors[i], &rate)) {
-            if (isPlaying) {
-                *isPlaying = fabsf(rate) > FLT_EPSILON;
-            }
-            return YES;
-        }
-    }
-
-    return NO;
-}
-
-static BOOL DYYYPlaybackObjectIsPlaying(id object, BOOL *isPlaying) {
-    for (id candidate in DYYYPlaybackCandidatesFromObject(object)) {
-        if (DYYYPlaybackTargetIsPlaying(candidate, isPlaying)) {
-            return YES;
-        }
-    }
-
-    return NO;
 }
 
 static BOOL DYYYSendPlaybackControl(id target, SEL selector) {
@@ -1174,44 +1029,6 @@ static BOOL DYYYSendPlaybackControl(id target, SEL selector) {
     }
 }
 
-static BOOL DYYYSendFirstPlaybackControl(id target, SEL *selectors, NSUInteger count) {
-    for (NSUInteger i = 0; i < count; i++) {
-        if (DYYYSendPlaybackControl(target, selectors[i])) {
-            return YES;
-        }
-    }
-
-    return NO;
-}
-
-static BOOL DYYYSendOfficialCommentPauseIfPossible(id target) {
-    SEL selectors[] = {
-        NSSelectorFromString(@"pauseVideoIfPlayingWithoutShowingPauseIcon"),
-        NSSelectorFromString(@"pauseVideoIfPlaying"),
-    };
-
-    return DYYYSendFirstPlaybackControl(target, selectors, sizeof(selectors) / sizeof(SEL));
-}
-
-static BOOL DYYYSendPauseToPlaybackTarget(id target) {
-    SEL selectors[] = {
-        @selector(pause),
-        NSSelectorFromString(@"pauseVideo"),
-    };
-
-    return DYYYSendFirstPlaybackControl(target, selectors, sizeof(selectors) / sizeof(SEL));
-}
-
-static BOOL DYYYSendPlayToPlaybackTarget(id target) {
-    SEL selectors[] = {
-        @selector(play),
-        NSSelectorFromString(@"playVideo"),
-        NSSelectorFromString(@"resumeVideo"),
-    };
-
-    return DYYYSendFirstPlaybackControl(target, selectors, sizeof(selectors) / sizeof(SEL));
-}
-
 static BOOL DYYYPlaybackTargetIsVisible(id target) {
     if ([target isKindOfClass:[UIViewController class]]) {
         return DYYYViewControllerVisibilityScore((UIViewController *)target) >= 0.0;
@@ -1223,45 +1040,19 @@ static BOOL DYYYPlaybackTargetIsVisible(id target) {
     return target != nil;
 }
 
-static BOOL DYYYCommentPausePlaybackStateIsPlaying(id target, AWEPlayInteractionViewController *interactionController, BOOL *isPlaying) {
-    if (DYYYPlaybackObjectIsPlaying(target, isPlaying)) {
-        return YES;
-    }
-
-    if (DYYYPlaybackObjectIsPlaying(interactionController, isPlaying)) {
-        return YES;
-    }
-
-    if (DYYYPlaybackObjectIsPlaying(dyyyActiveSpeedPlayerViewController, isPlaying)) {
-        return YES;
-    }
-
-    return DYYYPlaybackObjectIsPlaying(DYYYBestVisiblePlaybackRateTarget(nil), isPlaying);
-}
-
 static void DYYYCommentPausePlaybackIfNeeded(void) {
     if (!DYYYGetBool(@"DYYYCommentPausePlayback") || dyyyCommentPausePlaybackActive) {
         return;
     }
 
-    dyyyCommentPausePlaybackRestoreGeneration++;
-    AWEPlayInteractionViewController *interactionController = (AWEPlayInteractionViewController *)DYYYCurrentSpeedInteractionController();
-    id target = DYYYResolveCommentPausePlaybackTarget(interactionController);
+    id target = DYYYResolveCommentPausePlaybackTarget();
     BOOL isPlaying = NO;
-    if (!DYYYCommentPausePlaybackStateIsPlaying(target, interactionController, &isPlaying) || !isPlaying) {
+    if (!DYYYPlaybackTargetIsPlaying(target, &isPlaying) || !isPlaying) {
         return;
     }
 
-    BOOL didPause = DYYYSendOfficialCommentPauseIfPossible(interactionController);
-    if (!didPause) {
-        didPause = DYYYSendPauseToPlaybackTarget(target);
-    }
-    if (!didPause && target != interactionController) {
-        didPause = DYYYSendPauseToPlaybackTarget(interactionController);
-    }
-
-    if (didPause) {
-        dyyyCommentPausePlaybackTarget = target ?: interactionController ?: DYYYBestVisiblePlaybackRateTarget(nil);
+    if (DYYYSendPlaybackControl(target, @selector(pause))) {
+        dyyyCommentPausePlaybackTarget = target;
         dyyyCommentPausePlaybackActive = YES;
     }
 }
@@ -1274,140 +1065,17 @@ static void DYYYCommentRestorePlaybackIfNeeded(void) {
     id target = dyyyCommentPausePlaybackTarget;
     dyyyCommentPausePlaybackActive = NO;
     dyyyCommentPausePlaybackTarget = nil;
-    dyyyCommentPausePlaybackController = nil;
-    dyyyCommentPausePlaybackRestoreGeneration++;
 
     if (!target || !DYYYPlaybackTargetIsVisible(target)) {
-        target = DYYYResolveCommentPausePlaybackTarget((AWEPlayInteractionViewController *)DYYYCurrentSpeedInteractionController());
-        if (!target || !DYYYPlaybackTargetIsVisible(target)) {
-            return;
-        }
+        return;
     }
 
     BOOL isPlaying = NO;
-    if (DYYYPlaybackObjectIsPlaying(target, &isPlaying) && isPlaying) {
+    if (DYYYPlaybackTargetIsPlaying(target, &isPlaying) && isPlaying) {
         return;
     }
 
-    DYYYSendPlayToPlaybackTarget(target);
-}
-
-static BOOL DYYYCommentPausePlaybackClassNameIsPreview(NSString *className) {
-    if (className.length == 0) {
-        return NO;
-    }
-
-    static NSArray<NSString *> *previewClassNameFragments = nil;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-      previewClassNameFragments = @[
-          @"CommentMediaFeed",
-          @"CommentMedia",
-          @"CommentImagePreview",
-          @"CommentImage",
-          @"CommentCellSticker",
-          @"CommentSticker",
-          @"CommentEmoji",
-          @"CommentEmoticon",
-          @"EmoticonPreview",
-          @"EmojiPreview",
-          @"AWEIMEmoticon",
-          @"AWEIMEmoji"
-      ];
-    });
-
-    for (NSString *fragment in previewClassNameFragments) {
-        if ([className containsString:fragment]) {
-            return YES;
-        }
-    }
-
-    return NO;
-}
-
-static BOOL DYYYCommentPausePlaybackViewControllerTreeIsPreview(UIViewController *viewController, NSUInteger depth) {
-    if (!viewController || depth > 8) {
-        return NO;
-    }
-
-    if (DYYYCommentPausePlaybackClassNameIsPreview(NSStringFromClass([viewController class]))) {
-        return YES;
-    }
-
-    if ([viewController isKindOfClass:[UINavigationController class]]) {
-        UINavigationController *navigationController = (UINavigationController *)viewController;
-        if (DYYYCommentPausePlaybackViewControllerTreeIsPreview(navigationController.visibleViewController ?: navigationController.topViewController, depth + 1)) {
-            return YES;
-        }
-    } else if ([viewController isKindOfClass:[UITabBarController class]]) {
-        if (DYYYCommentPausePlaybackViewControllerTreeIsPreview(((UITabBarController *)viewController).selectedViewController, depth + 1)) {
-            return YES;
-        }
-    }
-
-    for (UIViewController *childViewController in viewController.childViewControllers) {
-        if (DYYYCommentPausePlaybackViewControllerTreeIsPreview(childViewController, depth + 1)) {
-            return YES;
-        }
-    }
-
-    return DYYYCommentPausePlaybackViewControllerTreeIsPreview(viewController.presentedViewController, depth + 1);
-}
-
-static BOOL DYYYCommentPausePlaybackShouldDeferRestore(UIViewController *commentViewController) {
-    if (!commentViewController || commentViewController.isBeingDismissed) {
-        return NO;
-    }
-
-    UINavigationController *navigationController = commentViewController.navigationController;
-    if (navigationController && navigationController.view.window && !navigationController.isBeingDismissed) {
-        UIViewController *topViewController = navigationController.visibleViewController ?: navigationController.topViewController;
-        if (topViewController && topViewController != commentViewController) {
-            return YES;
-        }
-
-        UIViewController *presentedViewController = navigationController.presentedViewController;
-        if (presentedViewController && !presentedViewController.isBeingDismissed) {
-            return YES;
-        }
-    }
-
-    UIViewController *presentedViewController = commentViewController.presentedViewController;
-    if (presentedViewController && !presentedViewController.isBeingDismissed) {
-        return YES;
-    }
-
-    UIViewController *topViewController = [DYYYUtils topView];
-    return topViewController &&
-           topViewController != commentViewController &&
-           DYYYCommentPausePlaybackViewControllerTreeIsPreview(topViewController, 0);
-}
-
-static void DYYYQueueCommentRestorePlaybackCheck(UIViewController *commentViewController, NSUInteger generation, NSTimeInterval delay) {
-    __weak UIViewController *weakCommentViewController = commentViewController;
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delay * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-      if (generation != dyyyCommentPausePlaybackRestoreGeneration || !dyyyCommentPausePlaybackActive) {
-          return;
-      }
-
-      UIViewController *strongCommentViewController = weakCommentViewController;
-      if (strongCommentViewController && DYYYCommentPausePlaybackShouldDeferRestore(strongCommentViewController)) {
-          DYYYQueueCommentRestorePlaybackCheck(strongCommentViewController, generation, 0.5);
-          return;
-      }
-
-      DYYYCommentRestorePlaybackIfNeeded();
-    });
-}
-
-static void DYYYScheduleCommentRestorePlaybackIfNeeded(UIViewController *commentViewController) {
-    if (!dyyyCommentPausePlaybackActive) {
-        return;
-    }
-
-    dyyyCommentPausePlaybackController = commentViewController;
-    dyyyCommentPausePlaybackRestoreGeneration++;
-    DYYYQueueCommentRestorePlaybackCheck(commentViewController, dyyyCommentPausePlaybackRestoreGeneration, 0.2);
+    DYYYSendPlaybackControl(target, @selector(play));
 }
 
 static double DYYYConfiguredPlaybackSpeed(void) {
@@ -13209,8 +12877,6 @@ static Class tabBarButtonClass = nil;
 - (void)viewDidAppear:(BOOL)animated {
     %orig;
     dyyyCommentViewVisible = YES;
-    dyyyCommentPausePlaybackController = self;
-    dyyyCommentPausePlaybackRestoreGeneration++;
     updateSpeedButtonVisibility();
     updateClearButtonVisibility();
     DYYYCommentPausePlaybackIfNeeded();
@@ -13237,7 +12903,7 @@ static Class tabBarButtonClass = nil;
     dyyyCommentViewVisible = NO;
     updateSpeedButtonVisibility();
     updateClearButtonVisibility();
-    DYYYScheduleCommentRestorePlaybackIfNeeded(self);
+    DYYYCommentRestorePlaybackIfNeeded();
 }
 
 - (void)viewDidLayoutSubviews {

--- a/DYYY.xm
+++ b/DYYY.xm
@@ -7923,6 +7923,25 @@ static NSHashTable *processedParentViews = nil;
 %end
 
 // 隐藏自己无公开作品的视图
+static void DYYYHideProfilePostGuideView(UIView *view) {
+    if (!view) {
+        return;
+    }
+
+    view.hidden = YES;
+    view.alpha = 0.0;
+    view.userInteractionEnabled = NO;
+    view.accessibilityElementsHidden = YES;
+
+    if ([view isKindOfClass:[UICollectionViewCell class]]) {
+        UIView *contentView = ((UICollectionViewCell *)view).contentView;
+        contentView.hidden = YES;
+        contentView.alpha = 0.0;
+        contentView.userInteractionEnabled = NO;
+        contentView.accessibilityElementsHidden = YES;
+    }
+}
+
 %hook AWEProfileMixItemCollectionViewCell
 - (void)layoutSubviews {
     %orig;
@@ -7948,6 +7967,24 @@ static NSHashTable *processedParentViews = nil;
 
 %end
 
+%hook AWEProfilePublishGuideCollectionViewCell
+
+- (void)didMoveToWindow {
+    %orig;
+    if (DYYYGetBool(@"DYYYHidePostView")) {
+        DYYYHideProfilePostGuideView((UIView *)self);
+    }
+}
+
+- (void)layoutSubviews {
+    %orig;
+    if (DYYYGetBool(@"DYYYHidePostView")) {
+        DYYYHideProfilePostGuideView((UIView *)self);
+    }
+}
+
+%end
+
 %hook AWEProfileTaskCardStyleListCollectionViewCell
 - (BOOL)shouldShowPublishGuide {
     if (DYYYGetBool(@"DYYYHidePostView")) {
@@ -7955,6 +7992,101 @@ static NSHashTable *processedParentViews = nil;
     }
     return %orig;
 }
+%end
+
+%hook AWEUserProfileUGCHeaderContributionGuideBannerSectionViewModel
+
+- (CGSize)sectionSize {
+    if (DYYYGetBool(@"DYYYHidePostView")) {
+        return CGSizeZero;
+    }
+    return %orig;
+}
+
+%end
+
+%hook AWEUserProfileUGCHeaderContributionGuideBannerSectionController
+
+- (void)configCell:(UICollectionViewCell *)cell index:(NSInteger)index model:(id)model {
+    if (DYYYGetBool(@"DYYYHidePostView")) {
+        DYYYHideProfilePostGuideView(cell);
+        return;
+    }
+    %orig(cell, index, model);
+}
+
+%end
+
+%hook AWEUserProfileUGCContributionGuideCollectionViewCell
+
+- (void)didMoveToWindow {
+    %orig;
+    if (DYYYGetBool(@"DYYYHidePostView")) {
+        DYYYHideProfilePostGuideView((UIView *)self);
+    }
+}
+
+- (void)layoutSubviews {
+    %orig;
+    if (DYYYGetBool(@"DYYYHidePostView")) {
+        DYYYHideProfilePostGuideView((UIView *)self);
+    }
+}
+
+%end
+
+%hook AWEUserProfileUGCContributionGuideEmptyCollectionViewCell
+
+- (void)didMoveToWindow {
+    %orig;
+    if (DYYYGetBool(@"DYYYHidePostView")) {
+        DYYYHideProfilePostGuideView((UIView *)self);
+    }
+}
+
+- (void)layoutSubviews {
+    %orig;
+    if (DYYYGetBool(@"DYYYHidePostView")) {
+        DYYYHideProfilePostGuideView((UIView *)self);
+    }
+}
+
+%end
+
+%hook AWEUserProfileUGCHeaderContributionGuideBannerSectionCell
+
+- (void)didMoveToWindow {
+    %orig;
+    if (DYYYGetBool(@"DYYYHidePostView")) {
+        DYYYHideProfilePostGuideView((UIView *)self);
+    }
+}
+
+- (void)layoutSubviews {
+    %orig;
+    if (DYYYGetBool(@"DYYYHidePostView")) {
+        DYYYHideProfilePostGuideView((UIView *)self);
+    }
+}
+
+%end
+
+%hook AWEUserProfileUGCTaskCardStyleListCollectionViewCell
+
+- (void)didMoveToWindow {
+    %orig;
+    if (DYYYGetBool(@"DYYYHidePostView")) {
+        DYYYHideProfilePostGuideView((UIView *)self);
+    }
+}
+
+- (void)layoutSubviews {
+    %orig;
+    if (DYYYGetBool(@"DYYYHidePostView")) {
+        DYYYHideProfilePostGuideView((UIView *)self);
+    }
+}
+
 %end
 
 %hook AWEProfileRichEmptyView

--- a/DYYY.xm
+++ b/DYYY.xm
@@ -9462,6 +9462,19 @@ static void DYYYHideProfilePostGuideView(UIView *view) {
 
 %end
 
+static BOOL DYYYShouldHideTemplateVideoForAweme(AWEAwemeModel *aweme) {
+    if (!DYYYGetBool(@"DYYYHideTemplateVideo")) {
+        return NO;
+    }
+
+    if (![aweme respondsToSelector:@selector(referString)]) {
+        return YES;
+    }
+
+    NSString *referString = aweme.referString;
+    return referString.length == 0 || [referString isEqualToString:@"homepage_hot"];
+}
+
 %hook AWEAwemeModel
 
 - (id)initWithDictionary:(id)arg1 error:(id *)arg2 {
@@ -9963,13 +9976,20 @@ static void DYYYHideProfilePostGuideView(UIView *view) {
 	%orig;
 }
 
-// 屏蔽底部合集（只对推荐页生效）
+// 屏蔽底部合集
 - (id)mixInfo {
-	BOOL DYYYHideTemplateVideo = DYYYGetBool(@"DYYYHideTemplateVideo");
-	if (DYYYHideTemplateVideo && [self.referString isEqualToString:@"homepage_hot"]) {
+	if (DYYYShouldHideTemplateVideoForAweme(self)) {
 		return nil;
 	}
 	return %orig;
+}
+
+- (void)setMixInfo:(id)info {
+	if (DYYYShouldHideTemplateVideoForAweme(self)) {
+		%orig(nil);
+		return;
+	}
+	%orig;
 }
 
 // 屏蔽短剧信息（复用屏蔽合集开关，只对推荐页生效）
@@ -10288,6 +10308,25 @@ static void DYYYHideProfilePostGuideView(UIView *view) {
 		return @{};
 	}
 	return %orig;
+}
+
+%end
+
+%hook AWESearchMixVideoModel
+
+- (id)mixInfo {
+	if (DYYYGetBool(@"DYYYHideTemplateVideo")) {
+		return nil;
+	}
+	return %orig;
+}
+
+- (void)setMixInfo:(id)info {
+	if (DYYYGetBool(@"DYYYHideTemplateVideo")) {
+		%orig(nil);
+		return;
+	}
+	%orig;
 }
 
 %end
@@ -13620,6 +13659,12 @@ static Class TagViewClass = nil;
 %hook AWEMixVideoPanelMoreView
 
 - (void)setFrame:(CGRect)frame {
+    if (DYYYGetBool(@"DYYYHideTemplateVideo")) {
+        self.hidden = YES;
+        %orig(frame);
+        return;
+    }
+
     if (DYYYGetBool(@"DYYYEnableFullScreen")) {
         CGFloat targetY = frame.origin.y - gCurrentTabBarHeight;
         CGFloat screenHeightMinusGDiff = [UIScreen mainScreen].bounds.size.height - gCurrentTabBarHeight;
@@ -13635,6 +13680,11 @@ static Class TagViewClass = nil;
 
 - (void)layoutSubviews {
     %orig;
+
+    if (DYYYGetBool(@"DYYYHideTemplateVideo")) {
+        self.hidden = YES;
+        return;
+    }
 
     if (DYYYGetBool(@"DYYYEnableFullScreen")) {
         self.backgroundColor = [UIColor clearColor];

--- a/DYYY.xm
+++ b/DYYY.xm
@@ -12827,7 +12827,9 @@ static Class TagViewClass = nil;
         CGAffineTransform targetTransform = CGAffineTransformIdentity;
         CGFloat boundsWidth = self.bounds.size.width;
         CGFloat currentScale = 1.0;
-        CGFloat targetHeight, tx, ty = 0;
+        CGFloat targetHeight = 0;
+        CGFloat tx = 0;
+        CGFloat ty = 0;
         UIWindow *keyWindow = [DYYYUtils getActiveWindow];
         if (keyWindow && keyWindow.safeAreaInsets.bottom == 0) {
             targetHeight = gCurrentTabBarHeight - originalTabBarHeight;
@@ -13041,7 +13043,9 @@ static Class TagViewClass = nil;
         CGAffineTransform targetTransform = CGAffineTransformIdentity;
         CGFloat boundsWidth = self.bounds.size.width;
         CGFloat currentScale = 1.0;
-        CGFloat targetHeight, tx, ty = 0;
+        CGFloat targetHeight = 0;
+        CGFloat tx = 0;
+        CGFloat ty = -20;
         UIWindow *keyWindow = [DYYYUtils getActiveWindow];
         if (keyWindow && keyWindow.safeAreaInsets.bottom == 0) {
             targetHeight = gCurrentTabBarHeight - originalTabBarHeight;
@@ -13069,7 +13073,7 @@ static Class TagViewClass = nil;
         if (shouldShiftUp) {
             ty -= targetHeight;
         }
-        targetTransform = CGAffineTransformMakeTranslation(0, -20);
+        targetTransform = CGAffineTransformMake(currentScale, 0, 0, currentScale, tx, ty);
 
         if (!CGAffineTransformEqualToTransform(self.transform, targetTransform)) {
             self.transform = targetTransform;

--- a/DYYY.xm
+++ b/DYYY.xm
@@ -13288,6 +13288,34 @@ static Class GuideViewClass = nil;
 static Class MuteViewClass = nil;
 static Class TagViewClass = nil;
 
+static BOOL DYYYLivePreStreamStackHasScalableContent(UIView *stackView) {
+    if (!stackView) {
+        return NO;
+    }
+
+    Class guideViewClass = GuideViewClass ?: NSClassFromString(@"AWELivePrestreamGuideView");
+    Class muteViewClass = MuteViewClass ?: NSClassFromString(@"AFDCancelMuteAwemeView");
+    Class tagViewClass = TagViewClass ?: NSClassFromString(@"AWELiveFeedLabelTagView");
+
+    return [DYYYUtils containsSubviewOfClass:guideViewClass inContainer:stackView] ||
+           [DYYYUtils containsSubviewOfClass:muteViewClass inContainer:stackView] ||
+           [DYYYUtils containsSubviewOfClass:tagViewClass inContainer:stackView];
+}
+
+static BOOL DYYYLivePreStreamShouldUseNestedLiveStack(UIView *stackView) {
+    Class liveStackClass = NSClassFromString(@"IESLiveStackView");
+    if (!stackView || !liveStackClass || [stackView isKindOfClass:liveStackClass]) {
+        return NO;
+    }
+
+    for (UIView *subview in stackView.subviews) {
+        if ([subview isKindOfClass:liveStackClass] && DYYYLivePreStreamStackHasScalableContent(subview)) {
+            return YES;
+        }
+    }
+    return NO;
+}
+
 %hook AWEElementStackView
 
 - (void)setAlpha:(CGFloat)alpha {
@@ -13416,6 +13444,13 @@ static Class TagViewClass = nil;
     UIViewController *viewController = [DYYYUtils firstAvailableViewControllerFromView:self];
 
     if ([viewController isKindOfClass:%c(AWELiveNewPreStreamViewController)]) {
+        if (DYYYLivePreStreamShouldUseNestedLiveStack(self)) {
+            if (!CGAffineTransformEqualToTransform(self.transform, CGAffineTransformIdentity)) {
+                self.transform = CGAffineTransformIdentity;
+            }
+            return;
+        }
+
         const BOOL shouldShiftUp = DYYYGetBool(@"DYYYEnableFullScreen");
         const CGFloat labelScaleValue = DYYYGetFloat(@"DYYYNicknameScale");
         const CGFloat targetLabelScale = (labelScaleValue != 0.0) ? MAX(0.01, labelScaleValue) : 1.0;
@@ -13437,7 +13472,7 @@ static Class TagViewClass = nil;
 
         if ([DYYYUtils containsSubviewOfClass:GuideViewClass inContainer:self]) {
             currentScale = targetLabelScale;
-            tx = 0; // 中对齐
+            tx = (boundsWidth - boundsWidth * currentScale) / 2 - boundsWidth * (1 - currentScale); // 左对齐
         } else if ([DYYYUtils containsSubviewOfClass:MuteViewClass inContainer:self]) {
             currentScale = targetElementScale;
             tx = (boundsWidth - boundsWidth * currentScale) / 2; // 右对齐
@@ -13653,7 +13688,7 @@ static Class TagViewClass = nil;
 
         if ([DYYYUtils containsSubviewOfClass:GuideViewClass inContainer:self]) {
             currentScale = targetLabelScale;
-            tx = 0; // 中对齐
+            tx = (boundsWidth - boundsWidth * currentScale) / 2 - boundsWidth * (1 - currentScale); // 左对齐
         } else if ([DYYYUtils containsSubviewOfClass:MuteViewClass inContainer:self]) {
             currentScale = targetElementScale;
             tx = (boundsWidth - boundsWidth * currentScale) / 2; // 右对齐

--- a/DYYY.xm
+++ b/DYYY.xm
@@ -9562,6 +9562,26 @@ static void DYYYHideProfilePostGuideView(UIView *view) {
 
 %end
 
+static BOOL DYYYAwemeModelIsRecommendFeed(AWEAwemeModel *aweme) {
+    if (![aweme respondsToSelector:@selector(referString)]) {
+        return NO;
+    }
+
+    return [aweme.referString isEqualToString:@"homepage_hot"];
+}
+
+static BOOL DYYYAwemeModelHasLiveSignal(AWEAwemeModel *aweme) {
+    if ([aweme respondsToSelector:@selector(isLive)] && aweme.isLive) {
+        return YES;
+    }
+
+    if ([aweme respondsToSelector:@selector(cellRoom)] && aweme.cellRoom != nil) {
+        return YES;
+    }
+
+    return [aweme respondsToSelector:@selector(videoFeedTag)] && [aweme.videoFeedTag isEqualToString:@"直播中"];
+}
+
 %hook AWEHotListDataController
 
 %new
@@ -9657,6 +9677,7 @@ static void DYYYHideProfilePostGuideView(UIView *view) {
     // --- 配置读取 ---
     NSInteger daysThreshold = DYYYGetInteger(@"DYYYFilterTimeLimit");
     BOOL skipLive = DYYYGetBool(@"DYYYSkipLive"); // 读取直播过滤开关
+    BOOL skipAllLive = DYYYGetBool(@"DYYYSkipAllLive");
     NSInteger minLikesThreshold = DYYYGetInteger(@"DYYYFilterLowLikes"); // 读取低赞过滤阈值 (例如: 1000)
     BOOL skipPhotoText = DYYYGetBool(@"DYYYSkipPhotoText"); // 图文过滤
     BOOL skipPhoto = DYYYGetBool(@"DYYYSkipPhoto"); // 图集过滤
@@ -9677,23 +9698,29 @@ static void DYYYHideProfilePostGuideView(UIView *view) {
         }
 
         AWEAwemeModel *m = (AWEAwemeModel *)obj;
+        BOOL isRecommendFeed = DYYYAwemeModelIsRecommendFeed(m);
+        BOOL isLiveAweme = DYYYAwemeModelHasLiveSignal(m);
 
         // 1. 广告过滤：合集、搜索内流、分页追加等旁路也会进入此共享转换。
         if (noAds && [DYYYUtils isAdvertisementAwemeModel:m]) {
             continue;
         }
 
-        // 2. 直播过滤逻辑 (仅依赖 cellRoom)
-        if (skipLive && [m respondsToSelector:@selector(cellRoom)] && m.cellRoom != nil) {
+        // 2. 直播过滤：当前路径是推荐流转换，全部过滤同样覆盖这里。
+        if ((skipAllLive || skipLive) && isLiveAweme) {
             continue; // 命中直播过滤，跳过
+        }
+
+        if (isLiveAweme) {
+            [baseFiltered addObject:obj];
+            continue;
         }
 
         // 2.1 图文模式过滤逻辑（推荐页）
         if (skipPhotoText &&
             [m respondsToSelector:@selector(isNewTextMode)] &&
             m.isNewTextMode &&
-            [m respondsToSelector:@selector(referString)] &&
-            [m.referString isEqualToString:@"homepage_hot"]) {
+            isRecommendFeed) {
             continue; // 图文模式且来自推荐页，跳过
         }
 
@@ -9701,15 +9728,13 @@ static void DYYYHideProfilePostGuideView(UIView *view) {
         if (skipPhoto &&
             [m respondsToSelector:@selector(awemeType)] &&
             m.awemeType == 68 &&
-            [m respondsToSelector:@selector(referString)] &&
-            [m.referString isEqualToString:@"homepage_hot"]) {
+            isRecommendFeed) {
             continue; // 图集且来自推荐页，跳过
         }
 
         // 2.3 音乐过滤逻辑（推荐页）
         if (skipMusic &&
-            [m respondsToSelector:@selector(referString)] &&
-            [m.referString isEqualToString:@"homepage_hot"] &&
+            isRecommendFeed &&
             [m respondsToSelector:@selector(musicCard)] &&
             m.musicCard) {
             continue; // 音乐卡片且来自推荐页，跳过
@@ -9755,6 +9780,11 @@ static void DYYYHideProfilePostGuideView(UIView *view) {
         }
 
         AWEAwemeModel *m = (AWEAwemeModel *)obj;
+        if (DYYYAwemeModelHasLiveSignal(m)) {
+            [lowLikesFiltered addObject:obj];
+            continue;
+        }
+
         NSNumber *diggCountValue = [self dyyy_resolvedDiggCountForAweme:m];
 
         if (!diggCountValue) {
@@ -9927,8 +9957,8 @@ static BOOL DYYYShouldHideTemplateVideoForAweme(AWEAwemeModel *aweme) {
 
     BOOL shouldFilterAds = noAds && [DYYYUtils isAdvertisementAwemeModel:self];
     BOOL shouldFilterHotSpot = skipHotSpot && self.hotSpotLynxCardModel;
-    BOOL shouldFilterAllLive = skipAllLive && [self.videoFeedTag isEqualToString:@"直播中"];
-    BOOL isRecommendFeed = [self.referString isEqualToString:@"homepage_hot"];
+    BOOL isRecommendFeed = DYYYAwemeModelIsRecommendFeed(self);
+    BOOL shouldFilterAllLive = skipAllLive && DYYYAwemeModelHasLiveSignal(self);
     BOOL shouldskipPhoto = skipPhoto && (self.awemeType == 68) && isRecommendFeed;
     BOOL shouldskipPhotoText = skipPhotoText && self.isNewTextMode && isRecommendFeed;
     BOOL shouldFilterMusic = skipMusic && self.musicCard && isRecommendFeed;

--- a/DYYY.xm
+++ b/DYYY.xm
@@ -227,6 +227,8 @@ static __weak AWEAwemeModel *dyyyCurrentSpeedAweme = nil;
 static NSString *dyyyLastAutoRestoredSpeedAwemeIdentifier = nil;
 static BOOL dyyyLongPressFastSpeedActive = NO;
 static BOOL dyyyLongPressLockedSpeedActive = NO;
+static __weak id dyyyCommentPausePlaybackTarget = nil;
+static BOOL dyyyCommentPausePlaybackActive = NO;
 
 static void DYYYClearLongPressSpeedState(void) {
     dyyyLongPressFastSpeedActive = NO;
@@ -533,6 +535,155 @@ static BOOL DYYYApplyPlaybackSpeed(AWEPlayInteractionViewController *interaction
 
 static BOOL DYYYApplyPlaybackSpeedToVisiblePlayer(double speed) {
     return DYYYSetPlaybackRateOnTarget(DYYYBestVisiblePlaybackRateTarget(nil), speed);
+}
+
+static BOOL DYYYPlaybackTargetSupportsPlayPause(id target) {
+    return target &&
+           [target respondsToSelector:@selector(play)] &&
+           [target respondsToSelector:@selector(pause)] &&
+           [target respondsToSelector:@selector(isPlaying)];
+}
+
+static id DYYYObjectReturnedBySelector(id object, SEL selector) {
+    if (!object || ![object respondsToSelector:selector]) {
+        return nil;
+    }
+
+    @try {
+        id (*messageSend)(id, SEL) = (id (*)(id, SEL))objc_msgSend;
+        return messageSend(object, selector);
+    } @catch (NSException *exception) {
+        return nil;
+    }
+}
+
+static id DYYYPlaybackControlTargetFromObject(id object) {
+    if (DYYYPlaybackTargetSupportsPlayPause(object)) {
+        return object;
+    }
+
+    SEL directSelectors[] = {
+        @selector(playVideoViewController),
+        @selector(playerViewController),
+        @selector(videoDelegate),
+        @selector(player),
+    };
+
+    for (NSUInteger i = 0; i < sizeof(directSelectors) / sizeof(SEL); i++) {
+        id candidate = DYYYObjectReturnedBySelector(object, directSelectors[i]);
+        if (DYYYPlaybackTargetSupportsPlayPause(candidate)) {
+            return candidate;
+        }
+
+        id nestedPlayer = DYYYObjectReturnedBySelector(candidate, @selector(player));
+        if (DYYYPlaybackTargetSupportsPlayPause(nestedPlayer)) {
+            return nestedPlayer;
+        }
+    }
+
+    return nil;
+}
+
+static id DYYYResolveCommentPausePlaybackTarget(void) {
+    AWEPlayInteractionViewController *interactionController = DYYYResolveCurrentSpeedInteractionController(nil);
+    Protocol *speedControllerProtocol = NSProtocolFromString(@"AWEFastSpeedControllerProtocol");
+    if (interactionController && speedControllerProtocol && [interactionController respondsToSelector:@selector(controllerByProtocol:)]) {
+        @try {
+            id speedController = [interactionController controllerByProtocol:speedControllerProtocol];
+            id target = DYYYPlaybackControlTargetFromObject(speedController);
+            if (target) {
+                return target;
+            }
+        } @catch (NSException *exception) {
+        }
+    }
+
+    id target = DYYYPlaybackControlTargetFromObject(interactionController);
+    if (target) {
+        return target;
+    }
+
+    target = DYYYPlaybackControlTargetFromObject(DYYYBestVisiblePlaybackRateTarget(nil));
+    return target;
+}
+
+static BOOL DYYYPlaybackTargetIsPlaying(id target, BOOL *isPlaying) {
+    if (!target || ![target respondsToSelector:@selector(isPlaying)]) {
+        return NO;
+    }
+
+    @try {
+        BOOL (*messageSend)(id, SEL) = (BOOL (*)(id, SEL))objc_msgSend;
+        if (isPlaying) {
+            *isPlaying = messageSend(target, @selector(isPlaying));
+        }
+        return YES;
+    } @catch (NSException *exception) {
+        return NO;
+    }
+}
+
+static BOOL DYYYSendPlaybackControl(id target, SEL selector) {
+    if (!target || ![target respondsToSelector:selector]) {
+        return NO;
+    }
+
+    @try {
+        void (*messageSend)(id, SEL) = (void (*)(id, SEL))objc_msgSend;
+        messageSend(target, selector);
+        return YES;
+    } @catch (NSException *exception) {
+        return NO;
+    }
+}
+
+static BOOL DYYYPlaybackTargetIsVisible(id target) {
+    if ([target isKindOfClass:[UIViewController class]]) {
+        return DYYYViewControllerVisibilityScore((UIViewController *)target) >= 0.0;
+    }
+    if ([target isKindOfClass:[UIView class]]) {
+        UIView *view = (UIView *)target;
+        return view.window && !view.hidden && view.alpha > 0.01 && !CGRectIsEmpty(view.bounds);
+    }
+    return target != nil;
+}
+
+static void DYYYCommentPausePlaybackIfNeeded(void) {
+    if (!DYYYGetBool(@"DYYYCommentPausePlayback") || dyyyCommentPausePlaybackActive) {
+        return;
+    }
+
+    id target = DYYYResolveCommentPausePlaybackTarget();
+    BOOL isPlaying = NO;
+    if (!DYYYPlaybackTargetIsPlaying(target, &isPlaying) || !isPlaying) {
+        return;
+    }
+
+    if (DYYYSendPlaybackControl(target, @selector(pause))) {
+        dyyyCommentPausePlaybackTarget = target;
+        dyyyCommentPausePlaybackActive = YES;
+    }
+}
+
+static void DYYYCommentRestorePlaybackIfNeeded(void) {
+    if (!dyyyCommentPausePlaybackActive) {
+        return;
+    }
+
+    id target = dyyyCommentPausePlaybackTarget;
+    dyyyCommentPausePlaybackActive = NO;
+    dyyyCommentPausePlaybackTarget = nil;
+
+    if (!target || !DYYYPlaybackTargetIsVisible(target)) {
+        return;
+    }
+
+    BOOL isPlaying = NO;
+    if (DYYYPlaybackTargetIsPlaying(target, &isPlaying) && isPlaying) {
+        return;
+    }
+
+    DYYYSendPlaybackControl(target, @selector(play));
 }
 
 static double DYYYConfiguredPlaybackSpeed(void) {
@@ -11318,6 +11469,7 @@ static Class tabBarButtonClass = nil;
     dyyyCommentViewVisible = YES;
     updateSpeedButtonVisibility();
     updateClearButtonVisibility();
+    DYYYCommentPausePlaybackIfNeeded();
     NSString *transparentValue = [[NSUserDefaults standardUserDefaults] objectForKey:@"DYYYTopBarTransparent"];
     if (transparentValue && transparentValue.length > 0) {
         CGFloat alphaValue = [transparentValue floatValue];
@@ -11341,6 +11493,7 @@ static Class tabBarButtonClass = nil;
     dyyyCommentViewVisible = NO;
     updateSpeedButtonVisibility();
     updateClearButtonVisibility();
+    DYYYCommentRestorePlaybackIfNeeded();
 }
 
 - (void)viewDidLayoutSubviews {

--- a/DYYY.xm
+++ b/DYYY.xm
@@ -11173,52 +11173,546 @@ static BOOL DYYYShouldHideTemplateVideoForAweme(AWEAwemeModel *aweme) {
 %hook AWEGeneralSearchModel
 - (instancetype)initWithDictionary:(id)dict error:(NSError **)error {
 	id orig = %orig;
-	
+
 	BOOL noAds = DYYYGetBool(@"DYYYNoAds");
 	if (!noAds || !orig) {
 		return orig;
 	}
-	
+
 	if ([DYYYUtils isAdvertisementContainerModel:orig] || [DYYYUtils isAdvertisementRawData:dict]) {
 		return nil;
 	}
-	
+
 	return orig;
 }
 %end
 
-%group DYYYMiniProgramJumpingAdsGroup
-%hook BDARewardedVideoAdBaseController
-
-- (BOOL)sendReward {
-    if (DYYYGetBool(kDYYYMiniProgramJumpingAdsKey)) {
-        return YES;
-    }
-    return %orig;
+static BOOL DYYYMiniProgramRewardBypassEnabled(void) {
+    return DYYYGetBool(kDYYYMiniProgramJumpingAdsKey);
 }
 
-- (BOOL)sendFirstReward {
-    if (DYYYGetBool(kDYYYMiniProgramJumpingAdsKey)) {
-        return YES;
-    }
-    return %orig;
+static NSMutableDictionary<NSString *, NSValue *> *DYYYMiniProgramRewardOriginalIMPs(void) {
+    static NSMutableDictionary<NSString *, NSValue *> *originalIMPs = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+      originalIMPs = [NSMutableDictionary dictionary];
+    });
+    return originalIMPs;
 }
 
-- (void)viewDidAppear:(BOOL)animated {
-    %orig;
-    if (!DYYYGetBool(kDYYYMiniProgramJumpingAdsKey)) {
+static NSMutableSet<NSString *> *DYYYMiniProgramRewardInstalledHooks(void) {
+    static NSMutableSet<NSString *> *installedHooks = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+      installedHooks = [NSMutableSet set];
+    });
+    return installedHooks;
+}
+
+static NSString *DYYYMiniProgramRewardHookKey(Class cls, SEL selector) {
+    return [NSString stringWithFormat:@"%s:%@", class_getName(cls), NSStringFromSelector(selector)];
+}
+
+static IMP DYYYMiniProgramOriginalIMPForObject(id object, SEL selector) {
+    if (!object || !selector) {
+        return NULL;
+    }
+
+    NSMutableDictionary<NSString *, NSValue *> *originalIMPs = DYYYMiniProgramRewardOriginalIMPs();
+    for (Class cls = object_getClass(object); cls; cls = class_getSuperclass(cls)) {
+        NSString *key = DYYYMiniProgramRewardHookKey(cls, selector);
+        NSValue *value = nil;
+        @synchronized(originalIMPs) {
+            value = [originalIMPs objectForKey:key];
+        }
+        if (value) {
+            return (IMP)[value pointerValue];
+        }
+    }
+
+    return NULL;
+}
+
+static BOOL DYYYMiniProgramHookInstanceMethod(Class cls, SEL selector, IMP replacement) {
+    if (!cls || !selector || !replacement || !class_getInstanceMethod(cls, selector)) {
+        return NO;
+    }
+
+    NSString *key = DYYYMiniProgramRewardHookKey(cls, selector);
+    NSMutableSet<NSString *> *installedHooks = DYYYMiniProgramRewardInstalledHooks();
+    @synchronized(installedHooks) {
+        if ([installedHooks containsObject:key]) {
+            return YES;
+        }
+
+        IMP original = NULL;
+        MSHookMessageEx(cls, selector, replacement, &original);
+        if (original) {
+            NSMutableDictionary<NSString *, NSValue *> *originalIMPs = DYYYMiniProgramRewardOriginalIMPs();
+            @synchronized(originalIMPs) {
+                [originalIMPs setObject:[NSValue valueWithPointer:(const void *)original] forKey:key];
+            }
+        }
+        [installedHooks addObject:key];
+    }
+
+    return YES;
+}
+
+static BOOL DYYYMiniProgramAddRelatedObject(NSMutableArray *objects, NSMutableSet *seenObjects, id object) {
+    if (!object || object == [NSNull null]) {
+        return NO;
+    }
+
+    if ([object isKindOfClass:[NSString class]] ||
+        [object isKindOfClass:[NSNumber class]] ||
+        [object isKindOfClass:[NSArray class]] ||
+        [object isKindOfClass:[NSDictionary class]] ||
+        [object isKindOfClass:[NSSet class]]) {
+        return NO;
+    }
+
+    NSValue *key = [NSValue valueWithNonretainedObject:object];
+    if ([seenObjects containsObject:key]) {
+        return NO;
+    }
+
+    [seenObjects addObject:key];
+    [objects addObject:object];
+    return YES;
+}
+
+static id DYYYMiniProgramObjectForSelector(id object, SEL selector) {
+    if (!object || !selector || ![object respondsToSelector:selector]) {
+        return nil;
+    }
+
+    return ((id (*)(id, SEL))objc_msgSend)(object, selector);
+}
+
+static NSArray *DYYYMiniProgramRewardRelatedObjects(id source) {
+    NSMutableArray *objects = [NSMutableArray array];
+    NSMutableSet *seenObjects = [NSMutableSet set];
+    DYYYMiniProgramAddRelatedObject(objects, seenObjects, source);
+
+    NSArray<NSString *> *selectorNames = @[
+        @"delegate",
+        @"RVController",
+        @"rewardVideoController",
+        @"videoAdViewController",
+        @"adRewardedVideoController"
+    ];
+
+    for (NSUInteger index = 0; index < objects.count && index < 12; index++) {
+        id object = [objects objectAtIndex:index];
+        for (NSString *selectorName in selectorNames) {
+            id relatedObject = DYYYMiniProgramObjectForSelector(object, NSSelectorFromString(selectorName));
+            DYYYMiniProgramAddRelatedObject(objects, seenObjects, relatedObject);
+        }
+    }
+
+    return objects;
+}
+
+static void DYYYMiniProgramSetIntegerIfPossible(id object, SEL selector, NSInteger value) {
+    if (!object || !selector || ![object respondsToSelector:selector]) {
         return;
     }
 
-    SEL closeSelector = NSSelectorFromString(@"close");
-    id controller = (id)self;
-    if ([controller respondsToSelector:closeSelector]) {
-        ((void (*)(id, SEL))objc_msgSend)(controller, closeSelector);
+    ((void (*)(id, SEL, NSInteger))objc_msgSend)(object, selector, value);
+}
+
+static void DYYYMiniProgramMarkRewardStateForObject(id object) {
+    if (!object || !DYYYMiniProgramRewardBypassEnabled()) {
+        return;
+    }
+
+    DYYYMiniProgramSetIntegerIfPossible(object, NSSelectorFromString(@"setDisableHostSendReward:"), 0);
+    DYYYMiniProgramSetIntegerIfPossible(object, NSSelectorFromString(@"setSendReward:"), 1);
+    DYYYMiniProgramSetIntegerIfPossible(object, NSSelectorFromString(@"setSendFirstReward:"), 1);
+    DYYYMiniProgramSetIntegerIfPossible(object, NSSelectorFromString(@"setEnableOneMore:"), 1);
+    DYYYMiniProgramSetIntegerIfPossible(object, NSSelectorFromString(@"setRewardOneMore:"), 1);
+}
+
+static void DYYYMiniProgramMarkRewardState(id source) {
+    for (id object in DYYYMiniProgramRewardRelatedObjects(source)) {
+        DYYYMiniProgramMarkRewardStateForObject(object);
     }
 }
 
-%end
-%end
+static id DYYYMiniProgramPreferredRewardObject(id source) {
+    NSArray *objects = DYYYMiniProgramRewardRelatedObjects(source);
+    for (id object in objects) {
+        if ([object respondsToSelector:NSSelectorFromString(@"sendReward")] ||
+            [object respondsToSelector:NSSelectorFromString(@"sendFirstReward")] ||
+            [object respondsToSelector:NSSelectorFromString(@"close")]) {
+            return object;
+        }
+    }
+
+    return objects.count > 0 ? [objects objectAtIndex:0] : source;
+}
+
+static BOOL DYYYMiniProgramShouldThrottleRewardCallback(id target) {
+    static char kDYYYMiniProgramRewardCallbackThrottleKey;
+    NSTimeInterval now = CACurrentMediaTime();
+    NSNumber *lastTime = objc_getAssociatedObject(target, &kDYYYMiniProgramRewardCallbackThrottleKey);
+    if (lastTime && now - [lastTime doubleValue] < 0.35) {
+        return YES;
+    }
+
+    objc_setAssociatedObject(target, &kDYYYMiniProgramRewardCallbackThrottleKey, @(now), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    return NO;
+}
+
+static __thread NSUInteger dyyyMiniProgramRewardEffectiveNotifyDepth = 0;
+
+static void DYYYMiniProgramNotifyRewardEffective(id source) {
+    if (!DYYYMiniProgramRewardBypassEnabled() || dyyyMiniProgramRewardEffectiveNotifyDepth > 0) {
+        return;
+    }
+
+    NSArray *objects = DYYYMiniProgramRewardRelatedObjects(source);
+    id rewardObject = DYYYMiniProgramPreferredRewardObject(source);
+    SEL effectiveSelector = NSSelectorFromString(@"videoAdBecomeEffective:");
+
+    dyyyMiniProgramRewardEffectiveNotifyDepth++;
+    @try {
+        for (id object in objects) {
+            if (![object respondsToSelector:effectiveSelector] || DYYYMiniProgramShouldThrottleRewardCallback(object)) {
+                continue;
+            }
+            ((void (*)(id, SEL, id))objc_msgSend)(object, effectiveSelector, rewardObject ?: source);
+        }
+    } @catch (__unused NSException *exception) {
+    } @finally {
+        dyyyMiniProgramRewardEffectiveNotifyDepth--;
+    }
+}
+
+static BOOL DYYYMiniProgramIsRewardViewController(id object) {
+    if (!object || ![object isKindOfClass:[UIViewController class]]) {
+        return NO;
+    }
+
+    Class rewardControllerClass = objc_getClass("BDARewardedVideoAdBaseController");
+    if (rewardControllerClass && [object isKindOfClass:rewardControllerClass]) {
+        return YES;
+    }
+
+    NSString *className = NSStringFromClass([object class]);
+    return [className containsString:@"BDARewardedVideo"];
+}
+
+static BOOL DYYYMiniProgramCanCloseRewardViewController(id object) {
+    if (!DYYYMiniProgramRewardBypassEnabled() || !DYYYMiniProgramIsRewardViewController(object)) {
+        return NO;
+    }
+
+    UIApplication *application = [UIApplication sharedApplication];
+    if (application.applicationState != UIApplicationStateActive) {
+        return NO;
+    }
+
+    UIViewController *viewController = (UIViewController *)object;
+    if (!viewController.isViewLoaded || !viewController.view.window || viewController.isBeingDismissed) {
+        return NO;
+    }
+    if (viewController.navigationController && viewController.navigationController.isBeingDismissed) {
+        return NO;
+    }
+
+    return YES;
+}
+
+static BOOL DYYYMiniProgramMarkRewardCloseScheduled(id object) {
+    static char kDYYYMiniProgramRewardCloseThrottleKey;
+    NSTimeInterval now = CACurrentMediaTime();
+    NSNumber *lastTime = objc_getAssociatedObject(object, &kDYYYMiniProgramRewardCloseThrottleKey);
+    if (lastTime && now - [lastTime doubleValue] < 1.5) {
+        return YES;
+    }
+
+    objc_setAssociatedObject(object, &kDYYYMiniProgramRewardCloseThrottleKey, @(now), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    return NO;
+}
+
+static BOOL DYYYMiniProgramCloseRewardViewController(id object) {
+    if (!DYYYMiniProgramCanCloseRewardViewController(object)) {
+        return NO;
+    }
+
+    SEL closeSelector = NSSelectorFromString(@"close");
+    if ([object respondsToSelector:closeSelector]) {
+        ((void (*)(id, SEL))objc_msgSend)(object, closeSelector);
+        return YES;
+    }
+
+    [(UIViewController *)object dismissViewControllerAnimated:NO completion:nil];
+    return YES;
+}
+
+static void DYYYMiniProgramCloseRewardObjectSoon(id source) {
+    if (!DYYYMiniProgramCanCloseRewardViewController(source) || DYYYMiniProgramMarkRewardCloseScheduled(source)) {
+        return;
+    }
+
+    __weak id weakSource = source;
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.25 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+      id object = weakSource;
+      DYYYMiniProgramCloseRewardViewController(object);
+    });
+}
+
+static void DYYYMiniProgramHandleRewardCallback(id owner, id adObject, BOOL shouldClose) {
+    if (!DYYYMiniProgramRewardBypassEnabled()) {
+        return;
+    }
+
+    id source = adObject ?: owner;
+    DYYYMiniProgramMarkRewardState(source);
+    DYYYMiniProgramNotifyRewardEffective(source);
+    if (shouldClose) {
+        DYYYMiniProgramCloseRewardObjectSoon(owner);
+    }
+}
+
+static NSInteger DYYYMiniProgramRewardTrueGetter(id self, SEL _cmd) {
+    if (DYYYMiniProgramRewardBypassEnabled()) {
+        return 1;
+    }
+
+    NSInteger (*original)(id, SEL) = (NSInteger (*)(id, SEL))DYYYMiniProgramOriginalIMPForObject(self, _cmd);
+    return original ? original(self, _cmd) : 0;
+}
+
+static NSInteger DYYYMiniProgramRewardFalseGetter(id self, SEL _cmd) {
+    if (DYYYMiniProgramRewardBypassEnabled()) {
+        return 0;
+    }
+
+    NSInteger (*original)(id, SEL) = (NSInteger (*)(id, SEL))DYYYMiniProgramOriginalIMPForObject(self, _cmd);
+    return original ? original(self, _cmd) : 0;
+}
+
+static void DYYYMiniProgramRewardTrueSetter(id self, SEL _cmd, NSInteger value) {
+    if (DYYYMiniProgramRewardBypassEnabled() && value < 1) {
+        value = 1;
+    }
+
+    void (*original)(id, SEL, NSInteger) = (void (*)(id, SEL, NSInteger))DYYYMiniProgramOriginalIMPForObject(self, _cmd);
+    if (original) {
+        original(self, _cmd, value);
+    }
+}
+
+static void DYYYMiniProgramRewardFalseSetter(id self, SEL _cmd, NSInteger value) {
+    if (DYYYMiniProgramRewardBypassEnabled()) {
+        value = 0;
+    }
+
+    void (*original)(id, SEL, NSInteger) = (void (*)(id, SEL, NSInteger))DYYYMiniProgramOriginalIMPForObject(self, _cmd);
+    if (original) {
+        original(self, _cmd, value);
+    }
+}
+
+static void DYYYMiniProgramRewardSetDelegate(id self, SEL _cmd, id delegate) {
+    void (*original)(id, SEL, id) = (void (*)(id, SEL, id))DYYYMiniProgramOriginalIMPForObject(self, _cmd);
+    if (original) {
+        original(self, _cmd, delegate);
+    }
+
+    DYYYMiniProgramHandleRewardCallback(self, self, NO);
+}
+
+static void DYYYMiniProgramRewardViewDidLoad(id self, SEL _cmd) {
+    void (*original)(id, SEL) = (void (*)(id, SEL))DYYYMiniProgramOriginalIMPForObject(self, _cmd);
+    if (original) {
+        original(self, _cmd);
+    }
+
+    DYYYMiniProgramHandleRewardCallback(self, self, NO);
+}
+
+static void DYYYMiniProgramRewardViewWillAppear(id self, SEL _cmd, BOOL animated) {
+    void (*original)(id, SEL, BOOL) = (void (*)(id, SEL, BOOL))DYYYMiniProgramOriginalIMPForObject(self, _cmd);
+    if (original) {
+        original(self, _cmd, animated);
+    }
+
+    DYYYMiniProgramHandleRewardCallback(self, self, NO);
+}
+
+static void DYYYMiniProgramRewardViewDidAppear(id self, SEL _cmd, BOOL animated) {
+    void (*original)(id, SEL, BOOL) = (void (*)(id, SEL, BOOL))DYYYMiniProgramOriginalIMPForObject(self, _cmd);
+    if (original) {
+        original(self, _cmd, animated);
+    }
+
+    DYYYMiniProgramHandleRewardCallback(self, self, YES);
+}
+
+static void DYYYMiniProgramRewardPrepareForReuse(id self, SEL _cmd) {
+    void (*original)(id, SEL) = (void (*)(id, SEL))DYYYMiniProgramOriginalIMPForObject(self, _cmd);
+    if (original) {
+        original(self, _cmd);
+    }
+
+    DYYYMiniProgramHandleRewardCallback(self, self, NO);
+}
+
+static void DYYYMiniProgramRewardCallback1(id self, SEL _cmd, id arg0) {
+    void (*original)(id, SEL, id) = (void (*)(id, SEL, id))DYYYMiniProgramOriginalIMPForObject(self, _cmd);
+    if (original) {
+        original(self, _cmd, arg0);
+    }
+
+    DYYYMiniProgramHandleRewardCallback(self, arg0, NO);
+}
+
+static void DYYYMiniProgramRewardEffectiveCallback1(id self, SEL _cmd, id arg0) {
+    void (*original)(id, SEL, id) = (void (*)(id, SEL, id))DYYYMiniProgramOriginalIMPForObject(self, _cmd);
+    if (original) {
+        original(self, _cmd, arg0);
+    }
+
+    if (DYYYMiniProgramRewardBypassEnabled()) {
+        DYYYMiniProgramMarkRewardState(arg0 ?: self);
+    }
+}
+
+static void DYYYMiniProgramRewardCallback2(id self, SEL _cmd, id arg0, id arg1) {
+    void (*original)(id, SEL, id, id) = (void (*)(id, SEL, id, id))DYYYMiniProgramOriginalIMPForObject(self, _cmd);
+    if (original) {
+        original(self, _cmd, arg0, arg1);
+    }
+
+    DYYYMiniProgramHandleRewardCallback(self, arg0 ?: arg1, NO);
+}
+
+static void DYYYMiniProgramRewardCallbackBeforeNext(id self, SEL _cmd, id arg0, BOOL isMore, NSInteger index, id info) {
+    void (*original)(id, SEL, id, BOOL, NSInteger, id) = (void (*)(id, SEL, id, BOOL, NSInteger, id))DYYYMiniProgramOriginalIMPForObject(self, _cmd);
+    if (original) {
+        original(self, _cmd, arg0, isMore, index, info);
+    }
+
+    DYYYMiniProgramHandleRewardCallback(self, arg0 ?: info, NO);
+}
+
+static void DYYYMiniProgramRewardCallbackDisplayInfoContext(id self, SEL _cmd, id arg0, id context, NSInteger index, id completion) {
+    void (*original)(id, SEL, id, id, NSInteger, id) = (void (*)(id, SEL, id, id, NSInteger, id))DYYYMiniProgramOriginalIMPForObject(self, _cmd);
+    if (original) {
+        original(self, _cmd, arg0, context, index, completion);
+    }
+
+    DYYYMiniProgramHandleRewardCallback(self, arg0 ?: context, NO);
+}
+
+static void DYYYMiniProgramRewardCallbackDisplayInfo(id self, SEL _cmd, id arg0, NSInteger index, id callback) {
+    void (*original)(id, SEL, id, NSInteger, id) = (void (*)(id, SEL, id, NSInteger, id))DYYYMiniProgramOriginalIMPForObject(self, _cmd);
+    if (original) {
+        original(self, _cmd, arg0, index, callback);
+    }
+
+    DYYYMiniProgramHandleRewardCallback(self, arg0, NO);
+}
+
+static void DYYYMiniProgramHookRewardControllerClass(Class cls) {
+    DYYYMiniProgramHookInstanceMethod(cls, NSSelectorFromString(@"disableHostSendReward"), (IMP)DYYYMiniProgramRewardFalseGetter);
+    DYYYMiniProgramHookInstanceMethod(cls, NSSelectorFromString(@"sendReward"), (IMP)DYYYMiniProgramRewardTrueGetter);
+    DYYYMiniProgramHookInstanceMethod(cls, NSSelectorFromString(@"sendFirstReward"), (IMP)DYYYMiniProgramRewardTrueGetter);
+    DYYYMiniProgramHookInstanceMethod(cls, NSSelectorFromString(@"enableOneMore"), (IMP)DYYYMiniProgramRewardTrueGetter);
+    DYYYMiniProgramHookInstanceMethod(cls, NSSelectorFromString(@"rewardOneMore"), (IMP)DYYYMiniProgramRewardTrueGetter);
+    DYYYMiniProgramHookInstanceMethod(cls, NSSelectorFromString(@"setDisableHostSendReward:"), (IMP)DYYYMiniProgramRewardFalseSetter);
+    DYYYMiniProgramHookInstanceMethod(cls, NSSelectorFromString(@"setSendReward:"), (IMP)DYYYMiniProgramRewardTrueSetter);
+    DYYYMiniProgramHookInstanceMethod(cls, NSSelectorFromString(@"setSendFirstReward:"), (IMP)DYYYMiniProgramRewardTrueSetter);
+    DYYYMiniProgramHookInstanceMethod(cls, NSSelectorFromString(@"setEnableOneMore:"), (IMP)DYYYMiniProgramRewardTrueSetter);
+    DYYYMiniProgramHookInstanceMethod(cls, NSSelectorFromString(@"setRewardOneMore:"), (IMP)DYYYMiniProgramRewardTrueSetter);
+    DYYYMiniProgramHookInstanceMethod(cls, NSSelectorFromString(@"setDelegate:"), (IMP)DYYYMiniProgramRewardSetDelegate);
+    DYYYMiniProgramHookInstanceMethod(cls, NSSelectorFromString(@"viewDidLoad"), (IMP)DYYYMiniProgramRewardViewDidLoad);
+    DYYYMiniProgramHookInstanceMethod(cls, NSSelectorFromString(@"viewWillAppear:"), (IMP)DYYYMiniProgramRewardViewWillAppear);
+    DYYYMiniProgramHookInstanceMethod(cls, NSSelectorFromString(@"viewDidAppear:"), (IMP)DYYYMiniProgramRewardViewDidAppear);
+    DYYYMiniProgramHookInstanceMethod(cls, NSSelectorFromString(@"prepareForReuse"), (IMP)DYYYMiniProgramRewardPrepareForReuse);
+}
+
+static void DYYYMiniProgramHookRewardCallbackClass(Class cls) {
+    DYYYMiniProgramHookInstanceMethod(cls, NSSelectorFromString(@"videoAdDidLoadSuccess:"), (IMP)DYYYMiniProgramRewardCallback1);
+    DYYYMiniProgramHookInstanceMethod(cls, NSSelectorFromString(@"videoAdBecomeEffective:"), (IMP)DYYYMiniProgramRewardEffectiveCallback1);
+    DYYYMiniProgramHookInstanceMethod(cls, NSSelectorFromString(@"videoAd:didClickCloseWithInfo:"), (IMP)DYYYMiniProgramRewardCallback2);
+    DYYYMiniProgramHookInstanceMethod(cls, NSSelectorFromString(@"videoAdBeforeStartRequestNextReward:isMore:index:info:"), (IMP)DYYYMiniProgramRewardCallbackBeforeNext);
+    DYYYMiniProgramHookInstanceMethod(cls, NSSelectorFromString(@"videoAdMoreRewardDisplayInfo:context:index:completion:"), (IMP)DYYYMiniProgramRewardCallbackDisplayInfoContext);
+    DYYYMiniProgramHookInstanceMethod(cls, NSSelectorFromString(@"videoAdMoreRewardDisplayInfo:index:callBack:"), (IMP)DYYYMiniProgramRewardCallbackDisplayInfo);
+}
+
+static void DYYYMiniProgramInstallRewardBypassHooks(void);
+
+static void DYYYScheduleMiniProgramRewardHookRetry(NSTimeInterval delay) {
+    static BOOL retryScheduled = NO;
+    if (retryScheduled) {
+        return;
+    }
+
+    retryScheduled = YES;
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delay * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+      retryScheduled = NO;
+      DYYYMiniProgramInstallRewardBypassHooks();
+    });
+}
+
+static void DYYYMiniProgramInstallRewardBypassHooks(void) {
+    if (![NSThread isMainThread]) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+          DYYYMiniProgramInstallRewardBypassHooks();
+        });
+        return;
+    }
+
+    Class rewardControllerClass = objc_getClass("BDARewardedVideoAdBaseController");
+    if (rewardControllerClass) {
+        DYYYMiniProgramHookRewardControllerClass(rewardControllerClass);
+    }
+
+    NSArray<NSString *> *rewardCallbackClassNames = @[
+        @"CMCRVSDKManager",
+        @"AWERewardedVideoManager",
+        @"BDPAppVideoAdvertisementImpl",
+        @"BDPBDAVideoAd",
+        @"BDPGameVideoAdvertisementImplHg",
+        @"BDAROpenRewardSession",
+        @"BDUGLuckyADRewardVideoManager",
+        @"AWEPayRewardVideoDelegateImp",
+        @"IESECMallAdRewardDelegateImp",
+        @"IESGCPADRewardTaskImp"
+    ];
+
+    for (NSString *className in rewardCallbackClassNames) {
+        Class cls = objc_getClass(className.UTF8String);
+        if (cls) {
+            DYYYMiniProgramHookRewardCallbackClass(cls);
+        }
+    }
+
+    static NSUInteger retryCount = 0;
+    if (retryCount < 40) {
+        retryCount++;
+        DYYYScheduleMiniProgramRewardHookRetry(0.5);
+    }
+}
+
+static void DYYYStartMiniProgramRewardBypassHookInstaller(void) {
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+      DYYYMiniProgramInstallRewardBypassHooks();
+      NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
+      [center addObserverForName:NSBundleDidLoadNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(__unused NSNotification *notification) {
+          DYYYMiniProgramInstallRewardBypassHooks();
+      }];
+      [center addObserverForName:UIApplicationDidBecomeActiveNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(__unused NSNotification *notification) {
+          DYYYMiniProgramInstallRewardBypassHooks();
+      }];
+    });
+}
 
 // 去除启动视频广告
 %hook AWEAwesomeSplashFeedCellOldAccessoryView
@@ -14964,9 +15458,7 @@ static void findTargetViewInView(UIView *view) {
         }
         [FloatingSpeedButton reloadConfiguration];
 
-        if (objc_getClass("BDARewardedVideoAdBaseController")) {
-            %init(DYYYMiniProgramJumpingAdsGroup);
-        }
+        DYYYStartMiniProgramRewardBypassHookInstaller();
 
         // 初始化红包激励挂件容器视图类组
         Class incentivePendantClass = objc_getClass("AWEIncentiveSwiftImplDOUYINLite.IncentivePendantContainerView");

--- a/DYYY.xm
+++ b/DYYY.xm
@@ -5017,6 +5017,245 @@ static BOOL isGestureActive = NO;
 }
 %end
 
+static char kDYYYAvatarPreviewSaveLongPressKey;
+
+static id DYYYAvatarPreviewObjectForSelector(id object, NSString *selectorName) {
+    if (!object || selectorName.length == 0) {
+        return nil;
+    }
+
+    SEL selector = NSSelectorFromString(selectorName);
+    if (![object respondsToSelector:selector]) {
+        return nil;
+    }
+
+    return ((id (*)(id, SEL))objc_msgSend)(object, selector);
+}
+
+static NSURL *DYYYAvatarPreviewURLFromString(NSString *urlString) {
+    if (![urlString isKindOfClass:NSString.class] || urlString.length == 0) {
+        return nil;
+    }
+
+    NSString *normalizedURLString = urlString;
+    if ([normalizedURLString hasPrefix:@"//"]) {
+        normalizedURLString = [@"https:" stringByAppendingString:normalizedURLString];
+    }
+
+    NSURL *url = [NSURL URLWithString:normalizedURLString];
+    if (!url.scheme || !url.host) {
+        return nil;
+    }
+
+    return url;
+}
+
+static NSURL *DYYYAvatarPreviewURLFromURLList(NSArray *urlList) {
+    if (![urlList isKindOfClass:NSArray.class] || urlList.count == 0) {
+        return nil;
+    }
+
+    for (id urlValue in urlList) {
+        if ([urlValue isKindOfClass:NSURL.class]) {
+            return urlValue;
+        }
+        NSURL *url = DYYYAvatarPreviewURLFromString(urlValue);
+        if (url) {
+            return url;
+        }
+    }
+
+    return nil;
+}
+
+static NSURL *DYYYAvatarPreviewURLFromObject(id object) {
+    if (!object) {
+        return nil;
+    }
+
+    if ([object isKindOfClass:NSURL.class]) {
+        return object;
+    }
+
+    if ([object isKindOfClass:NSString.class]) {
+        return DYYYAvatarPreviewURLFromString(object);
+    }
+
+    if ([object isKindOfClass:NSArray.class]) {
+        return DYYYAvatarPreviewURLFromURLList(object);
+    }
+
+    NSURL *originURL = DYYYAvatarPreviewURLFromURLList(DYYYAvatarPreviewObjectForSelector(object, @"originURLList"));
+    if (originURL) {
+        return originURL;
+    }
+
+    NSURL *urlListURL = DYYYAvatarPreviewURLFromURLList(DYYYAvatarPreviewObjectForSelector(object, @"URLList"));
+    if (urlListURL) {
+        return urlListURL;
+    }
+
+    id dyyyDownloadURL = DYYYAvatarPreviewObjectForSelector(object, @"getDYYYSrcURLDownload");
+    if ([dyyyDownloadURL isKindOfClass:NSURL.class]) {
+        return dyyyDownloadURL;
+    }
+
+    return nil;
+}
+
+static NSURL *DYYYAvatarPreviewSourceURLForController(id controller) {
+    NSArray<NSString *> *controllerURLSelectors = @[
+        @"avatarImageURL",
+        @"avatarImagePlaceholderURL",
+    ];
+
+    for (NSString *selectorName in controllerURLSelectors) {
+        NSURL *url = DYYYAvatarPreviewURLFromObject(DYYYAvatarPreviewObjectForSelector(controller, selectorName));
+        if (url) {
+            return url;
+        }
+    }
+
+    id user = DYYYAvatarPreviewObjectForSelector(controller, @"user");
+    NSArray<NSString *> *userAvatarSelectors = @[
+        @"avatarLarger",
+        @"avatar300X300",
+        @"avatar300x300",
+        @"avatar168X168",
+        @"avatar168x168",
+        @"avatarMedium",
+        @"avatarThumb",
+    ];
+
+    for (NSString *selectorName in userAvatarSelectors) {
+        NSURL *url = DYYYAvatarPreviewURLFromObject(DYYYAvatarPreviewObjectForSelector(user, selectorName));
+        if (url) {
+            return url;
+        }
+    }
+
+    return nil;
+}
+
+static BOOL DYYYInvokeAvatarPreviewNativeSave(id controller) {
+    id functionManager = DYYYAvatarPreviewObjectForSelector(controller, @"functionManager");
+    if (!functionManager || ![functionManager respondsToSelector:@selector(didClickedSaveAvatar)]) {
+        return NO;
+    }
+
+    ((void (*)(id, SEL))objc_msgSend)(functionManager, @selector(didClickedSaveAvatar));
+    return YES;
+}
+
+static void DYYYAttachAvatarPreviewSaveLongPressToView(id controller, UIView *targetView) {
+    if (!controller || !targetView || objc_getAssociatedObject(targetView, &kDYYYAvatarPreviewSaveLongPressKey)) {
+        return;
+    }
+
+    targetView.userInteractionEnabled = YES;
+    UILongPressGestureRecognizer *longPress = [[UILongPressGestureRecognizer alloc] initWithTarget:controller action:@selector(dyyy_handleAvatarPreviewSaveLongPress:)];
+    longPress.minimumPressDuration = 0.5;
+    longPress.cancelsTouchesInView = NO;
+    [targetView addGestureRecognizer:longPress];
+    objc_setAssociatedObject(targetView, &kDYYYAvatarPreviewSaveLongPressKey, longPress, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    objc_setAssociatedObject(longPress, &kDYYYAvatarPreviewSaveLongPressKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+static void DYYYAttachAvatarPreviewSaveLongPress(id controller) {
+    if (!controller || !DYYYGetBool(@"DYYYEnableSaveAvatar")) {
+        return;
+    }
+
+    id gestureView = DYYYAvatarPreviewObjectForSelector(controller, @"avatarGestureView");
+    if ([gestureView isKindOfClass:UIView.class]) {
+        DYYYAttachAvatarPreviewSaveLongPressToView(controller, gestureView);
+    }
+
+    id imageView = DYYYAvatarPreviewObjectForSelector(controller, @"avatarImageView");
+    if ([imageView isKindOfClass:UIView.class]) {
+        DYYYAttachAvatarPreviewSaveLongPressToView(controller, imageView);
+    }
+
+    id rootView = DYYYAvatarPreviewObjectForSelector(controller, @"view");
+    if ([rootView isKindOfClass:UIView.class]) {
+        DYYYAttachAvatarPreviewSaveLongPressToView(controller, rootView);
+    }
+}
+
+%hook AWEProfileAvatarViewController
+- (void)viewDidLoad {
+    %orig;
+    DYYYAttachAvatarPreviewSaveLongPress(self);
+}
+
+- (void)viewDidAppear:(BOOL)animated {
+    %orig(animated);
+    DYYYAttachAvatarPreviewSaveLongPress(self);
+}
+
+- (void)p_setupViews {
+    %orig;
+    DYYYAttachAvatarPreviewSaveLongPress(self);
+}
+
+%new
+- (void)dyyy_saveAvatarPreviewFromDouyinSource {
+    NSURL *avatarURL = DYYYAvatarPreviewSourceURLForController(self);
+    if (avatarURL) {
+        [DYYYManager downloadMedia:avatarURL
+                         mediaType:MediaTypeImage
+                             audio:nil
+                        completion:^(BOOL success) {
+                          if (!success) {
+                              [DYYYUtils showToast:@"头像下载失败"];
+                          }
+                        }];
+        return;
+    }
+
+    if (DYYYInvokeAvatarPreviewNativeSave(self)) {
+        [DYYYUtils showToast:@"正在保存头像..."];
+        return;
+    }
+
+    [DYYYUtils showToast:@"无法获取头像原始链接"];
+}
+
+%new
+- (void)dyyy_handleAvatarPreviewSaveLongPress:(UILongPressGestureRecognizer *)gesture {
+    if (gesture.state != UIGestureRecognizerStateBegan || !DYYYGetBool(@"DYYYEnableSaveAvatar")) {
+        return;
+    }
+
+    UIAlertController *alert = [UIAlertController alertControllerWithTitle:nil message:nil preferredStyle:UIAlertControllerStyleActionSheet];
+    [alert addAction:[UIAlertAction actionWithTitle:@"保存头像"
+                                              style:UIAlertActionStyleDefault
+                                            handler:^(__unused UIAlertAction *action) {
+                                              ((void (*)(id, SEL))objc_msgSend)(self, @selector(dyyy_saveAvatarPreviewFromDouyinSource));
+                                            }]];
+    [alert addAction:[UIAlertAction actionWithTitle:@"取消" style:UIAlertActionStyleCancel handler:nil]];
+
+    UIView *sourceView = gesture.view;
+    if (!sourceView) {
+        id rootView = DYYYAvatarPreviewObjectForSelector(self, @"view");
+        if ([rootView isKindOfClass:UIView.class]) {
+            sourceView = rootView;
+        }
+    }
+    if (alert.popoverPresentationController && sourceView) {
+        alert.popoverPresentationController.sourceView = sourceView;
+        CGPoint location = [gesture locationInView:sourceView];
+        alert.popoverPresentationController.sourceRect = CGRectMake(location.x, location.y, 1.0, 1.0);
+    }
+
+    UIViewController *presentingController = (UIViewController *)self;
+    while (presentingController.presentedViewController) {
+        presentingController = presentingController.presentedViewController;
+    }
+    [presentingController presentViewController:alert animated:YES completion:nil];
+}
+%end
+
 %hook AWECommentMediaDownloadConfigLivePhoto
 
 BOOL commentLivePhotoNotWaterMark = DYYYGetBool(@"DYYYCommentLivePhotoNotWaterMark");

--- a/DYYY.xm
+++ b/DYYY.xm
@@ -222,6 +222,7 @@ static BOOL DYYYShouldHandleSpeedFeatures(void) {
 }
 
 static __weak AWEPlayInteractionViewController *dyyyActiveSpeedInteractionController = nil;
+static __weak UIViewController *dyyyActiveSpeedPlayerViewController = nil;
 static __weak AWEAwemeModel *dyyyCurrentSpeedAweme = nil;
 static NSString *dyyyLastAutoRestoredSpeedAwemeIdentifier = nil;
 static BOOL dyyyLongPressFastSpeedActive = NO;
@@ -383,6 +384,43 @@ id DYYYCurrentSpeedInteractionController(void) {
     return DYYYResolveCurrentSpeedInteractionController(dyyyActiveSpeedInteractionController);
 }
 
+static id DYYYBestVisiblePlaybackRateTarget(id preferredTarget) {
+    if ([preferredTarget isKindOfClass:[UIViewController class]] &&
+        [preferredTarget respondsToSelector:@selector(setVideoControllerPlaybackRate:)] &&
+        DYYYViewControllerVisibilityScore((UIViewController *)preferredTarget) >= 0.0) {
+        return preferredTarget;
+    }
+
+    UIViewController *activePlayerViewController = dyyyActiveSpeedPlayerViewController;
+    if (activePlayerViewController &&
+        [activePlayerViewController respondsToSelector:@selector(setVideoControllerPlaybackRate:)] &&
+        DYYYViewControllerVisibilityScore(activePlayerViewController) >= 0.0) {
+        return activePlayerViewController;
+    }
+
+    UIWindow *window = [DYYYUtils getActiveWindow];
+    UIViewController *rootViewController = window.rootViewController;
+    while (rootViewController.presentedViewController) {
+        rootViewController = rootViewController.presentedViewController;
+    }
+
+    UIViewController *bestPlayerViewController = nil;
+    CGFloat bestPlayerVisibilityScore = -1.0;
+    for (UIViewController *viewController in rootViewController ? findViewControllersInHierarchy(rootViewController) : @[]) {
+        if ([viewController isKindOfClass:NSClassFromString(@"AWEAwemePlayVideoViewController")] ||
+            [viewController isKindOfClass:NSClassFromString(@"AWEDPlayerFeedPlayerViewController")] ||
+            [viewController isKindOfClass:NSClassFromString(@"AWEDPlayerViewController_Merge")]) {
+            CGFloat visibilityScore = DYYYViewControllerVisibilityScore(viewController);
+            if (visibilityScore > bestPlayerVisibilityScore) {
+                bestPlayerVisibilityScore = visibilityScore;
+                bestPlayerViewController = viewController;
+            }
+        }
+    }
+
+    return bestPlayerViewController;
+}
+
 static void DYYYEnsureFloatSpeedButton(AWEPlayInteractionViewController *interactionController) {
     [FloatingSpeedButton reloadConfiguration];
     AWEAwemeModel *targetAweme = dyyyCurrentSpeedAweme;
@@ -457,6 +495,9 @@ static BOOL DYYYSetPlaybackRateOnTarget(id target, double speed) {
 
     @try {
         [(AWEAwemePlayVideoViewController *)target setVideoControllerPlaybackRate:speed];
+        if ([target isKindOfClass:[UIViewController class]]) {
+            dyyyActiveSpeedPlayerViewController = (UIViewController *)target;
+        }
         return YES;
     } @catch (NSException *exception) {
         return NO;
@@ -487,27 +528,11 @@ static BOOL DYYYApplyPlaybackSpeed(AWEPlayInteractionViewController *interaction
         return YES;
     }
 
-    UIWindow *window = [DYYYUtils getActiveWindow];
-    UIViewController *rootViewController = window.rootViewController;
-    while (rootViewController.presentedViewController) {
-        rootViewController = rootViewController.presentedViewController;
-    }
+    return DYYYSetPlaybackRateOnTarget(DYYYBestVisiblePlaybackRateTarget(nil), speed);
+}
 
-    UIViewController *bestPlayerViewController = nil;
-    CGFloat bestPlayerVisibilityScore = -1.0;
-    for (UIViewController *viewController in rootViewController ? findViewControllersInHierarchy(rootViewController) : @[]) {
-        if ([viewController isKindOfClass:NSClassFromString(@"AWEAwemePlayVideoViewController")] ||
-            [viewController isKindOfClass:NSClassFromString(@"AWEDPlayerFeedPlayerViewController")] ||
-            [viewController isKindOfClass:NSClassFromString(@"AWEDPlayerViewController_Merge")]) {
-            CGFloat visibilityScore = DYYYViewControllerVisibilityScore(viewController);
-            if (visibilityScore > bestPlayerVisibilityScore) {
-                bestPlayerVisibilityScore = visibilityScore;
-                bestPlayerViewController = viewController;
-            }
-        }
-    }
-
-    return DYYYSetPlaybackRateOnTarget(bestPlayerViewController, speed);
+static BOOL DYYYApplyPlaybackSpeedToVisiblePlayer(double speed) {
+    return DYYYSetPlaybackRateOnTarget(DYYYBestVisiblePlaybackRateTarget(nil), speed);
 }
 
 static double DYYYConfiguredPlaybackSpeed(void) {
@@ -557,24 +582,53 @@ static void DYYYApplyPreparedPlaybackSpeedToPlayer(id playerViewController) {
     }
 }
 
-static void DYYYBindAndApplyCurrentPlaybackSpeed(void) {
+static void DYYYSchedulePreparedPlaybackSpeedToPlayer(id playerViewController, NSTimeInterval delay) {
+    if (!playerViewController) {
+        return;
+    }
+
+    __weak id weakPlayerViewController = playerViewController;
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delay * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+      id strongPlayerViewController = weakPlayerViewController;
+      if (strongPlayerViewController) {
+          DYYYApplyPreparedPlaybackSpeedToPlayer(strongPlayerViewController);
+      }
+    });
+}
+
+static void DYYYApplyPreparedPlaybackSpeedToPlayerWithRetry(id playerViewController) {
+    DYYYApplyPreparedPlaybackSpeedToPlayer(playerViewController);
+    DYYYSchedulePreparedPlaybackSpeedToPlayer(playerViewController, 0.2);
+}
+
+static void DYYYBindAndApplyCurrentPlaybackSpeedAllowingVisibleFallback(BOOL allowVisibleFallback) {
     if (!DYYYShouldHandleSpeedFeatures() || dyyyLongPressFastSpeedActive || dyyyLongPressLockedSpeedActive) {
         return;
     }
 
     AWEAwemeModel *targetAweme = dyyyCurrentSpeedAweme;
-    AWEPlayInteractionViewController *currentController = DYYYResolveSpeedInteractionController(nil, targetAweme, targetAweme == nil);
+    double speed = DYYYConfiguredPlaybackSpeed();
+    AWEPlayInteractionViewController *currentController = DYYYResolveSpeedInteractionController(nil, targetAweme, allowVisibleFallback || targetAweme == nil);
     if (!currentController) {
+        if (allowVisibleFallback) {
+            DYYYApplyPlaybackSpeedToVisiblePlayer(speed);
+        }
         return;
     }
 
     DYYYEnsureFloatSpeedButton(currentController);
-    DYYYApplyPlaybackSpeed(currentController, DYYYConfiguredPlaybackSpeed());
+    if (!DYYYApplyPlaybackSpeed(currentController, speed) && allowVisibleFallback) {
+        DYYYApplyPlaybackSpeedToVisiblePlayer(speed);
+    }
 }
 
-static void DYYYScheduleConfiguredPlaybackSpeedRestoreAfterDelay(NSTimeInterval delay) {
+static void DYYYBindAndApplyCurrentPlaybackSpeed(void) {
+    DYYYBindAndApplyCurrentPlaybackSpeedAllowingVisibleFallback(NO);
+}
+
+static void DYYYScheduleConfiguredPlaybackSpeedRestoreAfterDelayAllowingVisibleFallback(NSTimeInterval delay, BOOL allowVisibleFallback) {
     dispatch_block_t restoreBlock = ^{
-      DYYYBindAndApplyCurrentPlaybackSpeed();
+      DYYYBindAndApplyCurrentPlaybackSpeedAllowingVisibleFallback(allowVisibleFallback);
     };
     if (delay <= 0.0) {
         dispatch_async(dispatch_get_main_queue(), restoreBlock);
@@ -583,9 +637,13 @@ static void DYYYScheduleConfiguredPlaybackSpeedRestoreAfterDelay(NSTimeInterval 
     }
 }
 
+static void DYYYScheduleConfiguredPlaybackSpeedRestoreAllowingVisibleFallback(BOOL allowVisibleFallback) {
+    DYYYScheduleConfiguredPlaybackSpeedRestoreAfterDelayAllowingVisibleFallback(0.0, allowVisibleFallback);
+    DYYYScheduleConfiguredPlaybackSpeedRestoreAfterDelayAllowingVisibleFallback(0.2, allowVisibleFallback);
+}
+
 static void DYYYScheduleConfiguredPlaybackSpeedRestore(void) {
-    DYYYScheduleConfiguredPlaybackSpeedRestoreAfterDelay(0.0);
-    DYYYScheduleConfiguredPlaybackSpeedRestoreAfterDelay(0.2);
+    DYYYScheduleConfiguredPlaybackSpeedRestoreAllowingVisibleFallback(NO);
 }
 
 static void DYYYEndLockedLongPressSpeedAndRestoreIfNeeded(void) {
@@ -615,8 +673,8 @@ static void DYYYHandleCurrentSpeedAwemeChanged(id aweme) {
     DYYYClearLongPressSpeedState();
     DYYYRestoreFloatSpeedButtonForAwemeIfNeeded(dyyyCurrentSpeedAweme);
 
-    DYYYBindAndApplyCurrentPlaybackSpeed();
-    DYYYScheduleConfiguredPlaybackSpeedRestore();
+    DYYYBindAndApplyCurrentPlaybackSpeedAllowingVisibleFallback(YES);
+    DYYYScheduleConfiguredPlaybackSpeedRestoreAllowingVisibleFallback(YES);
 }
 
 @interface AWEFeedProgressSlider (DYYYProgressLabel)
@@ -11600,7 +11658,15 @@ static Class tabBarButtonClass = nil;
     dyyyCurrentSpeedAweme = self.model;
     DYYYRestoreFloatSpeedButtonForAwemeIfNeeded(self.model);
     DYYYEnsureFloatSpeedButton(self);
+    DYYYScheduleConfiguredPlaybackSpeedRestoreAllowingVisibleFallback(YES);
     reloadClearButtonConfiguration();
+}
+
+- (void)setModel:(AWEAwemeModel *)model {
+    %orig(model);
+    if (self.view.window && !self.view.hidden) {
+        DYYYHandleCurrentSpeedAwemeChanged(model);
+    }
 }
 
 - (void)viewDidLayoutSubviews {
@@ -11774,7 +11840,7 @@ static Class tabBarButtonClass = nil;
 
 - (void)setIsAutoPlay:(BOOL)arg0 {
     %orig(arg0);
-    DYYYApplyPreparedPlaybackSpeedToPlayer(self);
+    DYYYApplyPreparedPlaybackSpeedToPlayerWithRetry(self);
 }
 
 - (void)prepareForDisplay {
@@ -11783,7 +11849,7 @@ static Class tabBarButtonClass = nil;
         return;
     }
 
-    DYYYApplyPreparedPlaybackSpeedToPlayer(self);
+    DYYYApplyPreparedPlaybackSpeedToPlayerWithRetry(self);
     updateSpeedButtonUI();
 }
 
@@ -11824,7 +11890,7 @@ static Class tabBarButtonClass = nil;
 
 - (void)setIsAutoPlay:(BOOL)arg0 {
     %orig(arg0);
-    DYYYApplyPreparedPlaybackSpeedToPlayer(self);
+    DYYYApplyPreparedPlaybackSpeedToPlayerWithRetry(self);
 }
 
 - (void)prepareForDisplay {
@@ -11832,7 +11898,7 @@ static Class tabBarButtonClass = nil;
     if (!DYYYShouldHandleSpeedFeatures()) {
         return;
     }
-    DYYYApplyPreparedPlaybackSpeedToPlayer(self);
+    DYYYApplyPreparedPlaybackSpeedToPlayerWithRetry(self);
     updateSpeedButtonUI();
 }
 
@@ -11873,7 +11939,7 @@ static Class tabBarButtonClass = nil;
 
 - (void)setIsAutoPlay:(BOOL)arg0 {
     %orig(arg0);
-    DYYYApplyPreparedPlaybackSpeedToPlayer(self);
+    DYYYApplyPreparedPlaybackSpeedToPlayerWithRetry(self);
 }
 
 - (void)prepareForDisplay {
@@ -11881,7 +11947,7 @@ static Class tabBarButtonClass = nil;
     if (!DYYYShouldHandleSpeedFeatures()) {
         return;
     }
-    DYYYApplyPreparedPlaybackSpeedToPlayer(self);
+    DYYYApplyPreparedPlaybackSpeedToPlayerWithRetry(self);
     updateSpeedButtonUI();
 }
 

--- a/DYYY.xm
+++ b/DYYY.xm
@@ -6967,6 +6967,79 @@ static void DYYYApplyAvatarFollowPromptSettingsWithRetry(id owner) {
 }
 %end
 
+// 隐藏文案下推荐应用下载横幅
+static void DYYYHideRecommendAppDownloadViewForOwner(id owner) {
+    id addFeedMusicView = DYYYKVCValueIfPossible(owner, @"addFeedMusicView");
+    if ([addFeedMusicView isKindOfClass:[UIView class]]) {
+        UIView *view = (UIView *)addFeedMusicView;
+        view.hidden = YES;
+        [view removeFromSuperview];
+    }
+    DYYYSetKVCValueIfPossible(owner, @"addFeedMusicView", nil);
+}
+
+%hook AWEPlayInteractionMusicAiRefactorListenFeedController
+
+- (BOOL)shouldShowAddFeedMusicView {
+    if (DYYYGetBool(@"DYYYHideRecommendAppDownload")) {
+        return NO;
+    }
+    return %orig;
+}
+
+- (void)showFeedMusicViewIfNeeded {
+    if (DYYYGetBool(@"DYYYHideRecommendAppDownload")) {
+        DYYYHideRecommendAppDownloadViewForOwner(self);
+        return;
+    }
+    %orig;
+}
+
+- (void)setAddFeedMusicView:(UIView *)view {
+    if (DYYYGetBool(@"DYYYHideRecommendAppDownload")) {
+        if ([view isKindOfClass:[UIView class]]) {
+            view.hidden = YES;
+            [view removeFromSuperview];
+        }
+        %orig(nil);
+        return;
+    }
+    %orig;
+}
+
+- (void)updateAddFeedMusicViewLayoutWithShowSpeedControl:(BOOL)showSpeedControl {
+    if (DYYYGetBool(@"DYYYHideRecommendAppDownload")) {
+        DYYYHideRecommendAppDownloadViewForOwner(self);
+        return;
+    }
+    %orig;
+}
+
+%end
+
+%hook AWEFeedMeetMusicView
+
+- (void)layoutSubviews {
+    if (DYYYGetBool(@"DYYYHideRecommendAppDownload")) {
+        UIView *view = (UIView *)self;
+        view.hidden = YES;
+        [view removeFromSuperview];
+        return;
+    }
+    %orig;
+}
+
+- (void)didMoveToWindow {
+    %orig;
+    if (DYYYGetBool(@"DYYYHideRecommendAppDownload")) {
+        UIView *view = (UIView *)self;
+        view.hidden = YES;
+        [view removeFromSuperview];
+    }
+}
+
+%end
+
 %hook AWEMusicCoverButton
 
 - (void)layoutSubviews {

--- a/DYYY.xm
+++ b/DYYY.xm
@@ -41,8 +41,399 @@ static CGFloat gCurrentTabBarHeight = kInvalidHeight;
 static CGFloat originalTabBarHeight = kInvalidHeight;
 static NSString *const kDYYYGlobalTransparencyKey = @"DYYYGlobalTransparency";
 static NSString *const kDYYYGlobalTransparencyDidChangeNotification = @"DYYYGlobalTransparencyDidChangeNotification";
+static NSString *const kDYYYEnableLoginBypassKey = @"DYYYEnableLoginBypass";
 static char kDYYYGlobalTransparencyBaseAlphaKey;
 static NSInteger dyyyGlobalTransparencyMutationDepth = 0;
+
+static BOOL DYYYLoginBypassEnabled(void) {
+    id storedValue = [[NSUserDefaults standardUserDefaults] objectForKey:kDYYYEnableLoginBypassKey];
+    return storedValue == nil ? YES : [storedValue boolValue];
+}
+
+static BOOL DYYYShouldBlockVersionUpdateWorkflow(void) {
+    return DYYYGetBool(@"DYYYNoUpdates") || DYYYLoginBypassEnabled();
+}
+
+static void DYYYLoginBypassInvokeCloseCallback(id callback) {
+    if (!callback) {
+        return;
+    }
+
+    void (^completionBlock)(void) = callback;
+    completionBlock();
+}
+
+static NSArray<NSString *> *DYYYLoginBypassTargetBundleIdentifiers(void) {
+    static NSArray<NSString *> *bundleIdentifiers = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+      bundleIdentifiers = @[
+          @"com.ss.iphone.ugc.Aweme",
+          @"com.ss.iphone.ugc.Aweme.beta",
+          @"com.ss.iphone.ugc.Aweme.internal",
+          @"com.ss.iphone.ugc.aweme.lite"
+      ];
+    });
+    return bundleIdentifiers;
+}
+
+static BOOL DYYYLoginBypassIsTargetBundleIdentifier(id value) {
+    if (![value isKindOfClass:[NSString class]]) {
+        return NO;
+    }
+
+    for (NSString *bundleIdentifier in DYYYLoginBypassTargetBundleIdentifiers()) {
+        if ([value isEqualToString:bundleIdentifier]) {
+            return YES;
+        }
+    }
+    return NO;
+}
+
+static NSArray<NSString *> *DYYYLoginBypassEmojiSuffixes(void) {
+    static NSArray<NSString *> *suffixes = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+      suffixes = @[
+          @"\U0001F60A",
+          @"\U0001F60E",
+          @"\U0001F914",
+          @"\U0001F609",
+          @"\U0001F60B",
+          @"\U0001F60D",
+          @"\U0001F970",
+          @"\U0001F618",
+          @"\U0001F617",
+          @"\U0001F619",
+          @"\U0001F61A",
+          @"\U0001F642",
+          @"\U0001F917",
+          @"\U0001F929",
+          @"\U0001F928",
+          @"\U0001F9D0",
+          @"\U0001F913",
+          @"\U0001F607",
+          @"\U0001F973",
+          @"\U0001F60C",
+          @"\U0001F60F",
+          @"\U0001F60A",
+          @"\U0001F612",
+          @"\U0001F643"
+      ];
+    });
+    return suffixes;
+}
+
+static NSMutableDictionary<NSString *, NSString *> *DYYYLoginBypassReplacementCache(void) {
+    static NSMutableDictionary<NSString *, NSString *> *cache = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+      cache = [NSMutableDictionary dictionary];
+      [NSTimer scheduledTimerWithTimeInterval:60.0
+                                      repeats:YES
+                                        block:^(__unused NSTimer *timer) {
+                                          @synchronized(cache) {
+                                              [cache removeAllObjects];
+                                          }
+                                        }];
+    });
+    return cache;
+}
+
+static NSString *DYYYLoginBypassReplacementBundleIdentifier(NSString *bundleIdentifier) {
+    if (!DYYYLoginBypassEnabled() || !DYYYLoginBypassIsTargetBundleIdentifier(bundleIdentifier)) {
+        return bundleIdentifier;
+    }
+
+    NSMutableDictionary<NSString *, NSString *> *cache = DYYYLoginBypassReplacementCache();
+    @synchronized(cache) {
+        NSString *cachedValue = cache[bundleIdentifier];
+        if (cachedValue.length > 0) {
+            return cachedValue;
+        }
+
+        NSArray<NSString *> *suffixes = DYYYLoginBypassEmojiSuffixes();
+        if (suffixes.count == 0) {
+            return bundleIdentifier;
+        }
+
+        NSString *suffix = suffixes[arc4random_uniform((uint32_t)suffixes.count)];
+        NSString *replacement = [bundleIdentifier stringByAppendingString:suffix];
+        if (replacement.length > 0 && cache.count <= 99) {
+            cache[bundleIdentifier] = replacement;
+        }
+        return replacement ?: bundleIdentifier;
+    }
+}
+
+static NSString *DYYYLoginBypassHeaderValueByReplacingBundleIdentifier(NSString *value, NSString *field) {
+    if (!DYYYLoginBypassEnabled() || ![value isKindOfClass:[NSString class]] || ![field isKindOfClass:[NSString class]]) {
+        return value;
+    }
+
+    NSString *lowercaseField = [field lowercaseString];
+    BOOL isBundleHeaderField = [lowercaseField isEqualToString:@"x-bundle-id"] || [lowercaseField isEqualToString:@"bundle-identifier"] ||
+                               [lowercaseField isEqualToString:@"app-bundle-id"] || [lowercaseField isEqualToString:@"x-app-bundle-id"];
+    if (!isBundleHeaderField || !DYYYLoginBypassIsTargetBundleIdentifier(value)) {
+        return value;
+    }
+
+    return DYYYLoginBypassReplacementBundleIdentifier(value);
+}
+
+static NSDictionary *DYYYLoginBypassHeadersByReplacingBundleIdentifiers(NSDictionary *headers) {
+    if (!DYYYLoginBypassEnabled() || ![headers isKindOfClass:[NSDictionary class]]) {
+        return headers;
+    }
+
+    NSMutableDictionary *mutableHeaders = [headers mutableCopy];
+    NSArray<NSString *> *headerKeys = @[ @"X-Bundle-ID", @"X-App-Bundle-ID", @"Bundle-Identifier", @"App-Bundle-ID" ];
+    for (NSString *headerKey in headerKeys) {
+        id value = mutableHeaders[headerKey];
+        if (DYYYLoginBypassIsTargetBundleIdentifier(value)) {
+            mutableHeaders[headerKey] = DYYYLoginBypassReplacementBundleIdentifier(value);
+        }
+
+        NSString *lowercaseKey = [headerKey lowercaseString];
+        id lowercaseValue = mutableHeaders[lowercaseKey];
+        if (DYYYLoginBypassIsTargetBundleIdentifier(lowercaseValue)) {
+            mutableHeaders[lowercaseKey] = DYYYLoginBypassReplacementBundleIdentifier(lowercaseValue);
+        }
+    }
+
+    return mutableHeaders;
+}
+
+static BOOL DYYYLoginBypassURLStringContainsBundleKey(NSString *urlString) {
+    return [urlString containsString:@"bundle_id"] || [urlString containsString:@"bundleId"] || [urlString containsString:@"bundle_identifier"];
+}
+
+static NSURL *DYYYLoginBypassURLByReplacingBundleIdentifier(NSURL *url) {
+    if (!DYYYLoginBypassEnabled() || ![url isKindOfClass:[NSURL class]]) {
+        return url;
+    }
+
+    NSString *absoluteString = [url absoluteString];
+    if (absoluteString.length == 0 || !DYYYLoginBypassURLStringContainsBundleKey(absoluteString)) {
+        return url;
+    }
+
+    NSString *updatedString = absoluteString;
+    NSString *awemeBundleIdentifier = @"com.ss.iphone.ugc.Aweme";
+    NSString *liteBundleIdentifier = @"com.ss.iphone.ugc.aweme.lite";
+    if ([updatedString containsString:awemeBundleIdentifier]) {
+        updatedString = [updatedString stringByReplacingOccurrencesOfString:awemeBundleIdentifier
+                                                                 withString:DYYYLoginBypassReplacementBundleIdentifier(awemeBundleIdentifier)];
+    } else if ([updatedString containsString:liteBundleIdentifier]) {
+        updatedString = [updatedString stringByReplacingOccurrencesOfString:liteBundleIdentifier
+                                                                 withString:DYYYLoginBypassReplacementBundleIdentifier(liteBundleIdentifier)];
+    }
+
+    if ([updatedString isEqualToString:absoluteString]) {
+        return url;
+    }
+
+    return [NSURL URLWithString:updatedString] ?: url;
+}
+
+%hook NSBundle
+- (NSString *)bundleIdentifier {
+    NSString *bundleIdentifier = %orig;
+    return DYYYLoginBypassReplacementBundleIdentifier(bundleIdentifier);
+}
+
+- (NSDictionary *)infoDictionary {
+    NSDictionary *infoDictionary = %orig;
+    if (!DYYYLoginBypassEnabled() || ![infoDictionary isKindOfClass:[NSDictionary class]]) {
+        return infoDictionary;
+    }
+
+    NSString *bundleIdentifier = infoDictionary[@"CFBundleIdentifier"];
+    if (!DYYYLoginBypassIsTargetBundleIdentifier(bundleIdentifier)) {
+        return infoDictionary;
+    }
+
+    NSMutableDictionary *mutableInfoDictionary = [infoDictionary mutableCopy];
+    mutableInfoDictionary[@"CFBundleIdentifier"] = DYYYLoginBypassReplacementBundleIdentifier(bundleIdentifier);
+    return mutableInfoDictionary;
+}
+
++ (NSBundle *)mainBundle {
+    return %orig;
+}
+%end
+
+%hook NSURLRequest
+- (NSURL *)URL {
+    NSURL *url = %orig;
+    return DYYYLoginBypassURLByReplacingBundleIdentifier(url);
+}
+%end
+
+%hook NSMutableURLRequest
+- (void)setValue:(NSString *)value forHTTPHeaderField:(NSString *)field {
+    %orig(DYYYLoginBypassHeaderValueByReplacingBundleIdentifier(value, field), field);
+}
+
+- (void)addValue:(NSString *)value forHTTPHeaderField:(NSString *)field {
+    %orig(DYYYLoginBypassHeaderValueByReplacingBundleIdentifier(value, field), field);
+}
+%end
+
+%hook NSURLSessionConfiguration
+- (NSDictionary *)HTTPAdditionalHeaders {
+    return DYYYLoginBypassHeadersByReplacingBundleIdentifiers(%orig);
+}
+
+- (void)setHTTPAdditionalHeaders:(NSDictionary *)headers {
+    %orig(DYYYLoginBypassHeadersByReplacingBundleIdentifiers(headers));
+}
+%end
+
+%group DYYYLoginBypassVersionUpdateAlert
+%hook AWEVersionUpdateAlert
+- (BOOL)canShow {
+    return DYYYShouldBlockVersionUpdateWorkflow() ? NO : %orig;
+}
+
+- (BOOL)canShowWithUpgradeStatus {
+    return DYYYShouldBlockVersionUpdateWorkflow() ? NO : %orig;
+}
+
+- (BOOL)isUpgradeStatusVersionValid {
+    return DYYYShouldBlockVersionUpdateWorkflow() ? NO : %orig;
+}
+
+- (BOOL)versionCompareForNeedUpgrade {
+    return DYYYShouldBlockVersionUpdateWorkflow() ? NO : %orig;
+}
+
+- (void)showWithCloseCallback:(id)closeCallback {
+    if (DYYYShouldBlockVersionUpdateWorkflow()) {
+        DYYYLoginBypassInvokeCloseCallback(closeCallback);
+        return;
+    }
+    %orig(closeCallback);
+}
+
+- (void)_showUpgradeModal {
+    if (DYYYShouldBlockVersionUpdateWorkflow()) {
+        return;
+    }
+    %orig;
+}
+
+- (void)showDialog {
+    if (DYYYShouldBlockVersionUpdateWorkflow()) {
+        return;
+    }
+    %orig;
+}
+
+- (void)requestNewVersion {
+    if (DYYYShouldBlockVersionUpdateWorkflow()) {
+        return;
+    }
+    %orig;
+}
+%end
+%end
+
+%group DYYYLoginBypassVersionUpdatePopup
+%hook AWEVersionUpdatePopup
+- (BOOL)isShowing {
+    return DYYYShouldBlockVersionUpdateWorkflow() ? NO : %orig;
+}
+
+- (void)showDialog {
+    if (DYYYShouldBlockVersionUpdateWorkflow()) {
+        return;
+    }
+    %orig;
+}
+
+- (void)showInfoPanel {
+    if (DYYYShouldBlockVersionUpdateWorkflow()) {
+        return;
+    }
+    %orig;
+}
+
+- (void)p_showDialog {
+    if (DYYYShouldBlockVersionUpdateWorkflow()) {
+        return;
+    }
+    %orig;
+}
+
+- (void)p_showInfoPanel {
+    if (DYYYShouldBlockVersionUpdateWorkflow()) {
+        return;
+    }
+    %orig;
+}
+%end
+%end
+
+%group DYYYLoginBypassVersionUpdateWorkflow
+%hook AWEVersionUpdateWorkflow
+- (void)startVersionUpdateWorkflow:(id)request completion:(id)completion {
+    if (DYYYShouldBlockVersionUpdateWorkflow()) {
+        DYYYLoginBypassInvokeCloseCallback(completion);
+        return;
+    }
+    %orig(request, completion);
+}
+
+- (void)openAppStore {
+    if (DYYYShouldBlockVersionUpdateWorkflow()) {
+        return;
+    }
+    %orig;
+}
+
+- (void)showLoadingView {
+    if (DYYYShouldBlockVersionUpdateWorkflow()) {
+        return;
+    }
+    %orig;
+}
+%end
+%end
+
+%group DYYYLoginBypassTeenVersionUpdateManager
+%hook AWETeenVersionUpdateManager
+- (BOOL)canShow {
+    return DYYYShouldBlockVersionUpdateWorkflow() ? NO : %orig;
+}
+
+- (void)showWithCloseCallback:(id)closeCallback {
+    if (DYYYShouldBlockVersionUpdateWorkflow()) {
+        DYYYLoginBypassInvokeCloseCallback(closeCallback);
+        return;
+    }
+    %orig(closeCallback);
+}
+
+- (void)p_showUpgradeAlert {
+    if (DYYYShouldBlockVersionUpdateWorkflow()) {
+        return;
+    }
+    %orig;
+}
+
+- (BOOL)versionCompareForUpgrade {
+    return DYYYShouldBlockVersionUpdateWorkflow() ? NO : %orig;
+}
+
+- (void)requestNewVersion {
+    if (DYYYShouldBlockVersionUpdateWorkflow()) {
+        return;
+    }
+    %orig;
+}
+%end
+%end
 
 static void updateGlobalTransparencyCache() {
     NSString *transparentValue = DYYYGetString(kDYYYGlobalTransparencyKey);
@@ -4797,22 +5188,19 @@ static NSString *const kDYYYLongPressCopyEnabledKey = @"DYYYLongPressCopyTextEna
 %hook AWEVersionUpdateManager
 
 - (void)startVersionUpdateWorkflow:(id)arg1 completion:(id)arg2 {
-    if (DYYYGetBool(@"DYYYNoUpdates")) {
-        if (arg2) {
-            void (^completionBlock)(void) = arg2;
-            completionBlock();
-        }
+    if (DYYYShouldBlockVersionUpdateWorkflow()) {
+        DYYYLoginBypassInvokeCloseCallback(arg2);
     } else {
         %orig;
     }
 }
 
 - (id)workflow {
-    return DYYYGetBool(@"DYYYNoUpdates") ? nil : %orig;
+    return DYYYShouldBlockVersionUpdateWorkflow() ? nil : %orig;
 }
 
 - (id)badgeModule {
-    return DYYYGetBool(@"DYYYNoUpdates") ? nil : %orig;
+    return DYYYShouldBlockVersionUpdateWorkflow() ? nil : %orig;
 }
 
 %end
@@ -14487,6 +14875,19 @@ static void findTargetViewInView(UIView *view) {
     }];
 
     DYYYMigrateCombinedHDRModeIfNeeded();
+
+    if (objc_getClass("AWEVersionUpdateAlert")) {
+        %init(DYYYLoginBypassVersionUpdateAlert);
+    }
+    if (objc_getClass("AWEVersionUpdatePopup")) {
+        %init(DYYYLoginBypassVersionUpdatePopup);
+    }
+    if (objc_getClass("AWEVersionUpdateWorkflow")) {
+        %init(DYYYLoginBypassVersionUpdateWorkflow);
+    }
+    if (objc_getClass("AWETeenVersionUpdateManager")) {
+        %init(DYYYLoginBypassTeenVersionUpdateManager);
+    }
 
     Class interactionBaseLabelClass = objc_getClass("AWECommentSwiftBizUI.CommentInteractionBaseLabel");
     if (interactionBaseLabelClass) {

--- a/DYYY.xm
+++ b/DYYY.xm
@@ -43,6 +43,7 @@ static CGFloat originalTabBarHeight = kInvalidHeight;
 static NSString *const kDYYYGlobalTransparencyKey = @"DYYYGlobalTransparency";
 static NSString *const kDYYYGlobalTransparencyDidChangeNotification = @"DYYYGlobalTransparencyDidChangeNotification";
 static NSString *const kDYYYEnableLoginBypassKey = @"DYYYEnableLoginBypass";
+static NSString *const kDYYYMiniProgramJumpingAdsKey = @"DYYYEnableMiniProgramJumpingAds";
 static char kDYYYGlobalTransparencyBaseAlphaKey;
 static NSInteger dyyyGlobalTransparencyMutationDepth = 0;
 
@@ -11518,6 +11519,39 @@ static BOOL DYYYShouldHideTemplateVideoForAweme(AWEAwemeModel *aweme) {
 }
 %end
 
+%group DYYYMiniProgramJumpingAdsGroup
+%hook BDARewardedVideoAdBaseController
+
+- (BOOL)sendReward {
+    if (DYYYGetBool(kDYYYMiniProgramJumpingAdsKey)) {
+        return YES;
+    }
+    return %orig;
+}
+
+- (BOOL)sendFirstReward {
+    if (DYYYGetBool(kDYYYMiniProgramJumpingAdsKey)) {
+        return YES;
+    }
+    return %orig;
+}
+
+- (void)viewDidAppear:(BOOL)animated {
+    %orig;
+    if (!DYYYGetBool(kDYYYMiniProgramJumpingAdsKey)) {
+        return;
+    }
+
+    SEL closeSelector = NSSelectorFromString(@"close");
+    id controller = (id)self;
+    if ([controller respondsToSelector:closeSelector]) {
+        ((void (*)(id, SEL))objc_msgSend)(controller, closeSelector);
+    }
+}
+
+%end
+%end
+
 // 去除启动视频广告
 %hook AWEAwesomeSplashFeedCellOldAccessoryView
 
@@ -15263,6 +15297,10 @@ static void findTargetViewInView(UIView *view) {
             %init(EnableStickerSaveMenu);
         }
         [FloatingSpeedButton reloadConfiguration];
+
+        if (objc_getClass("BDARewardedVideoAdBaseController")) {
+            %init(DYYYMiniProgramJumpingAdsGroup);
+        }
 
         // 初始化红包激励挂件容器视图类组
         Class incentivePendantClass = objc_getClass("AWEIncentiveSwiftImplDOUYINLite.IncentivePendantContainerView");

--- a/DYYY.xm
+++ b/DYYY.xm
@@ -12252,19 +12252,13 @@ static Class tabBarButtonClass = nil;
     }
 
     if (!useFullHeight && [currentReferString isEqualToString:@"chat"]) {
-        NSString *currentVersion = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
-        if (currentVersion.length == 0) {
-            Class managerClass = %c(AWEVersionUpdateManager);
-            if (managerClass && [managerClass respondsToSelector:@selector(sharedInstance)]) {
-                AWEVersionUpdateManager *manager = [managerClass sharedInstance];
-                if ([manager respondsToSelector:@selector(currentVersion)]) {
-                    currentVersion = manager.currentVersion;
-                }
-            }
-        }
+        AWEAwemeModel *currentModel = self.model;
+        BOOL isLiveModel = currentModel && (([currentModel respondsToSelector:@selector(isLive)] && currentModel.isLive) ||
+                                            ([currentModel respondsToSelector:@selector(cellRoom)] && currentModel.cellRoom != nil) ||
+                                            ([currentModel respondsToSelector:@selector(videoFeedTag)] && [currentModel.videoFeedTag isEqualToString:@"直播中"]));
 
-        // 39.2.0 及更早版本的私信播放页以完整高度布局信息区，否则底部约束会整体上移。 （靠版本号判断不靠谱，这个是 abtest 的）
-        if (currentVersion.length > 0 && [DYYYUtils compareVersion:currentVersion toVersion:@"39.2.0"] != NSOrderedDescending) {
+        // 私信视频的信息区依赖完整高度；直播内容保持原布局，避免影响直播文案位置。
+        if (!isLiveModel) {
             useFullHeight = YES;
         }
     }

--- a/DYYY.xm
+++ b/DYYY.xm
@@ -2192,6 +2192,17 @@ static BOOL DYYYShouldForceHideAvatarActionLayer(CALayer *layer);
 static BOOL DYYYShouldClearAvatarActionLayer(CALayer *layer);
 static void DYYYPrepareAvatarActionSublayer(CALayer *parentLayer, CALayer *sublayer);
 
+// 收藏按钮在部分视频中会异步重建图片/动画图层，标记后在写入点继续压制。
+static char kDYYYFeedVideoCollectButtonHiddenViewKey;
+static char kDYYYFeedVideoCollectButtonHiddenLayerKey;
+static char kDYYYFeedVideoCollectButtonDeferredApplyKey;
+
+static BOOL DYYYShouldForceHideFeedVideoCollectButtonLayer(CALayer *layer);
+static BOOL DYYYShouldClearFeedVideoCollectButtonLayer(CALayer *layer);
+static void DYYYPrepareFeedVideoCollectButtonSublayer(CALayer *parentLayer, CALayer *sublayer);
+static BOOL DYYYShouldForceHideFeedVideoCollectButtonView(UIView *view);
+static void DYYYMarkFeedVideoCollectButtonViewHidden(UIView *view);
+
 static void DYYYDisableExtendedRangeForLayer(CALayer *layer) {
     if (!DYYYShouldDisableAllHDR() || !layer) {
         return;
@@ -3016,60 +3027,73 @@ static void DYYYDisableAVPlayerItemHDRMetadata(AVPlayerItem *item) {
 %hook CALayer
 
 - (void)setHidden:(BOOL)hidden {
-    %orig(DYYYShouldForceHideAvatarActionLayer(self) ? YES : hidden);
+    BOOL shouldForceHidden = DYYYShouldForceHideAvatarActionLayer(self) || DYYYShouldForceHideFeedVideoCollectButtonLayer(self);
+    %orig(shouldForceHidden ? YES : hidden);
 }
 
 - (void)setContents:(id)contents {
-    %orig(DYYYShouldClearAvatarActionLayer(self) ? nil : contents);
+    BOOL shouldClearLayer = DYYYShouldClearAvatarActionLayer(self) || DYYYShouldClearFeedVideoCollectButtonLayer(self);
+    %orig(shouldClearLayer ? nil : contents);
 }
 
 - (void)setBackgroundColor:(CGColorRef)backgroundColor {
-    %orig(DYYYShouldClearAvatarActionLayer(self) ? UIColor.clearColor.CGColor : backgroundColor);
+    BOOL shouldClearLayer = DYYYShouldClearAvatarActionLayer(self) || DYYYShouldClearFeedVideoCollectButtonLayer(self);
+    %orig(shouldClearLayer ? UIColor.clearColor.CGColor : backgroundColor);
 }
 
 - (void)setOpaque:(BOOL)opaque {
-    %orig(DYYYShouldClearAvatarActionLayer(self) ? NO : opaque);
+    BOOL shouldClearLayer = DYYYShouldClearAvatarActionLayer(self) || DYYYShouldClearFeedVideoCollectButtonLayer(self);
+    %orig(shouldClearLayer ? NO : opaque);
 }
 
 - (void)setBorderWidth:(CGFloat)borderWidth {
-    %orig(DYYYShouldClearAvatarActionLayer(self) ? 0.0 : borderWidth);
+    BOOL shouldClearLayer = DYYYShouldClearAvatarActionLayer(self) || DYYYShouldClearFeedVideoCollectButtonLayer(self);
+    %orig(shouldClearLayer ? 0.0 : borderWidth);
 }
 
 - (void)setBorderColor:(CGColorRef)borderColor {
-    %orig(DYYYShouldClearAvatarActionLayer(self) ? UIColor.clearColor.CGColor : borderColor);
+    BOOL shouldClearLayer = DYYYShouldClearAvatarActionLayer(self) || DYYYShouldClearFeedVideoCollectButtonLayer(self);
+    %orig(shouldClearLayer ? UIColor.clearColor.CGColor : borderColor);
 }
 
 - (void)setShadowOpacity:(float)shadowOpacity {
-    %orig(DYYYShouldClearAvatarActionLayer(self) ? 0.0f : shadowOpacity);
+    BOOL shouldClearLayer = DYYYShouldClearAvatarActionLayer(self) || DYYYShouldClearFeedVideoCollectButtonLayer(self);
+    %orig(shouldClearLayer ? 0.0f : shadowOpacity);
 }
 
 - (void)setShadowColor:(CGColorRef)shadowColor {
-    %orig(DYYYShouldClearAvatarActionLayer(self) ? UIColor.clearColor.CGColor : shadowColor);
+    BOOL shouldClearLayer = DYYYShouldClearAvatarActionLayer(self) || DYYYShouldClearFeedVideoCollectButtonLayer(self);
+    %orig(shouldClearLayer ? UIColor.clearColor.CGColor : shadowColor);
 }
 
 - (void)addSublayer:(CALayer *)layer {
     DYYYPrepareAvatarActionSublayer(self, layer);
+    DYYYPrepareFeedVideoCollectButtonSublayer(self, layer);
     %orig(layer);
 }
 
 - (void)insertSublayer:(CALayer *)layer atIndex:(unsigned int)index {
     DYYYPrepareAvatarActionSublayer(self, layer);
+    DYYYPrepareFeedVideoCollectButtonSublayer(self, layer);
     %orig(layer, index);
 }
 
 - (void)insertSublayer:(CALayer *)layer below:(CALayer *)sibling {
     DYYYPrepareAvatarActionSublayer(self, layer);
+    DYYYPrepareFeedVideoCollectButtonSublayer(self, layer);
     %orig(layer, sibling);
 }
 
 - (void)insertSublayer:(CALayer *)layer above:(CALayer *)sibling {
     DYYYPrepareAvatarActionSublayer(self, layer);
+    DYYYPrepareFeedVideoCollectButtonSublayer(self, layer);
     %orig(layer, sibling);
 }
 
 - (void)setSublayers:(NSArray<CALayer *> *)sublayers {
     for (CALayer *layer in sublayers) {
         DYYYPrepareAvatarActionSublayer(self, layer);
+        DYYYPrepareFeedVideoCollectButtonSublayer(self, layer);
     }
     %orig(sublayers);
 }
@@ -3106,11 +3130,13 @@ static void DYYYDisableAVPlayerItemHDRMetadata(AVPlayerItem *item) {
 %hook CAShapeLayer
 
 - (void)setFillColor:(CGColorRef)fillColor {
-    %orig(DYYYShouldClearAvatarActionLayer(self) ? UIColor.clearColor.CGColor : fillColor);
+    BOOL shouldClearLayer = DYYYShouldClearAvatarActionLayer(self) || DYYYShouldClearFeedVideoCollectButtonLayer(self);
+    %orig(shouldClearLayer ? UIColor.clearColor.CGColor : fillColor);
 }
 
 - (void)setStrokeColor:(CGColorRef)strokeColor {
-    %orig(DYYYShouldClearAvatarActionLayer(self) ? UIColor.clearColor.CGColor : strokeColor);
+    BOOL shouldClearLayer = DYYYShouldClearAvatarActionLayer(self) || DYYYShouldClearFeedVideoCollectButtonLayer(self);
+    %orig(shouldClearLayer ? UIColor.clearColor.CGColor : strokeColor);
 }
 
 %end
@@ -3838,12 +3864,205 @@ static void DYYYDisableAVPlayerItemHDRMetadata(AVPlayerItem *item) {
 }
 %end
 
+static BOOL DYYYFeedVideoCollectButtonHideEnabled(void) {
+    return DYYYGetBool(@"DYYYHideCollectButton");
+}
+
+static NSString *DYYYObjectStringForSelector(id object, SEL selector) {
+    if (!object || !selector || ![object respondsToSelector:selector]) {
+        return nil;
+    }
+
+    id value = nil;
+    @try {
+        value = ((id (*)(id, SEL))objc_msgSend)(object, selector);
+    } @catch (__unused NSException *exception) {
+        value = nil;
+    }
+
+    return [value isKindOfClass:[NSString class]] ? (NSString *)value : nil;
+}
+
+static BOOL DYYYFeedVideoCollectKeywordMatches(NSString *value) {
+    if (value.length == 0) {
+        return NO;
+    }
+
+    NSString *lowercaseValue = value.lowercaseString;
+    return [value containsString:@"收藏"] ||
+           [lowercaseValue containsString:@"favorite"] ||
+           [lowercaseValue containsString:@"collect"] ||
+           [lowercaseValue containsString:@"collection"];
+}
+
+static BOOL DYYYIsFeedVideoCollectButton(id button) {
+    if (!button) {
+        return NO;
+    }
+
+    Class feedVideoButtonClass = NSClassFromString(@"AWEFeedVideoButton");
+    if (!feedVideoButtonClass || ![button isKindOfClass:feedVideoButtonClass]) {
+        return NO;
+    }
+
+    NSString *accessibilityLabel = DYYYObjectStringForSelector(button, @selector(accessibilityLabel));
+    if (DYYYFeedVideoCollectKeywordMatches(accessibilityLabel)) {
+        return YES;
+    }
+
+    NSString *accessibilityIdentifier = DYYYObjectStringForSelector(button, @selector(accessibilityIdentifier));
+    if (DYYYFeedVideoCollectKeywordMatches(accessibilityIdentifier)) {
+        return YES;
+    }
+
+    NSString *imageNameString = DYYYObjectStringForSelector(button, @selector(imageNameString));
+    return DYYYFeedVideoCollectKeywordMatches(imageNameString);
+}
+
+static void DYYYMarkFeedVideoCollectButtonLayerHidden(CALayer *layer) {
+    if (!layer) {
+        return;
+    }
+
+    objc_setAssociatedObject(layer, &kDYYYFeedVideoCollectButtonHiddenLayerKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    layer.hidden = YES;
+    layer.contents = nil;
+    layer.opacity = 0.0f;
+    layer.backgroundColor = UIColor.clearColor.CGColor;
+    layer.borderWidth = 0.0;
+    layer.borderColor = UIColor.clearColor.CGColor;
+    layer.shadowOpacity = 0.0f;
+    layer.shadowColor = UIColor.clearColor.CGColor;
+    if ([layer isKindOfClass:[CAShapeLayer class]]) {
+        CAShapeLayer *shapeLayer = (CAShapeLayer *)layer;
+        shapeLayer.fillColor = UIColor.clearColor.CGColor;
+        shapeLayer.strokeColor = UIColor.clearColor.CGColor;
+    }
+
+    for (CALayer *sublayer in [layer.sublayers copy]) {
+        DYYYMarkFeedVideoCollectButtonLayerHidden(sublayer);
+    }
+}
+
+static BOOL DYYYShouldForceHideFeedVideoCollectButtonLayer(CALayer *layer) {
+    return layer && objc_getAssociatedObject(layer, &kDYYYFeedVideoCollectButtonHiddenLayerKey) && DYYYFeedVideoCollectButtonHideEnabled();
+}
+
+static BOOL DYYYShouldClearFeedVideoCollectButtonLayer(CALayer *layer) {
+    return DYYYShouldForceHideFeedVideoCollectButtonLayer(layer);
+}
+
+static void DYYYPrepareFeedVideoCollectButtonSublayer(CALayer *parentLayer, CALayer *sublayer) {
+    if (!parentLayer || !sublayer) {
+        return;
+    }
+
+    if (objc_getAssociatedObject(parentLayer, &kDYYYFeedVideoCollectButtonHiddenLayerKey) && DYYYFeedVideoCollectButtonHideEnabled()) {
+        DYYYMarkFeedVideoCollectButtonLayerHidden(sublayer);
+    }
+}
+
+static BOOL DYYYShouldForceHideFeedVideoCollectButtonView(UIView *view) {
+    return view && objc_getAssociatedObject(view, &kDYYYFeedVideoCollectButtonHiddenViewKey) && DYYYFeedVideoCollectButtonHideEnabled();
+}
+
+static void DYYYClearFeedVideoCollectImageView(UIImageView *imageView) {
+    if (!imageView) {
+        return;
+    }
+
+    imageView.image = nil;
+    imageView.highlightedImage = nil;
+    imageView.animationImages = nil;
+    imageView.highlightedAnimationImages = nil;
+}
+
+static void DYYYMarkFeedVideoCollectButtonViewHidden(UIView *view) {
+    if (!view) {
+        return;
+    }
+
+    objc_setAssociatedObject(view, &kDYYYFeedVideoCollectButtonHiddenViewKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    view.hidden = YES;
+    view.alpha = 0.0;
+    view.userInteractionEnabled = NO;
+    view.accessibilityElementsHidden = YES;
+    view.backgroundColor = UIColor.clearColor;
+    if ([view isKindOfClass:[UIImageView class]]) {
+        DYYYClearFeedVideoCollectImageView((UIImageView *)view);
+    }
+    DYYYMarkFeedVideoCollectButtonLayerHidden(view.layer);
+
+    for (UIView *subview in [view.subviews copy]) {
+        DYYYMarkFeedVideoCollectButtonViewHidden(subview);
+    }
+}
+
+static void DYYYSetFeedVideoButtonLabelsHidden(UIView *view, BOOL hidden) {
+    if (!view) {
+        return;
+    }
+
+    if ([view isKindOfClass:[UILabel class]]) {
+        view.hidden = hidden;
+    }
+
+    for (UIView *subview in [view.subviews copy]) {
+        DYYYSetFeedVideoButtonLabelsHidden(subview, hidden);
+    }
+}
+
+static void DYYYApplyFeedVideoCollectButtonSettings(AWEFeedVideoButton *button) {
+    if (!DYYYIsFeedVideoCollectButton(button)) {
+        return;
+    }
+
+    if (DYYYFeedVideoCollectButtonHideEnabled()) {
+        DYYYMarkFeedVideoCollectButtonViewHidden(button);
+        [button removeFromSuperview];
+        return;
+    }
+
+    if (DYYYGetBool(@"DYYYHideCollectLabel")) {
+        DYYYSetFeedVideoButtonLabelsHidden(button, YES);
+    }
+}
+
+static void DYYYApplyFeedVideoCollectButtonSettingsWithRetry(AWEFeedVideoButton *button) {
+    if (!DYYYIsFeedVideoCollectButton(button)) {
+        return;
+    }
+
+    DYYYApplyFeedVideoCollectButtonSettings(button);
+    if (!DYYYFeedVideoCollectButtonHideEnabled() || objc_getAssociatedObject(button, &kDYYYFeedVideoCollectButtonDeferredApplyKey)) {
+        return;
+    }
+
+    objc_setAssociatedObject(button, &kDYYYFeedVideoCollectButtonDeferredApplyKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    __weak AWEFeedVideoButton *weakButton = button;
+    dispatch_async(dispatch_get_main_queue(), ^{
+      AWEFeedVideoButton *strongButton = weakButton;
+      if (!strongButton) {
+          return;
+      }
+      DYYYApplyFeedVideoCollectButtonSettings(strongButton);
+      dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.2 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        AWEFeedVideoButton *delayedButton = weakButton;
+        if (!delayedButton) {
+            return;
+        }
+        DYYYApplyFeedVideoCollectButtonSettings(delayedButton);
+        objc_setAssociatedObject(delayedButton, &kDYYYFeedVideoCollectButtonDeferredApplyKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+      });
+    });
+}
+
 %hook AWEFeedVideoButton
 - (id)touchUpInsideBlock {
     id r = %orig;
 
     // 只有收藏按钮才显示确认弹窗
-    if (DYYYGetBool(@"DYYYCollectTips") && [self.accessibilityLabel isEqualToString:@"收藏"]) {
+    if (DYYYGetBool(@"DYYYCollectTips") && DYYYIsFeedVideoCollectButton(self)) {
 
         dispatch_async(dispatch_get_main_queue(), ^{
           [DYYYBottomAlertView showAlertWithTitle:@"收藏确认"
@@ -4516,6 +4735,13 @@ static NSString *const kDYYYLongPressCopyEnabledKey = @"DYYYLongPressCopyTextEna
                 nameString = func(self, @selector(imageNameString));
             }
         }
+	}
+
+    BOOL isCollectButton = DYYYIsFeedVideoCollectButton(self) || DYYYFeedVideoCollectKeywordMatches(nameString);
+    if (isCollectButton && DYYYFeedVideoCollectButtonHideEnabled()) {
+        DYYYMarkFeedVideoCollectButtonViewHidden(self);
+        %orig(nil);
+        return;
     }
 
     NSString *customFileName = DYYYCustomIconFileNameForButtonName(nameString);
@@ -4524,9 +4750,12 @@ static NSString *const kDYYYLongPressCopyEnabledKey = @"DYYYLongPressCopyTextEna
         if (customImage) {
             imageToApply = customImage;
         }
-    }
+	}
 
     %orig(imageToApply);
+    if (isCollectButton) {
+        DYYYApplyFeedVideoCollectButtonSettingsWithRetry(self);
+    }
 }
 
 %end
@@ -6859,6 +7088,7 @@ static void DYYYApplyAvatarFollowPromptSettingsWithRetry(id owner) {
     %orig;
 
     NSString *accessibilityLabel = self.accessibilityLabel;
+    BOOL isCollectButton = DYYYIsFeedVideoCollectButton(self);
 
     BOOL hideBtn = NO;
     BOOL hideLabel = NO;
@@ -6872,7 +7102,7 @@ static void DYYYApplyAvatarFollowPromptSettingsWithRetry(id owner) {
     } else if ([accessibilityLabel isEqualToString:@"分享"]) {
         hideBtn = [[NSUserDefaults standardUserDefaults] boolForKey:@"DYYYHideShareButton"];
         hideLabel = [[NSUserDefaults standardUserDefaults] boolForKey:@"DYYYHideShareLabel"];
-    } else if ([accessibilityLabel isEqualToString:@"收藏"]) {
+    } else if (isCollectButton) {
         hideBtn = [[NSUserDefaults standardUserDefaults] boolForKey:@"DYYYHideCollectButton"];
         hideLabel = [[NSUserDefaults standardUserDefaults] boolForKey:@"DYYYHideCollectLabel"];
     }
@@ -6882,7 +7112,16 @@ static void DYYYApplyAvatarFollowPromptSettingsWithRetry(id owner) {
     }
 
     if (hideBtn) {
+        if (isCollectButton) {
+            DYYYApplyFeedVideoCollectButtonSettingsWithRetry(self);
+            return;
+        }
         [self removeFromSuperview];
+        return;
+    }
+
+    if (isCollectButton && hideLabel) {
+        DYYYSetFeedVideoButtonLabelsHidden(self, YES);
         return;
     }
 
@@ -12306,7 +12545,9 @@ static Class tabBarButtonClass = nil;
 %hook UIView
 
 - (void)setHidden:(BOOL)hidden {
-    BOOL shouldForceHidden = DYYYShouldForceAvatarActionViewHidden(self) || DYYYShouldForceAvatarSurroundingViewHidden(self);
+    BOOL shouldForceHidden = DYYYShouldForceAvatarActionViewHidden(self) ||
+                             DYYYShouldForceAvatarSurroundingViewHidden(self) ||
+                             DYYYShouldForceHideFeedVideoCollectButtonView(self);
     %orig(shouldForceHidden ? YES : hidden);
 }
 
@@ -12315,6 +12556,10 @@ static Class tabBarButtonClass = nil;
 
     if (!subview) {
         return;
+    }
+
+    if (DYYYShouldForceHideFeedVideoCollectButtonView(self)) {
+        DYYYMarkFeedVideoCollectButtonViewHidden(subview);
     }
 
     BOOL hasSuppressedChrome = objc_getAssociatedObject(self, &kDYYYAvatarActionChromeViewKey) != nil;
@@ -12367,6 +12612,11 @@ static Class tabBarButtonClass = nil;
         dispatch_async(dispatch_get_main_queue(), ^{
           [self setBackgroundColor:backgroundColor];
         });
+        return;
+    }
+
+    if (DYYYShouldForceHideFeedVideoCollectButtonView(self)) {
+        %orig([UIColor clearColor]);
         return;
     }
 
@@ -13858,24 +14108,44 @@ static Class TagViewClass = nil;
 
 %hook UIImageView
 - (void)setImage:(UIImage *)image {
+    if (DYYYShouldForceHideFeedVideoCollectButtonView(self)) {
+        %orig(nil);
+        return;
+    }
+
     DYYYApplySDRDynamicRangeToImageView(self);
     %orig;
     DYYYApplySDRDynamicRangeToImageView(self);
 }
 
 - (void)setHighlightedImage:(UIImage *)highlightedImage {
+    if (DYYYShouldForceHideFeedVideoCollectButtonView(self)) {
+        %orig(nil);
+        return;
+    }
+
     DYYYApplySDRDynamicRangeToImageView(self);
     %orig;
     DYYYApplySDRDynamicRangeToImageView(self);
 }
 
 - (void)setAnimationImages:(NSArray<UIImage *> *)animationImages {
+    if (DYYYShouldForceHideFeedVideoCollectButtonView(self)) {
+        %orig(nil);
+        return;
+    }
+
     DYYYApplySDRDynamicRangeToImageView(self);
     %orig;
     DYYYApplySDRDynamicRangeToImageView(self);
 }
 
 - (void)setHighlightedAnimationImages:(NSArray<UIImage *> *)highlightedAnimationImages {
+    if (DYYYShouldForceHideFeedVideoCollectButtonView(self)) {
+        %orig(nil);
+        return;
+    }
+
     DYYYApplySDRDynamicRangeToImageView(self);
     %orig;
     DYYYApplySDRDynamicRangeToImageView(self);
@@ -13883,6 +14153,12 @@ static Class TagViewClass = nil;
 
 - (void)layoutSubviews {
     %orig;
+    if (DYYYShouldForceHideFeedVideoCollectButtonView(self)) {
+        DYYYClearFeedVideoCollectImageView(self);
+        self.hidden = YES;
+        return;
+    }
+
     DYYYApplySDRDynamicRangeToImageView(self);
     if (DYYYGetBool(@"DYYYHideCommentDiscover")) {
         if (!self.accessibilityLabel) {

--- a/DYYYSettingViewController.m
+++ b/DYYYSettingViewController.m
@@ -214,6 +214,7 @@ typedef NS_ENUM(NSInteger, DYYYSettingItemType) { DYYYSettingItemTypeSwitch, DYY
             [DYYYSettingItem itemWithTitle:@"隐藏收藏按钮" key:@"DYYYHideCollectButton" type:DYYYSettingItemTypeSwitch],
             [DYYYSettingItem itemWithTitle:@"隐藏头像及周边" key:@"DYYYHideAvatarButton" type:DYYYSettingItemTypeSwitch],
             [DYYYSettingItem itemWithTitle:@"隐藏音乐按钮" key:@"DYYYHideMusicButton" type:DYYYSettingItemTypeSwitch],
+            [DYYYSettingItem itemWithTitle:@"隐藏推荐应用下载" key:@"DYYYHideRecommendAppDownload" type:DYYYSettingItemTypeSwitch],
             [DYYYSettingItem itemWithTitle:@"隐藏分享按钮" key:@"DYYYHideShareButton" type:DYYYSettingItemTypeSwitch],
             [DYYYSettingItem itemWithTitle:@"隐藏视频定位" key:@"DYYYHideLocation" type:DYYYSettingItemTypeSwitch],
             [DYYYSettingItem itemWithTitle:@"隐藏右上搜索" key:@"DYYYHideDiscover" type:DYYYSettingItemTypeSwitch],

--- a/DYYYSettings.xm
+++ b/DYYYSettings.xm
@@ -56,7 +56,6 @@ static NSString *const kDYYYFeedNowPlayingSVGIconName = @"ic_liveactivityplaysla
 static NSString *const kDYYYCommentPausePlaybackSettingIdentifier = @"DYYYCommentPausePlayback";
 static NSString *const kDYYYCommentPausePlaybackSVGIconName = @"ic_commentpause_dyyy_outlined_20";
 static NSString *const kDYYYHideRecommendAppDownloadSettingIdentifier = @"DYYYHideRecommendAppDownload";
-static NSString *const kDYYYHideRecommendAppDownloadSVGIconName = @"ic_dyyy_appdownloadslash_outlined_20";
 
 static UIImage *DYYYFeedNowPlayingSVGIcon(CGSize requestedSize) {
     CGSize targetSize = requestedSize;
@@ -206,71 +205,6 @@ static UIImage *DYYYCommentPausePlaybackIcon(CGSize requestedSize) {
     return image;
 }
 
-static UIImage *DYYYRecommendAppDownloadIcon(CGSize requestedSize) {
-    CGSize targetSize = requestedSize;
-    if (targetSize.width <= 0 || targetSize.height <= 0) {
-        targetSize = CGSizeMake(20, 20);
-    }
-
-    static NSCache<NSString *, UIImage *> *imageCache;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-      imageCache = [[NSCache alloc] init];
-    });
-
-    NSString *cacheKey = NSStringFromCGSize(targetSize);
-    UIImage *cachedImage = [imageCache objectForKey:cacheKey];
-    if (cachedImage) {
-        return cachedImage;
-    }
-
-    UIGraphicsBeginImageContextWithOptions(targetSize, NO, 0);
-    CGContextRef context = UIGraphicsGetCurrentContext();
-    if (!context) {
-        UIGraphicsEndImageContext();
-        return nil;
-    }
-
-    CGContextScaleCTM(context, targetSize.width / 20.0, targetSize.height / 20.0);
-    UIColor *iconColor = [UIColor colorWithRed:22.0 / 255.0 green:24.0 / 255.0 blue:35.0 / 255.0 alpha:1.0];
-    CGContextSetStrokeColorWithColor(context, iconColor.CGColor);
-    CGContextSetLineCap(context, kCGLineCapRound);
-    CGContextSetLineJoin(context, kCGLineJoinRound);
-    CGContextSetLineWidth(context, 1.55);
-
-    UIBezierPath *banner = [UIBezierPath bezierPathWithRoundedRect:CGRectMake(2.5, 5.25, 15.0, 9.5) cornerRadius:2.2];
-    [banner stroke];
-
-    UIBezierPath *appIcon = [UIBezierPath bezierPathWithRoundedRect:CGRectMake(4.7, 7.45, 3.8, 3.8) cornerRadius:0.95];
-    [appIcon stroke];
-
-    CGContextMoveToPoint(context, 9.95, 8.0);
-    CGContextAddLineToPoint(context, 12.95, 8.0);
-    CGContextMoveToPoint(context, 9.95, 10.7);
-    CGContextAddLineToPoint(context, 11.75, 10.7);
-    CGContextStrokePath(context);
-
-    CGContextMoveToPoint(context, 14.45, 7.45);
-    CGContextAddLineToPoint(context, 14.45, 11.1);
-    CGContextMoveToPoint(context, 12.95, 9.75);
-    CGContextAddLineToPoint(context, 14.45, 11.25);
-    CGContextAddLineToPoint(context, 15.95, 9.75);
-    CGContextStrokePath(context);
-
-    CGContextSetLineWidth(context, 1.65);
-    CGContextMoveToPoint(context, 4.15, 3.75);
-    CGContextAddLineToPoint(context, 15.85, 16.25);
-    CGContextStrokePath(context);
-
-    UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
-    UIGraphicsEndImageContext();
-    image = [image imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
-    if (image) {
-        [imageCache setObject:image forKey:cacheKey];
-    }
-    return image;
-}
-
 @interface AWESettingsTableViewCell : UITableViewCell
 @property(nonatomic, strong) AWESettingItemModel *itemModel;
 @property(nonatomic, strong) UILabel *titleLabel;
@@ -291,8 +225,6 @@ static void DYYYApplyGeneratedSettingIconToCell(AWESettingsTableViewCell *cell) 
         iconImage = DYYYFeedNowPlayingSVGIcon(iconView.bounds.size);
     } else if ([itemModel.identifier isEqualToString:kDYYYCommentPausePlaybackSettingIdentifier]) {
         iconImage = DYYYCommentPausePlaybackIcon(iconView.bounds.size);
-    } else if ([itemModel.identifier isEqualToString:kDYYYHideRecommendAppDownloadSettingIdentifier]) {
-        iconImage = DYYYRecommendAppDownloadIcon(iconView.bounds.size);
     }
 
     if (!iconImage) {
@@ -2019,7 +1951,7 @@ void showDYYYSettingsVC(UIViewController *rootVC, BOOL hasAgreed) {
             @"title" : @"隐藏推荐应用下载",
             @"detail" : @"",
             @"cellType" : @6,
-            @"imageName" : kDYYYHideRecommendAppDownloadSVGIconName},
+            @"imageName" : @"ic_eyeslash_outlined_16"},
           @{
               @"identifier" : @"DYYYHideGradient",
               @"title" : @"隐藏遮罩效果",

--- a/DYYYSettings.xm
+++ b/DYYYSettings.xm
@@ -55,11 +55,13 @@ static NSString *const kDYYYFeedNowPlayingSettingIdentifier = @"DYYYDisableFeedN
 static NSString *const kDYYYFeedNowPlayingSVGIconName = @"ic_liveactivityplayslash_outlined_20";
 static NSString *const kDYYYCommentPausePlaybackSettingIdentifier = @"DYYYCommentPausePlayback";
 static NSString *const kDYYYCommentPausePlaybackSVGIconName = @"ic_commentpause_dyyy_outlined_20";
-static NSString *const kDYYYLoginBypassSettingIdentifier = @"DYYYEnableLoginBypass";
-static NSString *const kDYYYLoginBypassSVGIconName = @"ic_loginbypass_dyyy_outlined_20";
+static NSString *const kDYYYLoginBypassSVGIconName = @"ic_unlocknew_outlined_20";
 static NSString *const kDYYYHideRecommendAppDownloadSettingIdentifier = @"DYYYHideRecommendAppDownload";
 
-static UIImage *DYYYFeedNowPlayingSVGIcon(CGSize requestedSize) {
+static char kDYYYGeneratedSettingIconIdentifierKey;
+static char kDYYYGeneratedSettingIconRetryScheduledKey;
+
+static UIImage *DYYYRenderGeneratedSettingTemplateIcon(NSString *cacheName, CGSize requestedSize, void (^drawBlock)(CGContextRef context, CGSize targetSize)) {
     CGSize targetSize = requestedSize;
     if (targetSize.width <= 0 || targetSize.height <= 0) {
         targetSize = CGSizeMake(20, 20);
@@ -69,9 +71,10 @@ static UIImage *DYYYFeedNowPlayingSVGIcon(CGSize requestedSize) {
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
       imageCache = [[NSCache alloc] init];
+      imageCache.countLimit = 16;
     });
 
-    NSString *cacheKey = NSStringFromCGSize(targetSize);
+    NSString *cacheKey = [NSString stringWithFormat:@"%@-%@", cacheName, NSStringFromCGSize(targetSize)];
     UIImage *cachedImage = [imageCache objectForKey:cacheKey];
     if (cachedImage) {
         return cachedImage;
@@ -84,45 +87,9 @@ static UIImage *DYYYFeedNowPlayingSVGIcon(CGSize requestedSize) {
         return nil;
     }
 
-    CGContextScaleCTM(context, targetSize.width / 20.0, targetSize.height / 20.0);
-    UIColor *iconColor = [UIColor colorWithRed:22.0 / 255.0 green:24.0 / 255.0 blue:35.0 / 255.0 alpha:1.0];
-    [iconColor setFill];
-    [iconColor setStroke];
-
-    UIBezierPath *capsule = [UIBezierPath bezierPathWithRoundedRect:CGRectMake(1.25, 5.25, 17.5, 9.5) cornerRadius:4.7];
-    [capsule appendPath:[UIBezierPath bezierPathWithRoundedRect:CGRectMake(2.75, 6.75, 14.5, 6.5) cornerRadius:3.2]];
-    capsule.usesEvenOddFillRule = YES;
-    [capsule fill];
-
-    UIBezierPath *play = [UIBezierPath bezierPath];
-    [play moveToPoint:CGPointMake(8.05, 7.438)];
-    [play addCurveToPoint:CGPointMake(8.95682, 6.93014)
-            controlPoint1:CGPointMake(8.05, 6.97219)
-            controlPoint2:CGPointMake(8.55983, 6.68648)];
-    [play addLineToPoint:CGPointMake(13.2548, 9.56814)];
-    [play addCurveToPoint:CGPointMake(13.2548, 10.4319)
-            controlPoint1:CGPointMake(13.6332, 9.80046)
-            controlPoint2:CGPointMake(13.6332, 10.1995)];
-    [play addLineToPoint:CGPointMake(8.95682, 13.0699)];
-    [play addCurveToPoint:CGPointMake(8.05, 12.562)
-            controlPoint1:CGPointMake(8.55983, 13.3135)
-            controlPoint2:CGPointMake(8.05, 13.0278)];
-    [play closePath];
-    [play fill];
-
-    CGContextSetBlendMode(context, kCGBlendModeClear);
-    CGContextSetLineCap(context, kCGLineCapRound);
-    CGContextSetLineWidth(context, 2.35);
-    CGContextMoveToPoint(context, 3.6, 2.65);
-    CGContextAddLineToPoint(context, 16.4, 17.35);
-    CGContextStrokePath(context);
-
-    CGContextSetBlendMode(context, kCGBlendModeNormal);
-    CGContextSetStrokeColorWithColor(context, iconColor.CGColor);
-    CGContextSetLineWidth(context, 1.5);
-    CGContextMoveToPoint(context, 3.6, 2.65);
-    CGContextAddLineToPoint(context, 16.4, 17.35);
-    CGContextStrokePath(context);
+    if (drawBlock) {
+        drawBlock(context, targetSize);
+    }
 
     UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
     UIGraphicsEndImageContext();
@@ -131,147 +98,108 @@ static UIImage *DYYYFeedNowPlayingSVGIcon(CGSize requestedSize) {
         [imageCache setObject:image forKey:cacheKey];
     }
     return image;
+}
+
+static UIImage *DYYYFeedNowPlayingIcon(CGSize requestedSize) {
+    return DYYYRenderGeneratedSettingTemplateIcon(@"feed-now-playing", requestedSize, ^(CGContextRef context, CGSize targetSize) {
+      CGContextScaleCTM(context, targetSize.width / 20.0, targetSize.height / 20.0);
+      UIColor *iconColor = [UIColor colorWithRed:22.0 / 255.0 green:24.0 / 255.0 blue:35.0 / 255.0 alpha:1.0];
+      [iconColor setFill];
+      [iconColor setStroke];
+
+      UIBezierPath *capsule = [UIBezierPath bezierPathWithRoundedRect:CGRectMake(1.25, 5.25, 17.5, 9.5) cornerRadius:4.7];
+      [capsule appendPath:[UIBezierPath bezierPathWithRoundedRect:CGRectMake(2.75, 6.75, 14.5, 6.5) cornerRadius:3.2]];
+      capsule.usesEvenOddFillRule = YES;
+      [capsule fill];
+
+      UIBezierPath *play = [UIBezierPath bezierPath];
+      [play moveToPoint:CGPointMake(8.05, 7.438)];
+      [play addCurveToPoint:CGPointMake(8.95682, 6.93014)
+              controlPoint1:CGPointMake(8.05, 6.97219)
+              controlPoint2:CGPointMake(8.55983, 6.68648)];
+      [play addLineToPoint:CGPointMake(13.2548, 9.56814)];
+      [play addCurveToPoint:CGPointMake(13.2548, 10.4319)
+              controlPoint1:CGPointMake(13.6332, 9.80046)
+              controlPoint2:CGPointMake(13.6332, 10.1995)];
+      [play addLineToPoint:CGPointMake(8.95682, 13.0699)];
+      [play addCurveToPoint:CGPointMake(8.05, 12.562)
+              controlPoint1:CGPointMake(8.55983, 13.3135)
+              controlPoint2:CGPointMake(8.05, 13.0278)];
+      [play closePath];
+      [play fill];
+
+      CGContextSetBlendMode(context, kCGBlendModeClear);
+      CGContextSetLineCap(context, kCGLineCapRound);
+      CGContextSetLineWidth(context, 2.35);
+      CGContextMoveToPoint(context, 3.6, 2.65);
+      CGContextAddLineToPoint(context, 16.4, 17.35);
+      CGContextStrokePath(context);
+
+      CGContextSetBlendMode(context, kCGBlendModeNormal);
+      CGContextSetStrokeColorWithColor(context, iconColor.CGColor);
+      CGContextSetLineWidth(context, 1.5);
+      CGContextMoveToPoint(context, 3.6, 2.65);
+      CGContextAddLineToPoint(context, 16.4, 17.35);
+      CGContextStrokePath(context);
+    });
 }
 
 static UIImage *DYYYCommentPausePlaybackIcon(CGSize requestedSize) {
-    CGSize targetSize = requestedSize;
-    if (targetSize.width <= 0 || targetSize.height <= 0) {
-        targetSize = CGSizeMake(20, 20);
-    }
+    return DYYYRenderGeneratedSettingTemplateIcon(@"comment-pause-playback", requestedSize, ^(CGContextRef context, CGSize targetSize) {
+      CGContextScaleCTM(context, targetSize.width / 20.0, targetSize.height / 20.0);
+      UIColor *iconColor = [UIColor colorWithRed:22.0 / 255.0 green:24.0 / 255.0 blue:35.0 / 255.0 alpha:1.0];
+      [iconColor setFill];
 
-    static NSCache<NSString *, UIImage *> *imageCache;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-      imageCache = [[NSCache alloc] init];
+      UIBezierPath *bubble = [UIBezierPath bezierPath];
+      [bubble moveToPoint:CGPointMake(18.2295, 9.19579)];
+      [bubble addCurveToPoint:CGPointMake(9.99951, 1.77002)
+              controlPoint1:CGPointMake(18.2295, 5.01896)
+              controlPoint2:CGPointMake(14.465, 1.77002)];
+      [bubble addCurveToPoint:CGPointMake(1.76953, 9.1959)
+              controlPoint1:CGPointMake(5.53405, 1.77002)
+              controlPoint2:CGPointMake(1.76953, 5.01897)];
+      [bubble addCurveToPoint:CGPointMake(9.37823, 16.1374)
+              controlPoint1:CGPointMake(1.76953, 13.2087)
+              controlPoint2:CGPointMake(5.29956, 15.8541)];
+      [bubble addLineToPoint:CGPointMake(9.37823, 17.3396)];
+      [bubble addCurveToPoint:CGPointMake(10.5834, 18.078)
+              controlPoint1:CGPointMake(9.37823, 17.9499)
+              controlPoint2:CGPointMake(10.0237, 18.3639)];
+      [bubble addCurveToPoint:CGPointMake(15.6612, 14.5993)
+              controlPoint1:CGPointMake(11.2208, 17.7525)
+              controlPoint2:CGPointMake(13.9782, 16.2991)];
+      [bubble addCurveToPoint:CGPointMake(18.2295, 9.19579)
+              controlPoint1:CGPointMake(17.2249, 13.0198)
+              controlPoint2:CGPointMake(18.2295, 11.2807)];
+      [bubble closePath];
+
+      [bubble moveToPoint:CGPointMake(9.99951, 3.23002)];
+      [bubble addCurveToPoint:CGPointMake(16.7695, 9.19579)
+              controlPoint1:CGPointMake(13.8188, 3.23002)
+              controlPoint2:CGPointMake(16.7695, 5.97659)];
+      [bubble addCurveToPoint:CGPointMake(14.6236, 13.5721)
+              controlPoint1:CGPointMake(16.7695, 10.7555)
+              controlPoint2:CGPointMake(16.035, 12.1465)];
+      [bubble addCurveToPoint:CGPointMake(10.8382, 16.2821)
+              controlPoint1:CGPointMake(13.5418, 14.6648)
+              controlPoint2:CGPointMake(11.9072, 15.6785)];
+      [bubble addLineToPoint:CGPointMake(10.8382, 14.7027)];
+      [bubble addLineToPoint:CGPointMake(10.1082, 14.7027)];
+      [bubble addCurveToPoint:CGPointMake(3.22953, 9.1959)
+              controlPoint1:CGPointMake(6.20144, 14.7027)
+              controlPoint2:CGPointMake(3.22953, 12.3416)];
+      [bubble addCurveToPoint:CGPointMake(9.99951, 3.23002)
+              controlPoint1:CGPointMake(3.22953, 5.97658)
+              controlPoint2:CGPointMake(6.1803, 3.23002)];
+      [bubble closePath];
+      bubble.usesEvenOddFillRule = YES;
+      [bubble fill];
+
+      UIBezierPath *leftPause = [UIBezierPath bezierPathWithRoundedRect:CGRectMake(7.8, 7.15, 1.5, 4.7) cornerRadius:0.75];
+      [leftPause fill];
+      UIBezierPath *rightPause = [UIBezierPath bezierPathWithRoundedRect:CGRectMake(10.7, 7.15, 1.5, 4.7) cornerRadius:0.75];
+      [rightPause fill];
     });
-
-    NSString *cacheKey = NSStringFromCGSize(targetSize);
-    UIImage *cachedImage = [imageCache objectForKey:cacheKey];
-    if (cachedImage) {
-        return cachedImage;
-    }
-
-    UIGraphicsBeginImageContextWithOptions(targetSize, NO, 0);
-    CGContextRef context = UIGraphicsGetCurrentContext();
-    if (!context) {
-        UIGraphicsEndImageContext();
-        return nil;
-    }
-
-    CGContextScaleCTM(context, targetSize.width / 20.0, targetSize.height / 20.0);
-    UIColor *iconColor = [UIColor colorWithRed:22.0 / 255.0 green:24.0 / 255.0 blue:35.0 / 255.0 alpha:1.0];
-    CGContextSetStrokeColorWithColor(context, iconColor.CGColor);
-    CGContextSetFillColorWithColor(context, iconColor.CGColor);
-    CGContextSetLineCap(context, kCGLineCapRound);
-    CGContextSetLineJoin(context, kCGLineJoinRound);
-    CGContextSetLineWidth(context, 1.55);
-
-    UIBezierPath *bubble = [UIBezierPath bezierPath];
-    [bubble moveToPoint:CGPointMake(6.25, 3.8)];
-    [bubble addLineToPoint:CGPointMake(13.6, 3.8)];
-    [bubble addCurveToPoint:CGPointMake(17.0, 7.2)
-              controlPoint1:CGPointMake(15.65, 3.8)
-              controlPoint2:CGPointMake(17.0, 5.15)];
-    [bubble addLineToPoint:CGPointMake(17.0, 10.35)];
-    [bubble addCurveToPoint:CGPointMake(13.6, 13.75)
-              controlPoint1:CGPointMake(17.0, 12.4)
-              controlPoint2:CGPointMake(15.65, 13.75)];
-    [bubble addLineToPoint:CGPointMake(9.2, 13.75)];
-    [bubble addLineToPoint:CGPointMake(5.55, 16.6)];
-    [bubble addCurveToPoint:CGPointMake(4.55, 15.9)
-              controlPoint1:CGPointMake(5.1, 16.95)
-              controlPoint2:CGPointMake(4.55, 16.65)];
-    [bubble addLineToPoint:CGPointMake(4.55, 13.25)];
-    [bubble addCurveToPoint:CGPointMake(3.0, 10.35)
-              controlPoint1:CGPointMake(3.55, 12.6)
-              controlPoint2:CGPointMake(3.0, 11.55)];
-    [bubble addLineToPoint:CGPointMake(3.0, 7.2)];
-    [bubble addCurveToPoint:CGPointMake(6.25, 3.8)
-              controlPoint1:CGPointMake(3.0, 5.15)
-              controlPoint2:CGPointMake(4.25, 3.8)];
-    [bubble stroke];
-
-    CGContextSetLineWidth(context, 1.85);
-    CGContextMoveToPoint(context, 8.35, 7.05);
-    CGContextAddLineToPoint(context, 8.35, 11.45);
-    CGContextMoveToPoint(context, 11.65, 7.05);
-    CGContextAddLineToPoint(context, 11.65, 11.45);
-    CGContextStrokePath(context);
-
-    UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
-    UIGraphicsEndImageContext();
-    image = [image imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
-    if (image) {
-        [imageCache setObject:image forKey:cacheKey];
-    }
-    return image;
-}
-
-static UIImage *DYYYLoginBypassSettingIcon(CGSize requestedSize) {
-    CGSize targetSize = requestedSize;
-    if (targetSize.width <= 0 || targetSize.height <= 0) {
-        targetSize = CGSizeMake(20, 20);
-    }
-
-    static NSCache<NSString *, UIImage *> *imageCache;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-      imageCache = [[NSCache alloc] init];
-    });
-
-    NSString *cacheKey = NSStringFromCGSize(targetSize);
-    UIImage *cachedImage = [imageCache objectForKey:cacheKey];
-    if (cachedImage) {
-        return cachedImage;
-    }
-
-    UIGraphicsBeginImageContextWithOptions(targetSize, NO, 0);
-    CGContextRef context = UIGraphicsGetCurrentContext();
-    if (!context) {
-        UIGraphicsEndImageContext();
-        return nil;
-    }
-
-    CGContextScaleCTM(context, targetSize.width / 20.0, targetSize.height / 20.0);
-    UIColor *iconColor = [UIColor colorWithRed:22.0 / 255.0 green:24.0 / 255.0 blue:35.0 / 255.0 alpha:1.0];
-    CGContextSetStrokeColorWithColor(context, iconColor.CGColor);
-    CGContextSetFillColorWithColor(context, iconColor.CGColor);
-    CGContextSetLineCap(context, kCGLineCapRound);
-    CGContextSetLineJoin(context, kCGLineJoinRound);
-    CGContextSetLineWidth(context, 2.05);
-
-    UIBezierPath *shield = [UIBezierPath bezierPath];
-    [shield moveToPoint:CGPointMake(10.0, 2.35)];
-    [shield addCurveToPoint:CGPointMake(15.8, 4.45)
-              controlPoint1:CGPointMake(11.75, 3.45)
-              controlPoint2:CGPointMake(13.75, 4.15)];
-    [shield addLineToPoint:CGPointMake(15.8, 8.35)];
-    [shield addCurveToPoint:CGPointMake(10.0, 16.85)
-              controlPoint1:CGPointMake(15.8, 12.1)
-              controlPoint2:CGPointMake(13.45, 15.15)];
-    [shield addCurveToPoint:CGPointMake(4.2, 8.35)
-              controlPoint1:CGPointMake(6.55, 15.15)
-              controlPoint2:CGPointMake(4.2, 12.1)];
-    [shield addLineToPoint:CGPointMake(4.2, 4.45)];
-    [shield addCurveToPoint:CGPointMake(10.0, 2.35)
-              controlPoint1:CGPointMake(6.25, 4.15)
-              controlPoint2:CGPointMake(8.25, 3.45)];
-    [shield closePath];
-    [shield stroke];
-
-    UIBezierPath *keyhole = [UIBezierPath bezierPathWithOvalInRect:CGRectMake(8.85, 7.65, 2.3, 2.3)];
-    [keyhole fill];
-
-    UIBezierPath *slot = [UIBezierPath bezierPathWithRoundedRect:CGRectMake(9.25, 9.45, 1.5, 3.15) cornerRadius:0.75];
-    [slot fill];
-
-    UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
-    UIGraphicsEndImageContext();
-    image = [image imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
-    if (image) {
-        [imageCache setObject:image forKey:cacheKey];
-    }
-    return image;
 }
 
 @interface AWESettingsTableViewCell : UITableViewCell
@@ -280,41 +208,90 @@ static UIImage *DYYYLoginBypassSettingIcon(CGSize requestedSize) {
 @property(nonatomic, strong) UIImageView *iconImageView;
 - (void)updateSubviews;
 - (void)updateSubviewsAfterLayout;
+- (void)layoutSubviews;
 @end
 
-static void DYYYApplyGeneratedSettingIconToCell(AWESettingsTableViewCell *cell) {
-    AWESettingItemModel *itemModel = cell.itemModel;
-    UIImageView *iconView = cell.iconImageView;
-    if (!iconView) {
+static BOOL DYYYIsGeneratedSettingIconIdentifier(NSString *identifier) {
+    return [identifier isEqualToString:kDYYYFeedNowPlayingSettingIdentifier] || [identifier isEqualToString:kDYYYCommentPausePlaybackSettingIdentifier];
+}
+
+static UIImage *DYYYGeneratedSettingIconForIdentifier(NSString *identifier, CGSize targetSize) {
+    if ([identifier isEqualToString:kDYYYFeedNowPlayingSettingIdentifier]) {
+        return DYYYFeedNowPlayingIcon(targetSize);
+    }
+    if ([identifier isEqualToString:kDYYYCommentPausePlaybackSettingIdentifier]) {
+        return DYYYCommentPausePlaybackIcon(targetSize);
+    }
+    return nil;
+}
+
+static void DYYYApplyGeneratedSettingIconToCellInternal(AWESettingsTableViewCell *cell, BOOL scheduleRetry);
+
+static void DYYYScheduleGeneratedSettingIconReapply(AWESettingsTableViewCell *cell) {
+    if (!cell) {
         return;
     }
 
-    UIImage *iconImage = nil;
-    if ([itemModel.identifier isEqualToString:kDYYYFeedNowPlayingSettingIdentifier]) {
-        iconImage = DYYYFeedNowPlayingSVGIcon(iconView.bounds.size);
-    } else if ([itemModel.identifier isEqualToString:kDYYYCommentPausePlaybackSettingIdentifier]) {
-        iconImage = DYYYCommentPausePlaybackIcon(iconView.bounds.size);
-    } else if ([itemModel.identifier isEqualToString:kDYYYLoginBypassSettingIdentifier]) {
-        iconImage = DYYYLoginBypassSettingIcon(iconView.bounds.size);
+    if (objc_getAssociatedObject(cell, &kDYYYGeneratedSettingIconRetryScheduledKey)) {
+        return;
     }
 
+    objc_setAssociatedObject(cell, &kDYYYGeneratedSettingIconRetryScheduledKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    __weak AWESettingsTableViewCell *weakCell = cell;
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+      DYYYApplyGeneratedSettingIconToCellInternal(weakCell, NO);
+    });
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.06 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+      DYYYApplyGeneratedSettingIconToCellInternal(weakCell, NO);
+    });
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.25 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+      AWESettingsTableViewCell *strongCell = weakCell;
+      DYYYApplyGeneratedSettingIconToCellInternal(strongCell, NO);
+      if (strongCell) {
+          objc_setAssociatedObject(strongCell, &kDYYYGeneratedSettingIconRetryScheduledKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+      }
+    });
+}
+
+static void DYYYApplyGeneratedSettingIconToCellInternal(AWESettingsTableViewCell *cell, BOOL scheduleRetry) {
+    AWESettingItemModel *itemModel = cell.itemModel;
+    UIImageView *iconView = cell.iconImageView;
+    NSString *identifier = itemModel.identifier;
+
+    if (!DYYYIsGeneratedSettingIconIdentifier(identifier)) {
+        if (iconView) {
+            objc_setAssociatedObject(iconView, &kDYYYGeneratedSettingIconIdentifierKey, nil, OBJC_ASSOCIATION_COPY_NONATOMIC);
+        }
+        return;
+    }
+
+    if (!iconView) {
+        if (scheduleRetry) {
+            DYYYScheduleGeneratedSettingIconReapply(cell);
+        }
+        return;
+    }
+
+    UIImage *iconImage = DYYYGeneratedSettingIconForIdentifier(identifier, iconView.bounds.size);
     if (!iconImage) {
         return;
     }
 
+    objc_setAssociatedObject(iconView, &kDYYYGeneratedSettingIconIdentifierKey, identifier, OBJC_ASSOCIATION_COPY_NONATOMIC);
     iconView.image = iconImage;
     iconView.contentMode = UIViewContentModeScaleAspectFit;
     iconView.hidden = NO;
     iconView.alpha = 1.0;
-    iconView.tintColor = cell.titleLabel.textColor;
+    iconView.tintColor = cell.titleLabel.textColor ?: cell.tintColor ?: [UIColor colorWithRed:22.0 / 255.0 green:24.0 / 255.0 blue:35.0 / 255.0 alpha:1.0];
 
-    if ([itemModel.identifier isEqualToString:kDYYYLoginBypassSettingIdentifier] && cell.titleLabel.superview && iconView.superview &&
-        CGRectGetHeight(cell.titleLabel.bounds) > 0 && CGRectGetHeight(iconView.bounds) > 0) {
-        CGPoint titleCenter = [cell.titleLabel.superview convertPoint:cell.titleLabel.center toView:iconView.superview];
-        CGRect iconFrame = iconView.frame;
-        iconFrame.origin.y = round(titleCenter.y - CGRectGetHeight(iconFrame) / 2.0);
-        iconView.frame = iconFrame;
+    if (scheduleRetry) {
+        DYYYScheduleGeneratedSettingIconReapply(cell);
     }
+}
+
+static void DYYYApplyGeneratedSettingIconToCell(AWESettingsTableViewCell *cell) {
+    DYYYApplyGeneratedSettingIconToCellInternal(cell, YES);
 }
 
 static void DYYYRemoveRemoteConfigObserver(void) {
@@ -895,6 +872,11 @@ static void DYYYBuildSettingsSearchIndexIfNeeded(NSArray<AWESettingItemModel *> 
 }
 
 - (void)updateSubviewsAfterLayout {
+    %orig;
+    DYYYApplyGeneratedSettingIconToCell(self);
+}
+
+- (void)layoutSubviews {
     %orig;
     DYYYApplyGeneratedSettingIconToCell(self);
 }

--- a/DYYYSettings.xm
+++ b/DYYYSettings.xm
@@ -53,6 +53,8 @@ static BOOL DYYYSettingsSearchIndexBuilt = NO;
 static NSString *const kDYYYFeedNowPlayingSettingTitle = @"屏蔽灵动岛抖音播放信息";
 static NSString *const kDYYYFeedNowPlayingSettingIdentifier = @"DYYYDisableFeedNowPlayingInfo";
 static NSString *const kDYYYFeedNowPlayingSVGIconName = @"ic_liveactivityplayslash_outlined_20";
+static NSString *const kDYYYCommentPausePlaybackSettingIdentifier = @"DYYYCommentPausePlayback";
+static NSString *const kDYYYCommentPausePlaybackSVGIconName = @"ic_commentpause_dyyy_outlined_20";
 
 static UIImage *DYYYFeedNowPlayingSVGIcon(CGSize requestedSize) {
     CGSize targetSize = requestedSize;
@@ -128,6 +130,80 @@ static UIImage *DYYYFeedNowPlayingSVGIcon(CGSize requestedSize) {
     return image;
 }
 
+static UIImage *DYYYCommentPausePlaybackIcon(CGSize requestedSize) {
+    CGSize targetSize = requestedSize;
+    if (targetSize.width <= 0 || targetSize.height <= 0) {
+        targetSize = CGSizeMake(20, 20);
+    }
+
+    static NSCache<NSString *, UIImage *> *imageCache;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+      imageCache = [[NSCache alloc] init];
+    });
+
+    NSString *cacheKey = NSStringFromCGSize(targetSize);
+    UIImage *cachedImage = [imageCache objectForKey:cacheKey];
+    if (cachedImage) {
+        return cachedImage;
+    }
+
+    UIGraphicsBeginImageContextWithOptions(targetSize, NO, 0);
+    CGContextRef context = UIGraphicsGetCurrentContext();
+    if (!context) {
+        UIGraphicsEndImageContext();
+        return nil;
+    }
+
+    CGContextScaleCTM(context, targetSize.width / 20.0, targetSize.height / 20.0);
+    UIColor *iconColor = [UIColor colorWithRed:22.0 / 255.0 green:24.0 / 255.0 blue:35.0 / 255.0 alpha:1.0];
+    CGContextSetStrokeColorWithColor(context, iconColor.CGColor);
+    CGContextSetFillColorWithColor(context, iconColor.CGColor);
+    CGContextSetLineCap(context, kCGLineCapRound);
+    CGContextSetLineJoin(context, kCGLineJoinRound);
+    CGContextSetLineWidth(context, 1.55);
+
+    UIBezierPath *bubble = [UIBezierPath bezierPath];
+    [bubble moveToPoint:CGPointMake(6.25, 3.8)];
+    [bubble addLineToPoint:CGPointMake(13.6, 3.8)];
+    [bubble addCurveToPoint:CGPointMake(17.0, 7.2)
+              controlPoint1:CGPointMake(15.65, 3.8)
+              controlPoint2:CGPointMake(17.0, 5.15)];
+    [bubble addLineToPoint:CGPointMake(17.0, 10.35)];
+    [bubble addCurveToPoint:CGPointMake(13.6, 13.75)
+              controlPoint1:CGPointMake(17.0, 12.4)
+              controlPoint2:CGPointMake(15.65, 13.75)];
+    [bubble addLineToPoint:CGPointMake(9.2, 13.75)];
+    [bubble addLineToPoint:CGPointMake(5.55, 16.6)];
+    [bubble addCurveToPoint:CGPointMake(4.55, 15.9)
+              controlPoint1:CGPointMake(5.1, 16.95)
+              controlPoint2:CGPointMake(4.55, 16.65)];
+    [bubble addLineToPoint:CGPointMake(4.55, 13.25)];
+    [bubble addCurveToPoint:CGPointMake(3.0, 10.35)
+              controlPoint1:CGPointMake(3.55, 12.6)
+              controlPoint2:CGPointMake(3.0, 11.55)];
+    [bubble addLineToPoint:CGPointMake(3.0, 7.2)];
+    [bubble addCurveToPoint:CGPointMake(6.25, 3.8)
+              controlPoint1:CGPointMake(3.0, 5.15)
+              controlPoint2:CGPointMake(4.25, 3.8)];
+    [bubble stroke];
+
+    CGContextSetLineWidth(context, 1.85);
+    CGContextMoveToPoint(context, 8.35, 7.05);
+    CGContextAddLineToPoint(context, 8.35, 11.45);
+    CGContextMoveToPoint(context, 11.65, 7.05);
+    CGContextAddLineToPoint(context, 11.65, 11.45);
+    CGContextStrokePath(context);
+
+    UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
+    UIGraphicsEndImageContext();
+    image = [image imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
+    if (image) {
+        [imageCache setObject:image forKey:cacheKey];
+    }
+    return image;
+}
+
 @interface AWESettingsTableViewCell : UITableViewCell
 @property(nonatomic, strong) AWESettingItemModel *itemModel;
 @property(nonatomic, strong) UILabel *titleLabel;
@@ -136,18 +212,25 @@ static UIImage *DYYYFeedNowPlayingSVGIcon(CGSize requestedSize) {
 - (void)updateSubviewsAfterLayout;
 @end
 
-static void DYYYApplyFeedNowPlayingIconToCell(AWESettingsTableViewCell *cell) {
+static void DYYYApplyGeneratedSettingIconToCell(AWESettingsTableViewCell *cell) {
     AWESettingItemModel *itemModel = cell.itemModel;
-    if (![itemModel.identifier isEqualToString:kDYYYFeedNowPlayingSettingIdentifier]) {
-        return;
-    }
-
     UIImageView *iconView = cell.iconImageView;
     if (!iconView) {
         return;
     }
 
-    iconView.image = DYYYFeedNowPlayingSVGIcon(iconView.bounds.size);
+    UIImage *iconImage = nil;
+    if ([itemModel.identifier isEqualToString:kDYYYFeedNowPlayingSettingIdentifier]) {
+        iconImage = DYYYFeedNowPlayingSVGIcon(iconView.bounds.size);
+    } else if ([itemModel.identifier isEqualToString:kDYYYCommentPausePlaybackSettingIdentifier]) {
+        iconImage = DYYYCommentPausePlaybackIcon(iconView.bounds.size);
+    }
+
+    if (!iconImage) {
+        return;
+    }
+
+    iconView.image = iconImage;
     iconView.contentMode = UIViewContentModeScaleAspectFit;
     iconView.hidden = NO;
     iconView.alpha = 1.0;
@@ -695,7 +778,7 @@ static void DYYYBuildSettingsSearchIndexIfNeeded(NSArray<AWESettingItemModel *> 
     [coordinator updateLayout];
     for (AWESettingsTableViewCell *cell in self.tableView.visibleCells) {
         if ([cell isKindOfClass:%c(AWESettingsTableViewCell)]) {
-            DYYYApplyFeedNowPlayingIconToCell(cell);
+            DYYYApplyGeneratedSettingIconToCell(cell);
         }
     }
 }
@@ -723,17 +806,17 @@ static void DYYYBuildSettingsSearchIndexIfNeeded(NSArray<AWESettingItemModel *> 
 
 - (void)setItemModel:(AWESettingItemModel *)itemModel {
     %orig;
-    DYYYApplyFeedNowPlayingIconToCell(self);
+    DYYYApplyGeneratedSettingIconToCell(self);
 }
 
 - (void)updateSubviews {
     %orig;
-    DYYYApplyFeedNowPlayingIconToCell(self);
+    DYYYApplyGeneratedSettingIconToCell(self);
 }
 
 - (void)updateSubviewsAfterLayout {
     %orig;
-    DYYYApplyFeedNowPlayingIconToCell(self);
+    DYYYApplyGeneratedSettingIconToCell(self);
 }
 
 %end
@@ -3519,6 +3602,14 @@ void showDYYYSettingsVC(UIViewController *rootVC, BOOL hasAgreed) {
               @"detail" : @"",
               @"cellType" : @37,
               @"imageName" : @"ic_dansquare_outlined_20"
+          },
+          @{
+              @"identifier" : kDYYYCommentPausePlaybackSettingIdentifier,
+              @"title" : @"查看评论暂停播放",
+              @"subTitle" : @"打开评论区时暂停当前播放",
+              @"detail" : @"",
+              @"cellType" : @37,
+              @"imageName" : kDYYYCommentPausePlaybackSVGIconName
           },
           @{
               @"identifier" : @"DYYYEnableDoubleTapMenu",

--- a/DYYYSettings.xm
+++ b/DYYYSettings.xm
@@ -55,6 +55,8 @@ static NSString *const kDYYYFeedNowPlayingSettingIdentifier = @"DYYYDisableFeedN
 static NSString *const kDYYYFeedNowPlayingSVGIconName = @"ic_liveactivityplayslash_outlined_20";
 static NSString *const kDYYYCommentPausePlaybackSettingIdentifier = @"DYYYCommentPausePlayback";
 static NSString *const kDYYYCommentPausePlaybackSVGIconName = @"ic_commentpause_dyyy_outlined_20";
+static NSString *const kDYYYHideRecommendAppDownloadSettingIdentifier = @"DYYYHideRecommendAppDownload";
+static NSString *const kDYYYHideRecommendAppDownloadSVGIconName = @"ic_dyyy_appdownloadslash_outlined_20";
 
 static UIImage *DYYYFeedNowPlayingSVGIcon(CGSize requestedSize) {
     CGSize targetSize = requestedSize;
@@ -204,6 +206,71 @@ static UIImage *DYYYCommentPausePlaybackIcon(CGSize requestedSize) {
     return image;
 }
 
+static UIImage *DYYYRecommendAppDownloadIcon(CGSize requestedSize) {
+    CGSize targetSize = requestedSize;
+    if (targetSize.width <= 0 || targetSize.height <= 0) {
+        targetSize = CGSizeMake(20, 20);
+    }
+
+    static NSCache<NSString *, UIImage *> *imageCache;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+      imageCache = [[NSCache alloc] init];
+    });
+
+    NSString *cacheKey = NSStringFromCGSize(targetSize);
+    UIImage *cachedImage = [imageCache objectForKey:cacheKey];
+    if (cachedImage) {
+        return cachedImage;
+    }
+
+    UIGraphicsBeginImageContextWithOptions(targetSize, NO, 0);
+    CGContextRef context = UIGraphicsGetCurrentContext();
+    if (!context) {
+        UIGraphicsEndImageContext();
+        return nil;
+    }
+
+    CGContextScaleCTM(context, targetSize.width / 20.0, targetSize.height / 20.0);
+    UIColor *iconColor = [UIColor colorWithRed:22.0 / 255.0 green:24.0 / 255.0 blue:35.0 / 255.0 alpha:1.0];
+    CGContextSetStrokeColorWithColor(context, iconColor.CGColor);
+    CGContextSetLineCap(context, kCGLineCapRound);
+    CGContextSetLineJoin(context, kCGLineJoinRound);
+    CGContextSetLineWidth(context, 1.55);
+
+    UIBezierPath *banner = [UIBezierPath bezierPathWithRoundedRect:CGRectMake(2.5, 5.25, 15.0, 9.5) cornerRadius:2.2];
+    [banner stroke];
+
+    UIBezierPath *appIcon = [UIBezierPath bezierPathWithRoundedRect:CGRectMake(4.7, 7.45, 3.8, 3.8) cornerRadius:0.95];
+    [appIcon stroke];
+
+    CGContextMoveToPoint(context, 9.95, 8.0);
+    CGContextAddLineToPoint(context, 12.95, 8.0);
+    CGContextMoveToPoint(context, 9.95, 10.7);
+    CGContextAddLineToPoint(context, 11.75, 10.7);
+    CGContextStrokePath(context);
+
+    CGContextMoveToPoint(context, 14.45, 7.45);
+    CGContextAddLineToPoint(context, 14.45, 11.1);
+    CGContextMoveToPoint(context, 12.95, 9.75);
+    CGContextAddLineToPoint(context, 14.45, 11.25);
+    CGContextAddLineToPoint(context, 15.95, 9.75);
+    CGContextStrokePath(context);
+
+    CGContextSetLineWidth(context, 1.65);
+    CGContextMoveToPoint(context, 4.15, 3.75);
+    CGContextAddLineToPoint(context, 15.85, 16.25);
+    CGContextStrokePath(context);
+
+    UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
+    UIGraphicsEndImageContext();
+    image = [image imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
+    if (image) {
+        [imageCache setObject:image forKey:cacheKey];
+    }
+    return image;
+}
+
 @interface AWESettingsTableViewCell : UITableViewCell
 @property(nonatomic, strong) AWESettingItemModel *itemModel;
 @property(nonatomic, strong) UILabel *titleLabel;
@@ -224,6 +291,8 @@ static void DYYYApplyGeneratedSettingIconToCell(AWESettingsTableViewCell *cell) 
         iconImage = DYYYFeedNowPlayingSVGIcon(iconView.bounds.size);
     } else if ([itemModel.identifier isEqualToString:kDYYYCommentPausePlaybackSettingIdentifier]) {
         iconImage = DYYYCommentPausePlaybackIcon(iconView.bounds.size);
+    } else if ([itemModel.identifier isEqualToString:kDYYYHideRecommendAppDownloadSettingIdentifier]) {
+        iconImage = DYYYRecommendAppDownloadIcon(iconView.bounds.size);
     }
 
     if (!iconImage) {
@@ -1946,6 +2015,11 @@ void showDYYYSettingsVC(UIViewController *rootVC, BOOL hasAgreed) {
             @"detail" : @"",
             @"cellType" : @6,
             @"imageName" : @"ic_eyeslash_outlined_16"},
+          @{@"identifier" : kDYYYHideRecommendAppDownloadSettingIdentifier,
+            @"title" : @"隐藏推荐应用下载",
+            @"detail" : @"",
+            @"cellType" : @6,
+            @"imageName" : kDYYYHideRecommendAppDownloadSVGIconName},
           @{
               @"identifier" : @"DYYYHideGradient",
               @"title" : @"隐藏遮罩效果",

--- a/DYYYSettings.xm
+++ b/DYYYSettings.xm
@@ -2178,7 +2178,7 @@ void showDYYYSettingsVC(UIViewController *rootVC, BOOL hasAgreed) {
               @"identifier" : @"DYYYHideFeedAnchorContainer",
               @"title" : @"隐藏视频锚点",
               @"detail" : @"",
-              @"cellType" : @37,
+              @"cellType" : @6,
               @"imageName" : @"ic_eyeslash_outlined_16"
           },
           @{@"identifier" : @"DYYYHideLocation",

--- a/DYYYSettings.xm
+++ b/DYYYSettings.xm
@@ -613,6 +613,7 @@ static UIColor *DYYYSettingsSearchPlaceholderColor(BOOL usesLightBackground) {
 - (void)installNavigationInterceptors;
 - (void)applyThemeColors;
 - (void)updateLayout;
+- (void)updateSearchPlaceholderVisibilityAnimated:(BOOL)animated;
 - (void)updateNavigationGestureState;
 - (void)restoreNavigationGestureState;
 - (BOOL)handleBackNavigationRequest;
@@ -707,17 +708,7 @@ static UIColor *DYYYSettingsSearchPlaceholderColor(BOOL usesLightBackground) {
     self.containerView.frame = CGRectMake(16, 8, width - 32, 44);
     self.searchTextField.frame = self.containerView.bounds;
 
-    CGFloat iconSize = 18.0;
-    CGFloat spacing = 8.0;
-    CGSize labelSize = [self.centerPlaceholderLabel.text sizeWithAttributes:@{NSFontAttributeName : self.centerPlaceholderLabel.font}];
-    CGFloat placeholderWidth = iconSize + spacing + ceil(labelSize.width);
-    CGFloat placeholderHeight = MAX(iconSize, ceil(labelSize.height));
-    self.centerPlaceholderView.frame = CGRectMake((CGRectGetWidth(self.containerView.bounds) - placeholderWidth) / 2.0,
-                                                  (CGRectGetHeight(self.containerView.bounds) - placeholderHeight) / 2.0,
-                                                  placeholderWidth,
-                                                  placeholderHeight);
-    self.centerIconView.frame = CGRectMake(0, (placeholderHeight - iconSize) / 2.0, iconSize, iconSize);
-    self.centerPlaceholderLabel.frame = CGRectMake(iconSize + spacing, 0, ceil(labelSize.width), placeholderHeight);
+    [self updateSearchPlaceholderVisibilityAnimated:NO];
 
     if (needsHeaderUpdate) {
         tableView.tableHeaderView = self.headerView;
@@ -727,22 +718,73 @@ static UIColor *DYYYSettingsSearchPlaceholderColor(BOOL usesLightBackground) {
     [self updateNavigationGestureState];
 }
 
+- (CGRect)placeholderFrameForLeftAlignment:(BOOL)leftAligned {
+    CGFloat iconSize = 18.0;
+    CGFloat spacing = 8.0;
+    CGSize labelSize = [self.centerPlaceholderLabel.text sizeWithAttributes:@{NSFontAttributeName : self.centerPlaceholderLabel.font}];
+    CGFloat placeholderWidth = iconSize + spacing + ceil(labelSize.width);
+    CGFloat placeholderHeight = MAX(iconSize, ceil(labelSize.height));
+    self.centerIconView.frame = CGRectMake(0, (placeholderHeight - iconSize) / 2.0, iconSize, iconSize);
+    self.centerPlaceholderLabel.frame = CGRectMake(iconSize + spacing, 0, ceil(labelSize.width), placeholderHeight);
+
+    CGFloat containerWidth = CGRectGetWidth(self.containerView.bounds);
+    CGFloat containerHeight = CGRectGetHeight(self.containerView.bounds);
+    CGFloat targetX = leftAligned ? 14.0 : (containerWidth - placeholderWidth) / 2.0;
+    targetX = MAX(0.0, MIN(targetX, containerWidth - placeholderWidth));
+    return CGRectMake(targetX, (containerHeight - placeholderHeight) / 2.0, placeholderWidth, placeholderHeight);
+}
+
+- (void)updateSearchPlaceholderVisibility {
+    [self updateSearchPlaceholderVisibilityAnimated:NO];
+}
+
 - (NSString *)trimmedSearchText {
     return [self.searchTextField.text ?: @"" stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
 }
 
-- (void)updateSearchPlaceholderVisibility {
-    BOOL showCenteredPlaceholder = !self.searchTextField.isEditing && [self trimmedSearchText].length == 0;
-    self.centerPlaceholderView.hidden = !showCenteredPlaceholder;
-    if (showCenteredPlaceholder) {
-        self.searchTextField.placeholder = nil;
-        self.searchTextField.attributedPlaceholder = nil;
-    } else {
-        UIColor *placeholderColor = self.centerPlaceholderLabel.textColor ?: DYYYSettingsSearchPlaceholderColor(DYYYSettingsUsesDouyinLightBackground());
-        self.searchTextField.attributedPlaceholder = [[NSAttributedString alloc] initWithString:@"搜索设置项"
-                                                                                     attributes:@{NSForegroundColorAttributeName : placeholderColor}];
+- (void)updateSearchPlaceholderVisibilityAnimated:(BOOL)animated {
+    BOOL hasSearchText = [self trimmedSearchText].length > 0;
+    BOOL showPlaceholderView = !hasSearchText;
+    BOOL leftAligned = self.searchTextField.isEditing;
+    CGRect targetFrame = [self placeholderFrameForLeftAlignment:leftAligned];
+    CGFloat targetPlaceholderAlpha = showPlaceholderView ? 1.0 : 0.0;
+
+    self.searchTextField.placeholder = nil;
+    self.searchTextField.attributedPlaceholder = nil;
+    self.searchTextField.leftViewMode = (self.searchTextField.isEditing || hasSearchText) ? UITextFieldViewModeAlways : UITextFieldViewModeNever;
+    if (showPlaceholderView) {
+        self.centerPlaceholderView.hidden = NO;
+        self.leftIconView.alpha = 0.0;
     }
-    self.searchTextField.leftViewMode = showCenteredPlaceholder ? UITextFieldViewModeNever : UITextFieldViewModeAlways;
+
+    void (^animations)(void) = ^{
+      self.centerPlaceholderView.frame = targetFrame;
+      self.centerPlaceholderView.alpha = targetPlaceholderAlpha;
+      if (!showPlaceholderView) {
+          self.leftIconView.alpha = 1.0;
+      }
+    };
+
+    void (^completion)(BOOL) = ^(BOOL finished) {
+      if (!showPlaceholderView && finished) {
+          self.centerPlaceholderView.hidden = YES;
+      }
+    };
+
+    if (animated && self.centerPlaceholderView.superview) {
+        [UIView animateWithDuration:0.26
+                              delay:0
+             usingSpringWithDamping:0.88
+              initialSpringVelocity:0.0
+                            options:UIViewAnimationOptionBeginFromCurrentState | UIViewAnimationOptionAllowUserInteraction
+                         animations:animations
+                         completion:completion];
+    } else {
+        animations();
+        if (!showPlaceholderView) {
+            self.centerPlaceholderView.hidden = YES;
+        }
+    }
 }
 
 - (void)applyThemeColors {
@@ -815,7 +857,7 @@ static UIColor *DYYYSettingsSearchPlaceholderColor(BOOL usesLightBackground) {
 }
 
 - (void)searchTextDidChange:(UITextField *)textField {
-    [self updateSearchPlaceholderVisibility];
+    [self updateSearchPlaceholderVisibilityAnimated:YES];
     self.viewModel.sectionDataArray = [self sectionsForSearchText:[self trimmedSearchText]];
     [self.settingsVC.tableView reloadData];
     [self updateNavigationGestureState];
@@ -832,9 +874,15 @@ static UIColor *DYYYSettingsSearchPlaceholderColor(BOOL usesLightBackground) {
 
     self.searchTextField.text = @"";
     [self.searchTextField resignFirstResponder];
-    [self updateSearchPlaceholderVisibility];
+    [self updateSearchPlaceholderVisibilityAnimated:YES];
     self.viewModel.sectionDataArray = self.originalSections;
-    [self.settingsVC.tableView reloadData];
+    [UIView transitionWithView:self.settingsVC.tableView
+                      duration:0.18
+                       options:UIViewAnimationOptionTransitionCrossDissolve | UIViewAnimationOptionBeginFromCurrentState | UIViewAnimationOptionAllowUserInteraction
+                    animations:^{
+                      [self.settingsVC.tableView reloadData];
+                    }
+                    completion:nil];
     [self updateNavigationGestureState];
     return YES;
 }
@@ -921,12 +969,12 @@ static UIColor *DYYYSettingsSearchPlaceholderColor(BOOL usesLightBackground) {
 }
 
 - (void)textFieldDidBeginEditing:(UITextField *)textField {
-    [self updateSearchPlaceholderVisibility];
+    [self updateSearchPlaceholderVisibilityAnimated:YES];
     [self updateNavigationGestureState];
 }
 
 - (void)textFieldDidEndEditing:(UITextField *)textField {
-    [self updateSearchPlaceholderVisibility];
+    [self updateSearchPlaceholderVisibilityAnimated:YES];
     [self updateNavigationGestureState];
 }
 

--- a/DYYYSettings.xm
+++ b/DYYYSettings.xm
@@ -1,9 +1,11 @@
 #import "AwemeHeaders.h"
 #import "DYYYManager.h"
-#import <MobileCoreServices/MobileCoreServices.h>
+#import <fcntl.h>
 #import <math.h>
+#import <spawn.h>
 #import <stdlib.h>
 #import <UIKit/UIKit.h>
+#import <unistd.h>
 #import <objc/message.h>
 #import <objc/runtime.h>
 
@@ -62,6 +64,13 @@ static NSString *const kDYYYMiniProgramJumpingAdsSettingIdentifier = @"DYYYEnabl
 
 static char kDYYYGeneratedSettingIconIdentifierKey;
 static char kDYYYGeneratedSettingIconRetryScheduledKey;
+#ifdef __cplusplus
+extern "C" {
+#endif
+extern char **environ;
+#ifdef __cplusplus
+}
+#endif
 
 static UIImage *DYYYRenderGeneratedSettingTemplateIcon(NSString *cacheName, CGSize requestedSize, void (^drawBlock)(CGContextRef context, CGSize targetSize)) {
     CGSize targetSize = requestedSize;
@@ -205,39 +214,33 @@ static UIImage *DYYYCommentPausePlaybackIcon(CGSize requestedSize) {
 }
 
 static UIImage *DYYYMiniProgramJumpingAdsIcon(CGSize requestedSize) {
-    return DYYYRenderGeneratedSettingTemplateIcon(@"mini-program-jumping-ads", requestedSize, ^(CGContextRef context, CGSize targetSize) {
+    return DYYYRenderGeneratedSettingTemplateIcon(@"mini-program-jumping-ads-v2", requestedSize, ^(CGContextRef context, CGSize targetSize) {
       CGContextScaleCTM(context, targetSize.width / 20.0, targetSize.height / 20.0);
       UIColor *iconColor = [UIColor colorWithRed:22.0 / 255.0 green:24.0 / 255.0 blue:35.0 / 255.0 alpha:1.0];
-      [iconColor setFill];
       [iconColor setStroke];
+      CGContextSetLineWidth(context, 1.55);
+      CGContextSetLineCap(context, kCGLineCapRound);
+      CGContextSetLineJoin(context, kCGLineJoinRound);
 
-      UIBezierPath *roundedSquare = [UIBezierPath bezierPathWithRoundedRect:CGRectMake(2.2, 2.2, 9.4, 9.4) cornerRadius:2.2];
-      [roundedSquare appendPath:[UIBezierPath bezierPathWithRoundedRect:CGRectMake(4.2, 4.2, 5.4, 5.4) cornerRadius:1.2]];
-      roundedSquare.usesEvenOddFillRule = YES;
-      [roundedSquare fill];
-
-      UIBezierPath *smallSquare = [UIBezierPath bezierPathWithRoundedRect:CGRectMake(12.8, 3.0, 4.9, 4.9) cornerRadius:1.2];
-      [smallSquare fill];
-
-      UIBezierPath *bottomSquare = [UIBezierPath bezierPathWithRoundedRect:CGRectMake(3.0, 12.8, 4.9, 4.9) cornerRadius:1.2];
-      [bottomSquare fill];
+      UIBezierPath *tiles = [UIBezierPath bezierPath];
+      [tiles appendPath:[UIBezierPath bezierPathWithRoundedRect:CGRectMake(3.0, 3.0, 5.2, 5.2) cornerRadius:1.15]];
+      [tiles appendPath:[UIBezierPath bezierPathWithRoundedRect:CGRectMake(11.3, 3.3, 3.9, 3.9) cornerRadius:0.9]];
+      [tiles appendPath:[UIBezierPath bezierPathWithRoundedRect:CGRectMake(3.3, 11.3, 3.9, 3.9) cornerRadius:0.9]];
+      tiles.lineWidth = 1.55;
+      tiles.lineCapStyle = kCGLineCapRound;
+      tiles.lineJoinStyle = kCGLineJoinRound;
+      [tiles stroke];
 
       UIBezierPath *arrow = [UIBezierPath bezierPath];
-      [arrow moveToPoint:CGPointMake(10.9, 13.8)];
-      [arrow addLineToPoint:CGPointMake(16.1, 13.8)];
-      [arrow addLineToPoint:CGPointMake(14.2, 11.9)];
-      [arrow addCurveToPoint:CGPointMake(14.2, 10.95) controlPoint1:CGPointMake(13.95, 11.65) controlPoint2:CGPointMake(13.95, 11.2)];
-      [arrow addCurveToPoint:CGPointMake(15.15, 10.95) controlPoint1:CGPointMake(14.45, 10.7) controlPoint2:CGPointMake(14.9, 10.7)];
-      [arrow addLineToPoint:CGPointMake(18.45, 14.25)];
-      [arrow addCurveToPoint:CGPointMake(18.45, 15.2) controlPoint1:CGPointMake(18.7, 14.5) controlPoint2:CGPointMake(18.7, 14.95)];
-      [arrow addLineToPoint:CGPointMake(15.15, 18.5)];
-      [arrow addCurveToPoint:CGPointMake(14.2, 18.5) controlPoint1:CGPointMake(14.9, 18.75) controlPoint2:CGPointMake(14.45, 18.75)];
-      [arrow addCurveToPoint:CGPointMake(14.2, 17.55) controlPoint1:CGPointMake(13.95, 18.25) controlPoint2:CGPointMake(13.95, 17.8)];
-      [arrow addLineToPoint:CGPointMake(16.1, 15.65)];
-      [arrow addLineToPoint:CGPointMake(10.9, 15.65)];
-      [arrow addCurveToPoint:CGPointMake(10.9, 13.8) controlPoint1:CGPointMake(10.3, 15.65) controlPoint2:CGPointMake(10.3, 13.8)];
-      [arrow closePath];
-      [arrow fill];
+      [arrow moveToPoint:CGPointMake(10.0, 14.3)];
+      [arrow addLineToPoint:CGPointMake(16.7, 14.3)];
+      [arrow moveToPoint:CGPointMake(14.1, 11.7)];
+      [arrow addLineToPoint:CGPointMake(16.8, 14.3)];
+      [arrow addLineToPoint:CGPointMake(14.1, 16.9)];
+      arrow.lineWidth = 1.65;
+      arrow.lineCapStyle = kCGLineCapRound;
+      arrow.lineJoinStyle = kCGLineJoinRound;
+      [arrow stroke];
     });
 }
 
@@ -349,21 +352,121 @@ static NSString *DYYYStringOrEmpty(id value) {
     return [value isKindOfClass:[NSString class]] ? (NSString *)value : @"";
 }
 
+static NSString *DYYYShellQuotedString(NSString *string) {
+    NSString *safeString = [string ?: @"" stringByReplacingOccurrencesOfString:@"'" withString:@"'\\''"];
+    return [NSString stringWithFormat:@"'%@'", safeString];
+}
+
+static NSString *DYYYPreferredLaunchURLString(void) {
+    NSArray *urlTypes = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleURLTypes"];
+    NSMutableArray<NSString *> *schemes = [NSMutableArray array];
+    for (NSDictionary *urlType in urlTypes) {
+        if (![urlType isKindOfClass:[NSDictionary class]]) {
+            continue;
+        }
+        NSArray *urlSchemes = urlType[@"CFBundleURLSchemes"];
+        for (NSString *scheme in urlSchemes) {
+            if ([scheme isKindOfClass:[NSString class]] && scheme.length > 0) {
+                [schemes addObject:scheme];
+            }
+        }
+    }
+
+    for (NSString *preferredScheme in @[ @"snssdk1128", @"aweme" ]) {
+        for (NSString *scheme in schemes) {
+            if ([scheme caseInsensitiveCompare:preferredScheme] == NSOrderedSame) {
+                return [NSString stringWithFormat:@"%@://", scheme];
+            }
+        }
+    }
+
+    for (NSString *scheme in schemes) {
+        NSString *lowercaseScheme = scheme.lowercaseString;
+        if ([lowercaseScheme hasPrefix:@"snssdk"] &&
+            [lowercaseScheme rangeOfString:@"sync"].location == NSNotFound &&
+            [lowercaseScheme rangeOfString:@"lucky"].location == NSNotFound &&
+            [lowercaseScheme rangeOfString:@"share"].location == NSNotFound &&
+            [lowercaseScheme rangeOfString:@"pay"].location == NSNotFound) {
+            return [NSString stringWithFormat:@"%@://", scheme];
+        }
+    }
+
+    return nil;
+}
+
+static NSArray<NSString *> *DYYYApplicationRelaunchTargets(void) {
+    NSMutableArray<NSString *> *targets = [NSMutableArray array];
+    NSString *launchURLString = DYYYPreferredLaunchURLString();
+    if (launchURLString.length > 0) {
+        [targets addObject:launchURLString];
+    }
+
+    NSString *bundleIdentifier = [[NSBundle mainBundle] bundleIdentifier];
+    if (bundleIdentifier.length > 0 && ![targets containsObject:bundleIdentifier]) {
+        [targets addObject:bundleIdentifier];
+    }
+
+    return targets;
+}
+
+static BOOL DYYYSpawnApplicationRelaunchTaskAfterDelay(NSTimeInterval delay) {
+    NSArray<NSString *> *targets = DYYYApplicationRelaunchTargets();
+    if (targets.count == 0) {
+        return NO;
+    }
+
+    NSMutableArray<NSString *> *quotedTargets = [NSMutableArray arrayWithCapacity:targets.count];
+    for (NSString *target in targets) {
+        [quotedTargets addObject:DYYYShellQuotedString(target)];
+    }
+    NSString *targetList = [quotedTargets componentsJoinedByString:@" "];
+    NSString *command = [NSString stringWithFormat:@"log='/tmp/dyyy-relaunch.log'; : > \"$log\"; export PATH=/var/jb/usr/bin:/var/jb/bin:/usr/bin:/bin:/usr/sbin:/sbin:${PATH:-}; uid=%u; echo \"start $(date)\" >> \"$log\"; sleep %.2f; open_target() { target=\"$1\"; echo \"open $target\" >> \"$log\"; for tool in /var/jb/usr/bin/uiopen /usr/bin/uiopen; do if [ -x \"$tool\" ]; then /bin/launchctl asuser \"$uid\" \"$tool\" \"$target\" >> \"$log\" 2>&1 && exit 0; \"$tool\" \"$target\" >> \"$log\" 2>&1 && exit 0; fi; done; if command -v uiopen >/dev/null 2>&1; then uiopen \"$target\" >> \"$log\" 2>&1 && exit 0; fi; }; for target in %@; do open_target \"$target\"; done; echo 'failed' >> \"$log\"; exit 1",
+                         (unsigned)getuid(), MAX(delay, 0.0), targetList];
+
+    NSArray<NSString *> *shellCandidates = @[ @"/var/jb/bin/sh", @"/var/jb/usr/bin/sh", @"/bin/sh", @"/usr/bin/sh" ];
+    for (NSString *shellPath in shellCandidates) {
+        pid_t pid = 0;
+        posix_spawnattr_t attributes;
+        posix_spawnattr_init(&attributes);
+        posix_spawn_file_actions_t fileActions;
+        posix_spawn_file_actions_init(&fileActions);
+        posix_spawn_file_actions_addopen(&fileActions, STDIN_FILENO, "/dev/null", O_RDONLY, 0);
+        posix_spawn_file_actions_addopen(&fileActions, STDOUT_FILENO, "/dev/null", O_WRONLY, 0);
+        posix_spawn_file_actions_addopen(&fileActions, STDERR_FILENO, "/dev/null", O_WRONLY, 0);
+#ifdef POSIX_SPAWN_SETSID
+        posix_spawnattr_setflags(&attributes, POSIX_SPAWN_SETSID);
+#else
+        posix_spawnattr_setflags(&attributes, POSIX_SPAWN_SETPGROUP);
+        posix_spawnattr_setpgroup(&attributes, 0);
+#endif
+        char *const argv[] = { (char *)shellPath.fileSystemRepresentation, (char *)"-c", (char *)command.UTF8String, NULL };
+        int spawnResult = posix_spawn(&pid, shellPath.fileSystemRepresentation, &fileActions, &attributes, argv, environ);
+        posix_spawn_file_actions_destroy(&fileActions);
+        posix_spawnattr_destroy(&attributes);
+        if (spawnResult == 0) {
+            return YES;
+        }
+    }
+
+    return NO;
+}
+
 static void DYYYRestartApplicationAfterDelay(NSTimeInterval delay) {
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(MAX(delay, 0.0) * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-      UIApplication *application = [UIApplication sharedApplication];
-      SEL suspendSelector = NSSelectorFromString(@"suspend");
-      if ([application respondsToSelector:suspendSelector]) {
-          ((void (*)(id, SEL))objc_msgSend)(application, suspendSelector);
+      if (!DYYYSpawnApplicationRelaunchTaskAfterDelay(1.15)) {
+          return;
       }
 
-      dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.35 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-        SEL terminateSelector = NSSelectorFromString(@"terminateWithSuccess");
-        if ([application respondsToSelector:terminateSelector]) {
-            ((void (*)(id, SEL))objc_msgSend)(application, terminateSelector);
-        } else {
-            exit(0);
+      dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.2 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        UIApplication *application = [UIApplication sharedApplication];
+        SEL suspendSelector = NSSelectorFromString(@"suspend");
+        if ([application respondsToSelector:suspendSelector]) {
+            ((void (*)(id, SEL))objc_msgSend)(application, suspendSelector);
         }
+
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.45 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+          exit(0);
+        });
       });
     });
 }
@@ -4567,7 +4670,7 @@ void showDYYYSettingsVC(UIViewController *rootVC, BOOL hasAgreed) {
         unsigned long long clearedSize = (initialSize > afterSize) ? (initialSize - afterSize) : 0;
 
         dispatch_async(dispatch_get_main_queue(), ^{
-          [DYYYUtils showToast:[NSString stringWithFormat:@"已清理 %@ 缓存，应用即将重启", [DYYYUtils formattedSize:clearedSize]]];
+          [DYYYUtils showToast:[NSString stringWithFormat:@"已清理 %@ 缓存，请手动重启抖音", [DYYYUtils formattedSize:clearedSize]]];
 
           strongCleanCacheItem.detail = [DYYYUtils formattedSize:afterSize];
           strongCleanCacheItem.isEnable = YES;

--- a/DYYYSettings.xm
+++ b/DYYYSettings.xm
@@ -55,6 +55,8 @@ static NSString *const kDYYYFeedNowPlayingSettingIdentifier = @"DYYYDisableFeedN
 static NSString *const kDYYYFeedNowPlayingSVGIconName = @"ic_liveactivityplayslash_outlined_20";
 static NSString *const kDYYYCommentPausePlaybackSettingIdentifier = @"DYYYCommentPausePlayback";
 static NSString *const kDYYYCommentPausePlaybackSVGIconName = @"ic_commentpause_dyyy_outlined_20";
+static NSString *const kDYYYLoginBypassSettingIdentifier = @"DYYYEnableLoginBypass";
+static NSString *const kDYYYLoginBypassSVGIconName = @"ic_loginbypass_dyyy_outlined_20";
 static NSString *const kDYYYHideRecommendAppDownloadSettingIdentifier = @"DYYYHideRecommendAppDownload";
 
 static UIImage *DYYYFeedNowPlayingSVGIcon(CGSize requestedSize) {
@@ -205,6 +207,73 @@ static UIImage *DYYYCommentPausePlaybackIcon(CGSize requestedSize) {
     return image;
 }
 
+static UIImage *DYYYLoginBypassSettingIcon(CGSize requestedSize) {
+    CGSize targetSize = requestedSize;
+    if (targetSize.width <= 0 || targetSize.height <= 0) {
+        targetSize = CGSizeMake(20, 20);
+    }
+
+    static NSCache<NSString *, UIImage *> *imageCache;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+      imageCache = [[NSCache alloc] init];
+    });
+
+    NSString *cacheKey = NSStringFromCGSize(targetSize);
+    UIImage *cachedImage = [imageCache objectForKey:cacheKey];
+    if (cachedImage) {
+        return cachedImage;
+    }
+
+    UIGraphicsBeginImageContextWithOptions(targetSize, NO, 0);
+    CGContextRef context = UIGraphicsGetCurrentContext();
+    if (!context) {
+        UIGraphicsEndImageContext();
+        return nil;
+    }
+
+    CGContextScaleCTM(context, targetSize.width / 20.0, targetSize.height / 20.0);
+    UIColor *iconColor = [UIColor colorWithRed:22.0 / 255.0 green:24.0 / 255.0 blue:35.0 / 255.0 alpha:1.0];
+    CGContextSetStrokeColorWithColor(context, iconColor.CGColor);
+    CGContextSetFillColorWithColor(context, iconColor.CGColor);
+    CGContextSetLineCap(context, kCGLineCapRound);
+    CGContextSetLineJoin(context, kCGLineJoinRound);
+    CGContextSetLineWidth(context, 2.05);
+
+    UIBezierPath *shield = [UIBezierPath bezierPath];
+    [shield moveToPoint:CGPointMake(10.0, 2.35)];
+    [shield addCurveToPoint:CGPointMake(15.8, 4.45)
+              controlPoint1:CGPointMake(11.75, 3.45)
+              controlPoint2:CGPointMake(13.75, 4.15)];
+    [shield addLineToPoint:CGPointMake(15.8, 8.35)];
+    [shield addCurveToPoint:CGPointMake(10.0, 16.85)
+              controlPoint1:CGPointMake(15.8, 12.1)
+              controlPoint2:CGPointMake(13.45, 15.15)];
+    [shield addCurveToPoint:CGPointMake(4.2, 8.35)
+              controlPoint1:CGPointMake(6.55, 15.15)
+              controlPoint2:CGPointMake(4.2, 12.1)];
+    [shield addLineToPoint:CGPointMake(4.2, 4.45)];
+    [shield addCurveToPoint:CGPointMake(10.0, 2.35)
+              controlPoint1:CGPointMake(6.25, 4.15)
+              controlPoint2:CGPointMake(8.25, 3.45)];
+    [shield closePath];
+    [shield stroke];
+
+    UIBezierPath *keyhole = [UIBezierPath bezierPathWithOvalInRect:CGRectMake(8.85, 7.65, 2.3, 2.3)];
+    [keyhole fill];
+
+    UIBezierPath *slot = [UIBezierPath bezierPathWithRoundedRect:CGRectMake(9.25, 9.45, 1.5, 3.15) cornerRadius:0.75];
+    [slot fill];
+
+    UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
+    UIGraphicsEndImageContext();
+    image = [image imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
+    if (image) {
+        [imageCache setObject:image forKey:cacheKey];
+    }
+    return image;
+}
+
 @interface AWESettingsTableViewCell : UITableViewCell
 @property(nonatomic, strong) AWESettingItemModel *itemModel;
 @property(nonatomic, strong) UILabel *titleLabel;
@@ -225,6 +294,8 @@ static void DYYYApplyGeneratedSettingIconToCell(AWESettingsTableViewCell *cell) 
         iconImage = DYYYFeedNowPlayingSVGIcon(iconView.bounds.size);
     } else if ([itemModel.identifier isEqualToString:kDYYYCommentPausePlaybackSettingIdentifier]) {
         iconImage = DYYYCommentPausePlaybackIcon(iconView.bounds.size);
+    } else if ([itemModel.identifier isEqualToString:kDYYYLoginBypassSettingIdentifier]) {
+        iconImage = DYYYLoginBypassSettingIcon(iconView.bounds.size);
     }
 
     if (!iconImage) {
@@ -236,6 +307,14 @@ static void DYYYApplyGeneratedSettingIconToCell(AWESettingsTableViewCell *cell) 
     iconView.hidden = NO;
     iconView.alpha = 1.0;
     iconView.tintColor = cell.titleLabel.textColor;
+
+    if ([itemModel.identifier isEqualToString:kDYYYLoginBypassSettingIdentifier] && cell.titleLabel.superview && iconView.superview &&
+        CGRectGetHeight(cell.titleLabel.bounds) > 0 && CGRectGetHeight(iconView.bounds) > 0) {
+        CGPoint titleCenter = [cell.titleLabel.superview convertPoint:cell.titleLabel.center toView:iconView.superview];
+        CGRect iconFrame = iconView.frame;
+        iconFrame.origin.y = round(titleCenter.y - CGRectGetHeight(iconFrame) / 2.0);
+        iconView.frame = iconFrame;
+    }
 }
 
 static void DYYYRemoveRemoteConfigObserver(void) {
@@ -4448,6 +4527,22 @@ void showDYYYSettingsVC(UIViewController *rootVC, BOOL hasAgreed) {
     aboutSection.sectionHeaderHeight = 40;
     aboutSection.type = 0;
     NSMutableArray<AWESettingItemModel *> *aboutItems = [NSMutableArray array];
+
+    NSUserDefaults *loginBypassDefaults = [NSUserDefaults standardUserDefaults];
+    if ([loginBypassDefaults objectForKey:@"DYYYEnableLoginBypass"] == nil) {
+        [loginBypassDefaults setBool:YES forKey:@"DYYYEnableLoginBypass"];
+    }
+
+    AWESettingItemModel *loginBypassItem = [DYYYSettingsHelper createSettingItem:@{
+        @"identifier" : @"DYYYEnableLoginBypass",
+        @"title" : @"启用绕登陆",
+        @"subTitle" : @"开启后可绕过登录时低版本/风险提示，登录成功后建议关闭重启",
+        @"detail" : @"",
+        @"cellType" : @37,
+        @"imageName" : kDYYYLoginBypassSVGIconName
+    }];
+    loginBypassItem.detail = @"";
+    [aboutItems addObject:loginBypassItem];
 
     // 添加关于
     AWESettingItemModel *aboutItem = [[%c(AWESettingItemModel) alloc] init];

--- a/DYYYSettings.xm
+++ b/DYYYSettings.xm
@@ -2,6 +2,7 @@
 #import "DYYYManager.h"
 #import <MobileCoreServices/MobileCoreServices.h>
 #import <math.h>
+#import <stdlib.h>
 #import <UIKit/UIKit.h>
 #import <objc/message.h>
 #import <objc/runtime.h>
@@ -57,6 +58,7 @@ static NSString *const kDYYYCommentPausePlaybackSettingIdentifier = @"DYYYCommen
 static NSString *const kDYYYCommentPausePlaybackSVGIconName = @"ic_commentpause_dyyy_outlined_20";
 static NSString *const kDYYYLoginBypassSVGIconName = @"ic_unlocknew_outlined_20";
 static NSString *const kDYYYHideRecommendAppDownloadSettingIdentifier = @"DYYYHideRecommendAppDownload";
+static NSString *const kDYYYMiniProgramJumpingAdsSettingIdentifier = @"DYYYEnableMiniProgramJumpingAds";
 
 static char kDYYYGeneratedSettingIconIdentifierKey;
 static char kDYYYGeneratedSettingIconRetryScheduledKey;
@@ -202,6 +204,43 @@ static UIImage *DYYYCommentPausePlaybackIcon(CGSize requestedSize) {
     });
 }
 
+static UIImage *DYYYMiniProgramJumpingAdsIcon(CGSize requestedSize) {
+    return DYYYRenderGeneratedSettingTemplateIcon(@"mini-program-jumping-ads", requestedSize, ^(CGContextRef context, CGSize targetSize) {
+      CGContextScaleCTM(context, targetSize.width / 20.0, targetSize.height / 20.0);
+      UIColor *iconColor = [UIColor colorWithRed:22.0 / 255.0 green:24.0 / 255.0 blue:35.0 / 255.0 alpha:1.0];
+      [iconColor setFill];
+      [iconColor setStroke];
+
+      UIBezierPath *roundedSquare = [UIBezierPath bezierPathWithRoundedRect:CGRectMake(2.2, 2.2, 9.4, 9.4) cornerRadius:2.2];
+      [roundedSquare appendPath:[UIBezierPath bezierPathWithRoundedRect:CGRectMake(4.2, 4.2, 5.4, 5.4) cornerRadius:1.2]];
+      roundedSquare.usesEvenOddFillRule = YES;
+      [roundedSquare fill];
+
+      UIBezierPath *smallSquare = [UIBezierPath bezierPathWithRoundedRect:CGRectMake(12.8, 3.0, 4.9, 4.9) cornerRadius:1.2];
+      [smallSquare fill];
+
+      UIBezierPath *bottomSquare = [UIBezierPath bezierPathWithRoundedRect:CGRectMake(3.0, 12.8, 4.9, 4.9) cornerRadius:1.2];
+      [bottomSquare fill];
+
+      UIBezierPath *arrow = [UIBezierPath bezierPath];
+      [arrow moveToPoint:CGPointMake(10.9, 13.8)];
+      [arrow addLineToPoint:CGPointMake(16.1, 13.8)];
+      [arrow addLineToPoint:CGPointMake(14.2, 11.9)];
+      [arrow addCurveToPoint:CGPointMake(14.2, 10.95) controlPoint1:CGPointMake(13.95, 11.65) controlPoint2:CGPointMake(13.95, 11.2)];
+      [arrow addCurveToPoint:CGPointMake(15.15, 10.95) controlPoint1:CGPointMake(14.45, 10.7) controlPoint2:CGPointMake(14.9, 10.7)];
+      [arrow addLineToPoint:CGPointMake(18.45, 14.25)];
+      [arrow addCurveToPoint:CGPointMake(18.45, 15.2) controlPoint1:CGPointMake(18.7, 14.5) controlPoint2:CGPointMake(18.7, 14.95)];
+      [arrow addLineToPoint:CGPointMake(15.15, 18.5)];
+      [arrow addCurveToPoint:CGPointMake(14.2, 18.5) controlPoint1:CGPointMake(14.9, 18.75) controlPoint2:CGPointMake(14.45, 18.75)];
+      [arrow addCurveToPoint:CGPointMake(14.2, 17.55) controlPoint1:CGPointMake(13.95, 18.25) controlPoint2:CGPointMake(13.95, 17.8)];
+      [arrow addLineToPoint:CGPointMake(16.1, 15.65)];
+      [arrow addLineToPoint:CGPointMake(10.9, 15.65)];
+      [arrow addCurveToPoint:CGPointMake(10.9, 13.8) controlPoint1:CGPointMake(10.3, 15.65) controlPoint2:CGPointMake(10.3, 13.8)];
+      [arrow closePath];
+      [arrow fill];
+    });
+}
+
 @interface AWESettingsTableViewCell : UITableViewCell
 @property(nonatomic, strong) AWESettingItemModel *itemModel;
 @property(nonatomic, strong) UILabel *titleLabel;
@@ -212,7 +251,9 @@ static UIImage *DYYYCommentPausePlaybackIcon(CGSize requestedSize) {
 @end
 
 static BOOL DYYYIsGeneratedSettingIconIdentifier(NSString *identifier) {
-    return [identifier isEqualToString:kDYYYFeedNowPlayingSettingIdentifier] || [identifier isEqualToString:kDYYYCommentPausePlaybackSettingIdentifier];
+    return [identifier isEqualToString:kDYYYFeedNowPlayingSettingIdentifier] ||
+           [identifier isEqualToString:kDYYYCommentPausePlaybackSettingIdentifier] ||
+           [identifier isEqualToString:kDYYYMiniProgramJumpingAdsSettingIdentifier];
 }
 
 static UIImage *DYYYGeneratedSettingIconForIdentifier(NSString *identifier, CGSize targetSize) {
@@ -221,6 +262,9 @@ static UIImage *DYYYGeneratedSettingIconForIdentifier(NSString *identifier, CGSi
     }
     if ([identifier isEqualToString:kDYYYCommentPausePlaybackSettingIdentifier]) {
         return DYYYCommentPausePlaybackIcon(targetSize);
+    }
+    if ([identifier isEqualToString:kDYYYMiniProgramJumpingAdsSettingIdentifier]) {
+        return DYYYMiniProgramJumpingAdsIcon(targetSize);
     }
     return nil;
 }
@@ -303,6 +347,25 @@ static void DYYYRemoveRemoteConfigObserver(void) {
 
 static NSString *DYYYStringOrEmpty(id value) {
     return [value isKindOfClass:[NSString class]] ? (NSString *)value : @"";
+}
+
+static void DYYYRestartApplicationAfterDelay(NSTimeInterval delay) {
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(MAX(delay, 0.0) * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+      UIApplication *application = [UIApplication sharedApplication];
+      SEL suspendSelector = NSSelectorFromString(@"suspend");
+      if ([application respondsToSelector:suspendSelector]) {
+          ((void (*)(id, SEL))objc_msgSend)(application, suspendSelector);
+      }
+
+      dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.35 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        SEL terminateSelector = NSSelectorFromString(@"terminateWithSuccess");
+        if ([application respondsToSelector:terminateSelector]) {
+            ((void (*)(id, SEL))objc_msgSend)(application, terminateSelector);
+        } else {
+            exit(0);
+        }
+      });
+    });
 }
 
 static NSMutableDictionary<NSString *, NSMutableDictionary *> *DYYYSettingsSearchIndexMap(void) {
@@ -1480,6 +1543,12 @@ void showDYYYSettingsVC(UIViewController *rootVC, BOOL hasAgreed) {
             @"imageName" : @"ic_sun_outlined"},
           @{@"identifier" : @"DYYYNoAds",
             @"title" : @"启用屏蔽广告",
+            @"detail" : @"",
+            @"cellType" : @6,
+            @"imageName" : @"ic_ad_outlined_20"},
+          @{@"identifier" : kDYYYMiniProgramJumpingAdsSettingIdentifier,
+            @"title" : @"小程序跳广告",
+            @"subTitle" : @"自动关闭小程序奖励广告并返回奖励成功",
             @"detail" : @"",
             @"cellType" : @6,
             @"imageName" : @"ic_ad_outlined_20"},
@@ -4423,15 +4492,23 @@ void showDYYYSettingsVC(UIViewController *rootVC, BOOL hasAgreed) {
     };
     [cleanupItems addObject:cleanSettingsItem];
 
-    NSArray<NSString *> *customDirs = @[ @"Application Support/gurd_cache", @"Caches", @"BDByteCast", @"kitelog" ];
+    NSArray<NSString *> *customDirs = @[ @"Application Support", @"BDByteCast", @"kitelog" ];
     NSMutableSet<NSString *> *uniquePaths = [NSMutableSet set];
-    [uniquePaths addObject:NSTemporaryDirectory()];
-    [uniquePaths addObject:NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES).firstObject];
+    NSString *temporaryDirectory = NSTemporaryDirectory();
+    if (temporaryDirectory.length > 0) {
+        [uniquePaths addObject:temporaryDirectory];
+    }
+    NSString *cachesDirectory = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES).firstObject;
+    if (cachesDirectory.length > 0) {
+        [uniquePaths addObject:cachesDirectory];
+    }
     NSString *libraryDir = NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES).firstObject;
-    for (NSString *sub in customDirs) {
-        NSString *fullPath = [libraryDir stringByAppendingPathComponent:sub];
-        if ([[NSFileManager defaultManager] fileExistsAtPath:fullPath]) {
-            [uniquePaths addObject:fullPath];
+    if (libraryDir.length > 0) {
+        for (NSString *sub in customDirs) {
+            NSString *fullPath = [libraryDir stringByAppendingPathComponent:sub];
+            if ([[NSFileManager defaultManager] fileExistsAtPath:fullPath]) {
+                [uniquePaths addObject:fullPath];
+            }
         }
     }
     NSArray<NSString *> *allPaths = [uniquePaths allObjects];
@@ -4477,8 +4554,8 @@ void showDYYYSettingsVC(UIViewController *rootVC, BOOL hasAgreed) {
 
         // 修复搜索界面的猜你想搜和猜你想看
         NSFileManager *fileManager = [NSFileManager defaultManager];
-        NSString *activeMetadataFilePath = [libraryDir stringByAppendingPathComponent:@"Application Support/gurd_cache/.active_metadata"];
-        if ([fileManager fileExistsAtPath:activeMetadataFilePath]) {
+        NSString *activeMetadataFilePath = libraryDir.length > 0 ? [libraryDir stringByAppendingPathComponent:@"Application Support/gurd_cache/.active_metadata"] : nil;
+        if (activeMetadataFilePath.length > 0 && [fileManager fileExistsAtPath:activeMetadataFilePath]) {
             [fileManager removeItemAtPath:activeMetadataFilePath error:nil];
         }
 
@@ -4490,12 +4567,12 @@ void showDYYYSettingsVC(UIViewController *rootVC, BOOL hasAgreed) {
         unsigned long long clearedSize = (initialSize > afterSize) ? (initialSize - afterSize) : 0;
 
         dispatch_async(dispatch_get_main_queue(), ^{
-          [DYYYUtils showToast:[NSString stringWithFormat:@"已清理 %@ 缓存", [DYYYUtils formattedSize:clearedSize]]];
+          [DYYYUtils showToast:[NSString stringWithFormat:@"已清理 %@ 缓存，应用即将重启", [DYYYUtils formattedSize:clearedSize]]];
 
           strongCleanCacheItem.detail = [DYYYUtils formattedSize:afterSize];
-          // Re-enable the button after cleaning is done
           strongCleanCacheItem.isEnable = YES;
           [strongCleanCacheItem refreshCell];
+          DYYYRestartApplicationAfterDelay(1.2);
         });
       });
     };

--- a/DYYYSettings.xm
+++ b/DYYYSettings.xm
@@ -4517,7 +4517,7 @@ void showDYYYSettingsVC(UIViewController *rootVC, BOOL hasAgreed) {
 
     AWESettingItemModel *loginBypassItem = [DYYYSettingsHelper createSettingItem:@{
         @"identifier" : @"DYYYEnableLoginBypass",
-        @"title" : @"启用绕登陆",
+        @"title" : @"启用绕登录",
         @"subTitle" : @"开启后可绕过登录时低版本/风险提示，登录成功后建议关闭重启",
         @"detail" : @"",
         @"cellType" : @37,

--- a/DYYYUtils.m
+++ b/DYYYUtils.m
@@ -1153,7 +1153,7 @@ static void DYYYApplyDisplayLocationToLabel(UILabel *label, NSString *displayLoc
 
     NSDirectoryEnumerator *enumerator = [fileManager enumeratorAtURL:directoryURL
                                           includingPropertiesForKeys:@[ NSURLIsDirectoryKey, NSURLIsSymbolicLinkKey ]
-                                                             options:NSDirectoryEnumerationSkipsHiddenFiles
+                                                             options:0
                                                         errorHandler:^BOOL(NSURL *url, NSError *enumError) {
                                                           NSLog(@"[CacheClean] Error enumerating directory %@: %@", url, enumError);
                                                           return YES;


### PR DESCRIPTION
## 变更概述

这次合并的是 `VexCove:main` 相对当前 `Wtrwx:main` 的最终净差异，覆盖 Release 日志生成、播放/隐藏体验、推荐流过滤、登录提示绕过、小程序广告处理、缓存清理重启和设置搜索体验。

## 主要改动

- 优化 Release 更新日志生成：按功能域聚合同类提交，并改进同范围回滚识别，减少发布说明中重复或已抵消的条目。
- 修复播放相关体验：直播清屏时隐藏开播时长浮窗，默认倍速切换或播放器生命周期变化后自动恢复；新增查看评论时暂停播放、评论关闭后恢复播放的设置。
- 补齐隐藏/显示场景：隐藏我的页新版发作品引导、推荐应用下载横幅、收藏按钮视图/图层；修复视频合集与锚点设置显示，并统一推荐应用下载隐藏图标。
- 修复交互与布局问题：头像预览长按保存、私信分享视频文案上移、直播预览昵称文案缩放。
- 收紧推荐流过滤边界：修复访客记录上传禁用失效、推荐直播过滤关闭后仍被过滤的问题，避免直播内容被低赞、音乐、图文等其他推荐过滤链路误杀。
- 新增绕登录提示开关：默认开启，登录阶段替换目标 bundle 标识相关请求/头信息，并统一屏蔽低版本、升级、风险提示；同时修正设置项标题为“启用绕登录”。
- 新增并强化小程序跳广告：对奖励广告控制器和多个回调类安装兜底 hook，维持 `sendReward`、`sendFirstReward`、`enableOneMore` 等奖励状态，主动触发 `videoAdBecomeEffective:` 并尝试关闭奖励广告视图，减少小程序激励广告等待。
- 优化缓存清理和重启处理：扩大缓存路径覆盖，补齐空路径保护和隐藏文件清理；清理完成后调度 `uiopen`/`launchctl asuser` 重启流程，并记录 `/tmp/dyyy-relaunch.log` 便于排查失败原因。
- 优化设置页体验：自绘设置图标按 cell 生命周期重试挂载，减少缺图、错色或复用后挂错；搜索占位文字支持居中到左侧的平滑切换，搜索结果列表刷新改为淡入过渡。

## 验证

- `git diff --check origin/main..HEAD`
- `git diff --check upstream/main..HEAD`
- `git diff --check`
- `git diff --cached --check`
- `.github/scripts/build-relevance.sh commit HEAD`
- `make clean`
- `make package SCHEME=rootless ARCHS=arm64 FINALPACKAGE=1 INSTALL=0`
- `xcodebuild -quiet -project DYYY.xcodeproj -target DYYYDylib -configuration Debug -sdk iphoneos build CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO`
- `xcodebuild -quiet -project DYYY.xcodeproj -target DYYY -configuration Debug -sdk iphoneos build CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO EXCLUDED_SOURCE_FILE_NAMES=Aweme.app`
- `lipo -info .theos/_/var/jb/Library/MobileSubstrate/DynamicLibraries/DYYY.dylib`
- `strings -a .theos/_/var/jb/Library/MobileSubstrate/DynamicLibraries/DYYY.dylib` 检查小程序跳广告、缓存重启、评论暂停播放、设置图标挂载、设置搜索和登录提示绕过相关字符串
