### PR TITLE
修复国外 IP 属地优先显示国家的问题

### DIFF
--- a/DYYY.xm
+++ b/DYYY.xm
@@ -3761,10 +3761,6 @@ static void DYYYDisableAVPlayerItemHDRMetadata(AVPlayerItem *item) {
     if (cityCode.length > 0) {
         displayLocation = [CityManager.sharedInstance getCityNameWithCode:cityCode];
 
-        if (!displayLocation && regionCode.length > 0) {
-            displayLocation = [CityManager.sharedInstance getCountryNameWithCode:regionCode];
-        }
-
         if (!displayLocation) {
             @synchronized(inFlight) {
                 if ([inFlight containsObject:cityCode]) {
@@ -3782,25 +3778,49 @@ static void DYYYDisableAVPlayerItemHDRMetadata(AVPlayerItem *item) {
                     NSString *apiLocation = nil;
 
                     if (!error && locationInfo) {
-                        NSString *cityName = locationInfo[@"adminName1"];
+                        NSString *localName = locationInfo[@"name"];
+                        NSString *adminName1 = locationInfo[@"adminName1"];
                         NSString *countryName = locationInfo[@"countryName"];
 
-                        if (cityName && countryName) {
-                            if ([cityName isEqualToString:countryName]) {
-                                apiLocation = countryName;
+                        if (![localName isKindOfClass:[NSString class]]) {
+                            localName = nil;
+                        }
+                        if (![adminName1 isKindOfClass:[NSString class]]) {
+                            adminName1 = nil;
+                        }
+                        if (![countryName isKindOfClass:[NSString class]]) {
+                            countryName = nil;
+                        }
+
+                        if (countryName.length > 0) {
+                            if (adminName1.length > 0 && localName.length > 0 && ![countryName isEqualToString:localName]) {
+                                if ([adminName1 isEqualToString:localName]) {
+                                    apiLocation = [NSString stringWithFormat:@"%@ %@", countryName, localName];
+                                } else {
+                                    apiLocation = [NSString stringWithFormat:@"%@ %@ %@", countryName, adminName1, localName];
+                                }
+                            } else if (localName.length > 0 && ![countryName isEqualToString:localName]) {
+                                apiLocation = [NSString stringWithFormat:@"%@ %@", countryName, localName];
+                            } else if (adminName1.length > 0 && ![countryName isEqualToString:adminName1]) {
+                                apiLocation = [NSString stringWithFormat:@"%@ %@", countryName, adminName1];
                             } else {
-                                apiLocation = [NSString stringWithFormat:@"%@ %@", countryName, cityName];
+                                apiLocation = countryName;
                             }
-                        } else if (countryName) {
-                            apiLocation = countryName;
-                        } else if (cityName) {
-                            apiLocation = cityName;
+                        } else if (localName.length > 0) {
+                            apiLocation = localName;
+                        } else if (adminName1.length > 0) {
+                            apiLocation = adminName1;
                         }
                     }
 
-                    if (apiLocation) {
+                    if (apiLocation.length > 0) {
                         [locationCache setObject:apiLocation forKey:cacheKey];
                         updateLabelWithLocation(label, apiLocation);
+                    } else {
+                        if (regionCode.length > 0) {
+                            NSString *fallbackCountry = [CityManager.sharedInstance getCountryNameWithCode:regionCode];
+                            updateLabelWithLocation(label, fallbackCountry);
+                        }
                     }
                 });
             }];

--- a/DYYYUtils.m
+++ b/DYYYUtils.m
@@ -542,6 +542,51 @@ static NSString *DYYYJSONStringFromObject(id object) {
     return [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
 }
 
+static NSString *DYYYDisplayLocationFromGeoNamesInfo(NSDictionary *locationInfo) {
+    if (![locationInfo isKindOfClass:[NSDictionary class]]) {
+        return nil;
+    }
+
+    NSString *countryName = locationInfo[@"countryName"];
+    NSString *adminName1 = locationInfo[@"adminName1"];
+    NSString *localName = locationInfo[@"name"];
+
+    if (![countryName isKindOfClass:[NSString class]]) {
+        countryName = nil;
+    }
+    if (![adminName1 isKindOfClass:[NSString class]]) {
+        adminName1 = nil;
+    }
+    if (![localName isKindOfClass:[NSString class]]) {
+        localName = nil;
+    }
+
+    if (countryName.length > 0) {
+        if (adminName1.length > 0 && localName.length > 0 && ![countryName isEqualToString:localName]) {
+            if ([adminName1 isEqualToString:localName]) {
+                return [NSString stringWithFormat:@"%@ %@", countryName, localName];
+            }
+            return [NSString stringWithFormat:@"%@ %@ %@", countryName, adminName1, localName];
+        }
+        if (localName.length > 0 && ![countryName isEqualToString:localName]) {
+            return [NSString stringWithFormat:@"%@ %@", countryName, localName];
+        }
+        if (adminName1.length > 0 && ![countryName isEqualToString:adminName1]) {
+            return [NSString stringWithFormat:@"%@ %@", countryName, adminName1];
+        }
+        return countryName;
+    }
+
+    if (localName.length > 0) {
+        return localName;
+    }
+    if (adminName1.length > 0) {
+        return adminName1;
+    }
+
+    return nil;
+}
+
 static void DYYYApplyDisplayLocationToLabel(UILabel *label, NSString *displayLocation, NSString *colorHexString) {
     if (!label) {
         return;
@@ -619,22 +664,7 @@ static void DYYYApplyDisplayLocationToLabel(UILabel *label, NSString *displayLoc
 
         // 3. 处理缓存数据或发起网络请求
         if (cachedData) {
-            NSString *countryName = cachedData[@"countryName"];
-            NSString *adminName1 = cachedData[@"adminName1"];
-            NSString *localName = cachedData[@"name"];
-            NSString *displayLocation = @"未知";
-
-            if (countryName.length > 0) {
-                if (adminName1.length > 0 && localName.length > 0 && ![countryName isEqualToString:@"中国"] && ![countryName isEqualToString:localName]) {
-                    displayLocation = [NSString stringWithFormat:@"%@ %@ %@", countryName, adminName1, localName];
-                } else if (localName.length > 0 && ![countryName isEqualToString:localName]) {
-                    displayLocation = [NSString stringWithFormat:@"%@ %@", countryName, localName];
-                } else {
-                    displayLocation = countryName;
-                }
-            } else if (localName.length > 0) {
-                displayLocation = localName;
-            }
+            NSString *displayLocation = DYYYDisplayLocationFromGeoNamesInfo(cachedData) ?: @"未知";
 
             if (displayLocation.length == 0 || [displayLocation isEqualToString:@"未知"]) {
                 NSString *fallbackLocation = [DYYYUtils fallbackLocationFromIPAttribution:model];
@@ -668,21 +698,10 @@ static void DYYYApplyDisplayLocationToLabel(UILabel *label, NSString *displayLoc
                                         }
                                     } else if (locationInfo) {
                                         BOOL shouldCacheLocation = NO;
-                                        NSString *countryName = locationInfo[@"countryName"];
-                                        NSString *adminName1 = locationInfo[@"adminName1"];
-                                        NSString *localName = locationInfo[@"name"];
 
-                                        if (countryName.length > 0) {
-                                            if (adminName1.length > 0 && localName.length > 0 && ![countryName isEqualToString:@"中国"] && ![countryName isEqualToString:localName]) {
-                                                displayLocation = [NSString stringWithFormat:@"%@ %@ %@", countryName, adminName1, localName];
-                                            } else if (localName.length > 0 && ![countryName isEqualToString:localName]) {
-                                                displayLocation = [NSString stringWithFormat:@"%@ %@", countryName, localName];
-                                            } else {
-                                                displayLocation = countryName;
-                                            }
-                                            shouldCacheLocation = YES;
-                                        } else if (localName.length > 0) {
-                                            displayLocation = localName;
+                                        NSString *resolvedLocation = DYYYDisplayLocationFromGeoNamesInfo(locationInfo);
+                                        if (resolvedLocation.length > 0) {
+                                            displayLocation = resolvedLocation;
                                             shouldCacheLocation = YES;
                                         }
 


### PR DESCRIPTION
## 修复内容

本次修复国外 IP 属地在部分场景下只显示国家的问题，例如原本应显示「澳大利亚 维多利亚州 墨尔本」时，可能提前回退成「澳大利亚」。

主要调整：

- 有 `cityCode` 时优先使用 GeoNames 查询更具体的属地，不再先用 `region` 国家码提前兜底。
- 统一 GeoNames 返回字段的显示规则，优先组合 `countryName + adminName1 + name`。
- 当字段不完整时逐级降级为「国家 城市」「国家 省/州」「国家」，避免异常返回导致显示失败。
- 对 GeoNames 返回字段增加类型检查，避免 `NSNull` 等异常数据影响显示逻辑。

## 影响范围

- 影响「时间属地显示」中的国外 IP 属地解析。
- 国内城市码仍优先走本地城市表，不改变原有国内显示逻辑。
- GeoNames 请求失败或没有可用城市码时，仍会退回国家/原始 IP 属地兜底。

## 验证

- 已通过 `git diff --check`。
- 已在 fork 的 GitHub Actions 成功编译三套包：rootful、rootless、roothide。
- 构建记录：<https://github.com/kikozz/DYYY/actions/runs/28742307227>